### PR TITLE
Fix internal links to use renamed road trip URL

### DIFF
--- a/src/__tests__/llms.test.ts
+++ b/src/__tests__/llms.test.ts
@@ -21,7 +21,7 @@ describe('llms utilities', () => {
   it('groups routes by section mapping', () => {
     expect(sectionForPath('/cooling/cooling-mats/')).toBe('Cooling Guides');
     expect(sectionForPath('/calming/car-anxiety-for-dogs/')).toBe('Calming Guides');
-    expect(sectionForPath('/travel/rhys-road-trip-chill-kit/')).toBe('Travel Guides');
+    expect(sectionForPath('/travel/dog-road-trip-gear/')).toBe('Travel Guides');
     expect(sectionForPath('/about/')).toBe('About');
     expect(sectionForPath('/contact/')).toBe('About');
     expect(sectionForPath('/unknown/path/')).toBe('Core Pages');

--- a/src/data/cooling-products.ts
+++ b/src/data/cooling-products.ts
@@ -317,7 +317,7 @@ export const categoryMeta: Record<ProductCategory, CategoryMeta> = {
       },
     ],
     internalLinks: [
-      { label: 'Road Trip Chill Kit', href: '/travel/rhys-road-trip-chill-kit/' },
+      { label: 'Road Trip Chill Kit', href: '/travel/dog-road-trip-gear/' },
       { label: 'Cooling Mats', href: '/cooling/cooling-mats/' },
       { label: 'Cooling Vests', href: '/cooling/cooling-vests/' },
       { label: 'All Cooling Products', href: '/cooling/best-cooling-products-for-dogs/' },

--- a/src/data/product-page-map.ts
+++ b/src/data/product-page-map.ts
@@ -83,7 +83,7 @@ export function buildProductPageMap(): ProductPageMap {
   }
 
   // Road trip page: manually mapped based on the imports in that file
-  const roadTripRef: PageRef = { label: 'rhys-road-trip-chill-kit', href: '/travel/rhys-road-trip-chill-kit/' };
+  const roadTripRef: PageRef = { label: 'dog-road-trip-gear', href: '/travel/dog-road-trip-gear/' };
   // car-cooling (all 4)
   for (const p of coolingProducts.filter((p) => p.category === 'car-cooling')) {
     addRef(map, p.id, roadTripRef);

--- a/src/pages/cooling/best-cooling-products-for-dogs.astro
+++ b/src/pages/cooling/best-cooling-products-for-dogs.astro
@@ -210,7 +210,7 @@ const pillarFaqs = [
       heading="Beyond the Heat"
       guides={[
         {
-          href: '/travel/rhys-road-trip-chill-kit/',
+          href: '/travel/dog-road-trip-gear/',
           title: "Rhys's Road Trip Chill Kit",
           description: 'Planning a long drive? See the complete road trip cooling and calming setup — window shades, fans, mats, and anti-anxiety picks used on real cross-country trips.',
         },


### PR DESCRIPTION
Update all references from /travel/rhys-road-trip-chill-kit/ to
/travel/dog-road-trip-gear/ in data files, page templates, and tests.

https://claude.ai/code/session_01KVfVUdutEJP1U55QXaGU1k