### PR TITLE
Restore crate training and crate converter pages

### DIFF
--- a/docs/amazon-product-data.md
+++ b/docs/amazon-product-data.md
@@ -26,7 +26,7 @@ Both return the same general structure. The key field we use is `product.main_im
 
 ### What it does
 
-1. Reads all ASINs from `src/data/cooling-products.ts` and `src/data/calming-products.ts`
+1. Reads all ASINs from product data files, including cooling, calming, relaxation, tracking, and accessory products
 2. Checks each ASIN against the local cache (`src/data/amazon-products/{ASIN}.json`)
 3. Fetches only uncached ASINs from the selected provider
 4. Saves the full JSON response to the cache directory
@@ -61,7 +61,7 @@ bun run scripts/fetch-amazon-data.ts --help
 
 ## How to Add a New Product
 
-1. **Add the product** to the appropriate data file (`src/data/cooling-products.ts` or `src/data/calming-products.ts`) with its ASIN
+1. **Add the product** to the appropriate product data file with its ASIN
 2. **Run the fetch script** for just that ASIN:
    ```bash
    bun run scripts/fetch-amazon-data.ts --asin B0NEWASIN

--- a/docs/system-definition.yaml
+++ b/docs/system-definition.yaml
@@ -32,11 +32,13 @@ site_system:
   page_inventory:
     - name: "Home"
       type: "attractor"
-      target_action: "Route visitors into cooling, calming, or comforting collector paths"
+      target_action: "Route visitors into cooling, calming, comforting, crate-training, and road-trip crate paths"
       metric: "hero_click_cooling + hero_click_calming CTR + comfort block clicks"
       notes: >
         Home page includes a dusty rose color block introducing the Comfort & Rest collector
         with tagline "Settle in." — positioned between HomepageHero and the start-prompt section.
+        The latest/guide lists include How to Crate Train Your Dog and Best Travel Crates for Road Trips
+        to connect informational crate intent with the new crate converter path.
 
     - name: "Cooling"
       type: "collector"
@@ -101,16 +103,27 @@ site_system:
       type: "converter"
       pillar: "comfort"
       pillar_tagline: "Rest. Recovery. Relaxation."
-      target_action: "Drive affiliate outbound clicks on dog beds"
+      target_action: "Drive affiliate outbound clicks on dog beds and dog crates"
       metric: "amazon_outbound_click rate"
       routes:
         - "/comforting/best-calming-dog-beds/"
         - "/comforting/best-orthopedic-dog-beds/"
+        - "/comforting/best-puppy-crates/"
+        - "/comforting/best-anxiety-dog-crates/"
+        - "/comforting/best-travel-crates-for-road-trips/"
       notes: >
-        Relaxation pillar is in early build-out. Collector page and additional
-        converters (dog crates, etc.) are planned but not yet live.
+        Comfort collector routes to calming beds, orthopedic beds, puppy crates, anxiety crates, and travel crates.
+        Additional crate-related converters may be added as the crate-training cluster expands.
         Placeholder product entries (ASINs B0D5B56X9V, B0DTH4195V) need
         to be identified and updated in src/data/relaxation-products.ts.
+
+    - name: "Crate Training for Dogs"
+      type: "collector"
+      collector_subtype: "article"
+      target_action: "Route crate-training-intent traffic to calming and comfort converters"
+      metric: "collector_to_converter_click to calming and comfort converters"
+      routes:
+        - "/calming/crate-training-for-dogs/"
 
     - name: "Road Trip Chill Kit"
       type: "collector"
@@ -244,7 +257,7 @@ site_system:
     product_catalog: "src/data/product-catalog.ts — normalized admin inventory across every product data source; /admin/products/ must consume this data module and remain complete whenever products are added"
     cooling_products: "src/data/cooling-products.ts — 15 products with ASIN, affiliate URL, and image thumbnails"
     calming_products: "src/data/calming-products.ts — 13 products with ASIN, affiliate URL, and image thumbnails"
-    relaxation_products: "src/data/relaxation-products.ts — 13 products (calming beds, orthopedic beds, crates) with ASIN, affiliate URL, and image thumbnails"
+    relaxation_products: "src/data/relaxation-products.ts — 24 products (calming beds, orthopedic beds, crates, travel beds) with ASIN, affiliate URL, and image thumbnails"
     tracking_products: "src/data/tracking-products.ts — 8 tracker products and 1 accessory product across cellular/off-grid/bluetooth/accessory types"
     raw_api_cache: "src/data/amazon-products/*.json — full SearchAPI Amazon Product responses per ASIN"
 

--- a/scripts/fetch-amazon-data.ts
+++ b/scripts/fetch-amazon-data.ts
@@ -12,6 +12,7 @@
 
 import { coolingProducts } from '../src/data/cooling-products';
 import { calmingProducts } from '../src/data/calming-products';
+import { relaxationProducts } from '../src/data/relaxation-products';
 import { trackerProducts, accessoryProducts } from '../src/data/tracking-products';
 import { writeFile, mkdir, access } from 'fs/promises';
 import { join } from 'path';
@@ -99,6 +100,7 @@ await mkdir(OUT_DIR, { recursive: true });
 const allProducts = [
   ...coolingProducts.map((p) => ({ asin: p.asin, name: p.name })),
   ...calmingProducts.map((p) => ({ asin: p.asin, name: p.name })),
+  ...relaxationProducts.map((p) => ({ asin: p.asin, name: p.name })),
   ...trackerProducts.map((p) => ({ asin: p.asin, name: p.name })),
   ...accessoryProducts.map((p) => ({ asin: p.asin, name: p.name })),
 ];

--- a/src/__tests__/analytics.test.ts
+++ b/src/__tests__/analytics.test.ts
@@ -20,6 +20,15 @@ describe('track', () => {
     delete (window as any).posthog;
     expect(() => track('test_event', {})).not.toThrow();
   });
+
+  it('does not log analytics events when posthog is absent', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    delete (window as any).posthog;
+
+    track('test_event', {});
+
+    expect(log).not.toHaveBeenCalled();
+  });
 });
 
 describe('init — click tracking', () => {

--- a/src/__tests__/relaxation-converter-pages.test.ts
+++ b/src/__tests__/relaxation-converter-pages.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildRelaxationItemListSchema,
+  getRelaxationConverterPageConfig,
+} from '../data/relaxation-converter-pages';
+import { getRelaxationProductsByCategory } from '../data/relaxation-products';
+
+describe('relaxation converter page config', () => {
+  it('returns puppy crates converter config with crate training route', () => {
+    const config = getRelaxationConverterPageConfig('best-puppy-crates');
+
+    expect(config.pageSlug).toBe('best-puppy-crates');
+    expect(config.hero.secondaryCta?.href).toBe('/calming/crate-training-for-dogs/');
+    expect(config.itemListSchema?.productIds).toEqual([
+      'kindtail-pawd-collapsible-crate',
+      'midwest-icrate-puppy',
+      'midwest-life-stages-puppy-crate',
+      'petmate-training-retreat-kennel',
+    ]);
+  });
+
+  it('returns anxiety crates converter config with safety framing', () => {
+    const config = getRelaxationConverterPageConfig('best-anxiety-dog-crates');
+
+    expect(config.pageSlug).toBe('best-anxiety-dog-crates');
+    expect(config.hero.secondaryCta?.href).toBe('/calming/crate-training-for-dogs/');
+    expect(config.itemListSchema?.productIds).toEqual([
+      'midwest-life-stages-crate',
+      'petmate-sky-kennel',
+      'impact-high-anxiety-crate',
+    ]);
+    expect(config.blocks.some((block) => (
+      block.kind === 'prose' &&
+      block.heading === 'Safety First: A Crate Is Not a Separation Anxiety Cure'
+    ))).toBe(true);
+  });
+
+  it('returns travel crates converter config with road trip product logic', () => {
+    const config = getRelaxationConverterPageConfig('best-travel-crates-for-road-trips');
+
+    expect(config.pageSlug).toBe('best-travel-crates-for-road-trips');
+    expect(config.hero.secondaryCta?.href).toBe('/travel/dog-road-trip-gear/');
+    expect(config.itemListSchema?.productIds).toEqual([
+      'petsafe-happy-ride-travel-crate',
+      'petmate-sky-kennel',
+      'elitefield-three-door-soft-crate',
+      'lesure-soft-collapsible-crate',
+    ]);
+    expect(config.blocks.some((block) => (
+      block.kind === 'prose' &&
+      block.heading === 'Hard-Sided vs Soft Folding Travel Crates'
+    ))).toBe(true);
+  });
+
+  it('builds item list schema for puppy crates', () => {
+    const config = getRelaxationConverterPageConfig('best-puppy-crates');
+    const schema = buildRelaxationItemListSchema(config.itemListSchema!);
+
+    expect(schema['@type']).toBe('ItemList');
+    expect(schema.numberOfItems).toBe(4);
+  });
+
+  it('keeps puppy crate products in the crates category', () => {
+    const productIds = getRelaxationProductsByCategory('crates').map((product) => product.id);
+
+    expect(productIds).toEqual(expect.arrayContaining([
+      'kindtail-pawd-collapsible-crate',
+      'midwest-icrate-puppy',
+      'midwest-life-stages-puppy-crate',
+      'midwest-icrate',
+      'midwest-life-stages-crate',
+      'petmate-training-retreat-kennel',
+      'petmate-sky-kennel',
+      'impact-high-anxiety-crate',
+      'petsafe-happy-ride-travel-crate',
+      'elitefield-three-door-soft-crate',
+      'lesure-soft-collapsible-crate',
+    ]));
+  });
+
+  it('throws for unknown slugs', () => {
+    expect(() => getRelaxationConverterPageConfig('missing-slug')).toThrow(
+      'Missing relaxation converter page config for slug: missing-slug'
+    );
+  });
+});

--- a/src/__tests__/routes.test.ts
+++ b/src/__tests__/routes.test.ts
@@ -1,11 +1,23 @@
 import { describe, expect, it } from 'vitest';
 
 import { ROUTES } from '../data/routes';
-import { calmingCollectorBody } from '../data/collector-bodies';
+import { calmingCollectorBody, comfortCollectorBody } from '../data/collector-bodies';
 
 describe('route constants', () => {
   it('uses canonical calming alternatives route', () => {
     expect(ROUTES.calmingAlternatives).toBe('/calming/best-thundershirt-alternatives/');
+  });
+
+  it('uses canonical puppy crates route', () => {
+    expect(ROUTES.comfortPuppyCrates).toBe('/comforting/best-puppy-crates/');
+  });
+
+  it('uses canonical anxiety crates route', () => {
+    expect(ROUTES.comfortAnxietyCrates).toBe('/comforting/best-anxiety-dog-crates/');
+  });
+
+  it('uses canonical travel crates route', () => {
+    expect(ROUTES.comfortTravelCrates).toBe('/comforting/best-travel-crates-for-road-trips/');
   });
 
   it('keeps calming collector links aligned to canonical route', () => {
@@ -20,5 +32,24 @@ describe('route constants', () => {
     expect(alternativesCard?.dataToPage).toBe(ROUTES.calmingAlternatives);
     expect(carAnxietyCard?.href).toBe(ROUTES.calmingCar);
     expect(carAnxietyCard?.dataToPage).toBe(ROUTES.calmingCar);
+  });
+
+  it('keeps comfort collector puppy crate link aligned to canonical route', () => {
+    const puppyCratesCard = comfortCollectorBody.sections[0].cards.find(
+      (card) => card.title === 'Best Puppy Crates'
+    );
+    const anxietyCratesCard = comfortCollectorBody.sections[0].cards.find(
+      (card) => card.title === 'Best Dog Crates for Anxiety'
+    );
+    const travelCratesCard = comfortCollectorBody.sections[0].cards.find(
+      (card) => card.title === 'Best Travel Crates for Road Trips'
+    );
+
+    expect(puppyCratesCard?.href).toBe(ROUTES.comfortPuppyCrates);
+    expect(puppyCratesCard?.dataToPage).toBe(ROUTES.comfortPuppyCrates);
+    expect(anxietyCratesCard?.href).toBe(ROUTES.comfortAnxietyCrates);
+    expect(anxietyCratesCard?.dataToPage).toBe(ROUTES.comfortAnxietyCrates);
+    expect(travelCratesCard?.href).toBe(ROUTES.comfortTravelCrates);
+    expect(travelCratesCard?.dataToPage).toBe(ROUTES.comfortTravelCrates);
   });
 });

--- a/src/__tests__/site-smoke.test.ts
+++ b/src/__tests__/site-smoke.test.ts
@@ -72,6 +72,17 @@ describe('site smoke tests', () => {
     expect(canonical?.getAttribute('href')).toBe('https://www.chill-dogs.com/');
   });
 
+  it('links the homepage into crate training and road trip crate paths', () => {
+    const doc = readBuiltPage('index.html');
+
+    const links = Array.from(doc.querySelectorAll<HTMLAnchorElement>('a')).map((link) =>
+      link.getAttribute('href')
+    );
+
+    expect(links).toContain('/calming/crate-training-for-dogs/');
+    expect(links).toContain('/comforting/best-travel-crates-for-road-trips/');
+  });
+
   it('publishes generated per-page OG assets and metadata references', () => {
     const homeDoc = readBuiltPage('index.html');
     const coolingDoc = readBuiltPage(path.join('cooling', 'cooling-mats', 'index.html'));
@@ -217,8 +228,18 @@ describe('site smoke tests', () => {
     expect(sitemap).toContain('/cooling/car-cooling-for-dogs/');
     expect(sitemap).toContain('/travel/dog-road-trip-gear/');
     expect(sitemap).toContain('/calming/best-calming-products-for-anxious-dogs/');
+    expect(sitemap).toContain('/comforting/best-puppy-crates/');
+    expect(sitemap).toContain('/comforting/best-anxiety-dog-crates/');
+    expect(sitemap).toContain('/comforting/best-travel-crates-for-road-trips/');
     expect(sitemap).not.toContain('/cooling/v/');
     expect(sitemap).not.toContain('/calming/v/');
+  });
+
+  it('publishes article collection entries in rss feed', () => {
+    const rssXml = readBuiltAsset('rss.xml');
+
+    expect(rssXml).toContain('/calming/crate-training-for-dogs/');
+    expect(rssXml).toContain('How to Crate Train Your Dog');
   });
 
   it('does not render escaped HTML tags as visible text on any page', () => {

--- a/src/__tests__/third-party.test.ts
+++ b/src/__tests__/third-party.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import { shouldLoadPinterestTag } from '../utils/third-party';
+
+describe('shouldLoadPinterestTag', () => {
+  it('loads only on indexable production pages with a configured tag', () => {
+    expect(
+      shouldLoadPinterestTag({
+        tagId: '2612767302267',
+        noindex: false,
+        vercelEnv: 'production',
+      })
+    ).toBe(true);
+  });
+
+  it('does not load without a tag id', () => {
+    expect(
+      shouldLoadPinterestTag({
+        tagId: '',
+        noindex: false,
+        vercelEnv: 'production',
+      })
+    ).toBe(false);
+  });
+
+  it('does not load on noindex pages', () => {
+    expect(
+      shouldLoadPinterestTag({
+        tagId: '2612767302267',
+        noindex: true,
+        vercelEnv: 'production',
+      })
+    ).toBe(false);
+  });
+
+  it('does not load outside production', () => {
+    expect(
+      shouldLoadPinterestTag({
+        tagId: '2612767302267',
+        noindex: false,
+        vercelEnv: 'preview',
+      })
+    ).toBe(false);
+  });
+});

--- a/src/components/Pinterest.astro
+++ b/src/components/Pinterest.astro
@@ -6,9 +6,11 @@
  * Skipped entirely on noindex pages (variant URLs, admin, etc.) so Pinterest
  * does not receive signal from pages that should never appear in search or ads.
  *
- * Gated on PUBLIC_PINTEREST_TAG_ID — set this in .env and Vercel environment
- * variables. If the var is absent the component renders nothing.
+ * Gated on PUBLIC_PINTEREST_TAG_ID and VERCEL_ENV=production. If either is
+ * absent, the component renders nothing to keep local and preview consoles quiet.
  */
+
+import { shouldLoadPinterestTag } from '@utils/third-party';
 
 interface Props {
   noindex?: boolean;
@@ -16,9 +18,14 @@ interface Props {
 
 const { noindex = false } = Astro.props;
 const tagId = import.meta.env.PUBLIC_PINTEREST_TAG_ID;
+const shouldRenderPinterest = shouldLoadPinterestTag({
+  tagId,
+  noindex,
+  vercelEnv: import.meta.env.VERCEL_ENV,
+});
 ---
 
-{tagId && !noindex && (
+{shouldRenderPinterest && (
   <script is:inline define:vars={{ tagId }}>
     (function () {
       if (window.pintrk) return;

--- a/src/components/modules/CalmingConverterPage.astro
+++ b/src/components/modules/CalmingConverterPage.astro
@@ -211,7 +211,7 @@ function quickPickProduct(item: QuickPickItem) {
   }
 
   .section-copy a {
-    color: var(--color-accent-text);
+    color: var(--color-link);
     text-decoration: underline;
   }
 

--- a/src/components/modules/HomepageBody.astro
+++ b/src/components/modules/HomepageBody.astro
@@ -72,7 +72,9 @@ const moreArticles = [
   { title: 'Cooling Mats', description: 'Compare pressure-activated and water-based cooling mats.', href: ROUTES.coolingMats, color: 'cool' },
   { title: 'Cooling Vests', description: 'Evaporative cooling vests for active outdoor dogs.', href: ROUTES.coolingVests, color: 'cool' },
   { title: 'Anxiety Vest Alternatives', description: 'When to choose wraps, chews, lick mats, or snuffle mats instead.', href: ROUTES.calmingAlternatives, color: 'calm' },
+  { title: 'How to Crate Train Your Dog', description: 'Crate training for puppies, anxious dogs, and travel routines.', href: ROUTES.calmingCrateGuide, color: 'calm' },
   { title: "Rhys's Road Trip Chill Kit", description: 'Cooling and calming picks for long drives with dogs.', href: ROUTES.roadTrip, color: 'calm' },
+  { title: 'Travel Crates for Road Trips', description: 'Hard-sided and soft folding crates for dogs who travel by car.', href: ROUTES.comfortTravelCrates, color: 'comfort' },
   { title: 'The Day Rhys Ran Off on Cerro San Luis Obispo', description: 'What a foggy summit and a 30-minute search taught us about GPS trackers.', href: ROUTES.rhysRanAway, color: 'gear' },
   { title: 'What To Do If Your Dog Runs Away', description: 'A step-by-step action guide for the first hour and beyond.', href: ROUTES.dogRanAwaySafety, color: 'gear' },
 ];
@@ -92,7 +94,9 @@ const latestGuides = [
   { title: 'Cooling Mats', description: 'Compare pressure-activated and water-based cooling mats.', href: ROUTES.coolingMats },
   { title: 'Cooling Vests', description: 'Evaporative cooling vests for active outdoor dogs.', href: ROUTES.coolingVests },
   { title: 'Anxiety Vest Alternatives', description: 'When to choose wraps, chews, lick mats, or snuffle mats instead.', href: ROUTES.calmingAlternatives },
+  { title: 'How to Crate Train Your Dog', description: 'Crate training for puppies, anxious dogs, and travel routines.', href: ROUTES.calmingCrateGuide },
   { title: "Rhys's Road Trip Chill Kit", description: 'Cooling and calming picks for long drives with dogs.', href: ROUTES.roadTrip },
+  { title: 'Travel Crates for Road Trips', description: 'Hard-sided and soft folding crates for dogs who travel by car.', href: ROUTES.comfortTravelCrates },
   { title: 'The Day Rhys Ran Off on Cerro San Luis Obispo', description: 'What a foggy summit and a 30-minute search taught us about GPS trackers.', href: ROUTES.rhysRanAway },
   { title: 'What To Do If Your Dog Runs Away', description: 'A step-by-step action guide for the first hour and beyond.', href: ROUTES.dogRanAwaySafety },
 ];

--- a/src/components/modules/RelaxationConverterPage.astro
+++ b/src/components/modules/RelaxationConverterPage.astro
@@ -198,7 +198,7 @@ function quickPickProduct(item: QuickPickItem) {
   }
 
   .section-copy a {
-    color: var(--color-sky);
+    color: var(--color-link);
     text-decoration: underline;
   }
 

--- a/src/content/articles/calming-crate-training-for-dogs.mdx
+++ b/src/content/articles/calming-crate-training-for-dogs.mdx
@@ -1,0 +1,224 @@
+---
+title: 'How to Crate Train Your Dog'
+description: "Crate training gives your dog a safe, familiar space. It is a practical tool for housebreaking, anxiety management, and travel. Here's how to do it right."
+pubDate: 2026-04-09
+canonicalPath: '/calming/crate-training-for-dogs/'
+---
+
+import Toc from '@components/modules/Toc.astro';
+import FAQ from '@components/modules/FAQ.astro';
+import InternalLinkStrip from '@components/modules/InternalLinkStrip.astro';
+import Disclosure from '@components/modules/Disclosure.astro';
+import AffiliateLink from '@components/AffiliateLink.astro';
+import { ROUTES } from '@data/routes';
+
+export const pageSlug = 'crate-training-for-dogs';
+
+export const tocHeadings = [
+  { label: 'Why Crate Training Works', anchor: 'why-crate-training-works' },
+  { label: 'Crate Training a Puppy', anchor: 'crate-training-a-puppy' },
+  { label: 'Crates and Anxiety', anchor: 'crates-and-anxiety' },
+  { label: 'Crates for Travel', anchor: 'crates-for-travel' },
+  { label: 'Choosing the Right Crate', anchor: 'choosing-the-right-crate' },
+  { label: 'Common Mistakes to Avoid', anchor: 'common-mistakes' },
+];
+
+export const faqs = [
+  {
+    question: 'Is crate training cruel?',
+    answer:
+      'No. Dogs are den animals and naturally seek out small, enclosed spaces for rest. When introduced with positive reinforcement — treats, meals, and gradual exposure — a crate becomes a space your dog chooses to use. The crate becomes a problem only when it\'s used as punishment or when a dog is confined for too long without breaks.',
+  },
+  {
+    question: 'How long does crate training take?',
+    answer:
+      'It depends on the dog\'s age, temperament, and past experiences. Some puppies settle in within a few days. Adult dogs or dogs with anxiety may need several weeks of gradual introduction. The AKC notes that full crate training can take up to 6 months of consistent, patient work.',
+  },
+  {
+    question: 'How long can I leave my dog in a crate?',
+    answer:
+      'A common guideline for puppies is their age in months plus 1 hour — so a 3-month-old can handle about 4 hours. Adult dogs can generally manage 6–8 hours, but shouldn\'t be crated longer than that without a break for exercise and interaction. Dogs crated all day and all night aren\'t getting enough stimulation.',
+  },
+  {
+    question: 'What\'s the best type of crate for an anxious dog?',
+    answer:
+      'Plastic or enclosed crates tend to work better for anxious dogs because they reduce visual stimulation and create a den-like environment. Wire crates are more open and can increase restlessness in some dogs. However, dogs with true confinement anxiety may do better with an exercise pen or gated room instead of any crate.',
+  },
+  {
+    question: 'Should I put a bed or blanket in the crate?',
+    answer:
+      'For most dogs, yes — a machine-washable pad or blanket makes the crate more comfortable and inviting. However, some puppies or anxious dogs will shred bedding or use it as a potty spot. If that happens, try a bare crate floor or a chew-proof crate mat until the behavior settles.',
+  },
+];
+
+export const internalLinks = [
+  { label: 'Best Puppy Crates', href: ROUTES.comfortPuppyCrates },
+  { label: 'Best Anxiety Dog Crates', href: ROUTES.comfortAnxietyCrates },
+  { label: 'Best Travel Crates', href: ROUTES.comfortTravelCrates },
+  { label: 'Best Calming Products for Anxious Dogs', href: ROUTES.calmingTop },
+  { label: 'Best Calming Dog Beds', href: ROUTES.comfortCalmingBeds },
+];
+
+<article class="collector-article container">
+  <header class="article-header">
+    <span class="eyebrow">Calming &amp; Comfort</span>
+    <h1>How to Crate Train Your Dog</h1>
+    <p class="lede">
+      Crate training gives your dog a safe, familiar space. It is a practical tool for housebreaking, anxiety management, and travel. Here's how to do it right.
+    </p>
+  </header>
+
+  <Toc headings={tocHeadings} pageSlug={pageSlug} />
+
+  <div class="prose">
+
+    <p>
+      Crate training is one of those dog-ownership topics that sounds simple until you're actually doing it. The concept is straightforward — teach your dog to be comfortable in a crate — but the execution depends heavily on why you need the crate in the first place. A puppy learning to hold their bladder has different needs than an adult dog with separation anxiety, and both have different needs than a dog who needs to travel safely in a car or on a plane.
+    </p>
+    <p>
+      This guide covers all three scenarios: puppies, anxiety, and travel. The approach in each case is grounded in the same principle — positive association, built gradually — but the details and the timeline differ. We'll also cover how to choose the right crate, because the type of crate matters more than most people realize.
+    </p>
+
+    <h2 id="why-crate-training-works">Why Crate Training Works</h2>
+    <p>
+      Dogs are den animals. In the wild, canines seek out small, enclosed spaces for rest and protection. They like snug environments with one entrance that offer a sense of security. A crate, when introduced correctly, taps into that instinct. It becomes a modern den: a place your dog retreats to voluntarily, not a place they're forced into.
+    </p>
+    <p>
+      According to the AKC, crate training provides dogs with a feeling of security and can help calm anxiety when introduced at an early age. The crate works because it aligns with what dogs already want. The key is to introduce it correctly. A crate that's associated with punishment or forced confinement does the opposite.
+    </p>
+    <p>
+      Crate training has many practical benefits. It accelerates housebreaking because dogs instinctively avoid soiling their sleeping area. It keeps puppies safe from household hazards when left unsupervised. It builds the skill of being alone, which prevents separation anxiety. And it creates a portable home base that makes vet visits, travel, and overnight stays less stressful.
+    </p>
+
+    <h2 id="crate-training-a-puppy">Crate Training a Puppy</h2>
+    <p>
+      The earlier you start, the easier it goes. Puppies are naturally curious about enclosed spaces and generally take to crates faster than adult dogs. The process follows a consistent framework that the AKC, the Animal Humane Society, and veterinary training programs all agree on: go slow, stay positive, and never use the crate as punishment.
+    </p>
+    <p>
+      <strong>Start with the door open.</strong> Place the crate in a high-traffic area like the kitchen or living room. Leave the door secured open so it can't swing shut and startle the puppy. Toss high-value treats around the entrance, then just inside, then all the way to the back. Let your puppy discover them at their own pace. Some walk right in within minutes. Others need a few days.
+    </p>
+    <p>
+      <strong>Feed meals inside.</strong> Once your puppy enters the crate voluntarily, start serving meals inside it. This builds a strong positive association. After a few days of open-door meals, close the door while they eat and open it before they finish. Gradually extend the closed-door time.
+    </p>
+    <p>
+      <strong>Add enrichment.</strong> A frozen KONG stuffed with peanut butter is a classic trainer recommendation. It gives the puppy something to work on, reinforces the idea that crate time predicts good things, and helps them settle into a calm state.
+    </p>
+    <p>
+      <strong>Build duration slowly.</strong> Start with 10-minute sessions and work up. A widely used guideline: a puppy can hold their bladder for roughly their age in months plus 1 hour. A 3-month-old puppy can manage about 4 hours. This means young puppies should never be crated for a full workday. For longer absences, set up a puppy-safe area with the crate (door open), water, toys, and a designated potty spot.
+    </p>
+    <p>
+      <strong>Size the crate correctly.</strong> The crate should be large enough for your puppy to stand up, turn around, and lie down — but not so large that they can designate a bathroom corner. A crate with a divider panel lets you adjust the space as the puppy grows, which saves you from buying a new crate every few weeks.
+    </p>
+    <p>
+      If you are buying your first crate, start with our <a href={ROUTES.comfortPuppyCrates} data-track="collector_to_converter_click" data-from-page={pageSlug} data-to-page={ROUTES.comfortPuppyCrates} data-link-position="section">puppy crate picks</a> for divider-based wire crates that fit this training approach.
+    </p>
+
+    <h2 id="crates-and-anxiety">Crates and Anxiety</h2>
+    <p>
+      This is where crate training gets more nuanced. The relationship between crates and anxiety isn't simple, and getting it wrong can make things worse.
+    </p>
+    <p>
+      There's a meaningful difference between three conditions that look similar on the surface: <strong>separation anxiety</strong> (distress triggered by the owner's absence), <strong>confinement anxiety</strong> (distress triggered by being in a small enclosed space), and <strong>incomplete crate training</strong> (the dog never built positive associations with the crate). All three can produce whining, pacing, drooling, and destructive behavior, but they require different responses.
+    </p>
+    <p>
+      <strong>When crates help.</strong> For dogs with mild to moderate separation anxiety who already have a positive relationship with their crate, the enclosed space can reduce environmental stimulation, limit frantic pacing that escalates arousal, and provide predictability. The den-like quality of an enclosed plastic crate blocks noise and distractions. It can genuinely help some dogs settle. A crate also keeps anxious dogs safe from themselves. Dogs in a panicked state sometimes chew through drywall, eat objects that cause blockages, or escape the house. A sturdy crate is harm reduction while you address the underlying issue.
+    </p>
+    <p>
+      If your dog already tolerates confinement, our <a href={ROUTES.comfortAnxietyCrates} data-track="collector_to_converter_click" data-from-page={pageSlug} data-to-page={ROUTES.comfortAnxietyCrates} data-link-position="section">anxiety crate comparison</a> breaks down wire, enclosed, and heavy-duty options by anxiety pattern.
+    </p>
+    <p>
+      <strong>When crates make things worse.</strong> Dogs with confinement anxiety panic in small spaces regardless of whether or not the owner is home. These dogs may injure themselves trying to escape — bending bars, cracking panels, breaking teeth. If your dog shows escalating distress the moment they're confined, even with you standing right there, the crate is not the right tool. Professional trainers working with severe separation anxiety often recommend removing the crate entirely and using an exercise pen or gated room instead.
+    </p>
+    <p>
+      <strong>The right approach.</strong> If you're introducing a crate to an anxious dog, go even slower than you would with a puppy. Start with just the crate base — no top, no door — in a central area of the home. Feed meals on it. Add the top after a few days, then reintroduce the door without closing it.
+    </p>
+    <p>
+      The critical rule: don't let the crate become associated only with your departure. Use it for naps, quiet time, and treat sessions while you're home. An anxious dog who only enters the crate when you're leaving learns that the crate means abandonment.
+    </p>
+    <p>
+      If your dog won't eat treats in the closed crate, or eats when you're present but stops when you leave the room, those are important signals. Consider a camera to observe their behavior when left alone. And if you're seeing genuine panic — drooling, escape attempts, self-injury — consult a Certified Separation Anxiety Trainer (CSAT) or your vet rather than pushing through it.
+    </p>
+    <p>
+      For dogs with ongoing anxiety, pairing crate training with broader <a href={ROUTES.calmingTop} data-track="collector_to_converter_click" data-from-page={pageSlug} data-to-page={ROUTES.calmingTop} data-link-position="section">calming products</a> can help ease the transition.
+    </p>
+
+    <h2 id="crates-for-travel">Crates for Travel</h2>
+    <p>
+      Travel is where crate training pays its biggest practical dividend. A dog who's comfortable in a crate can ride safely in a car, stay calm in a hotel, handle a vet overnight, and fly in cargo with far less stress than a dog encountering a crate for the first time at the airport.
+    </p>
+    <p>
+      Crate training is also important in case you ever need to evacuate your home in an emergency. A stressful evacuation when you only have minutes to spare should not be the first time you try to force a fearful dog into a crate.
+    </p>
+    <p>
+      <strong>Car travel.</strong> A crate is the safest way to transport a dog in a vehicle. In a sudden stop or accident, an unsecured dog becomes a projectile. The ASPCA recommends a well-ventilated crate secured in the back seat or cargo area, away from airbags. If your dog isn't used to car rides in a crate, start with short drives and gradually increase duration. Familiar bedding and an item with your scent placed inside the crate can help.
+    </p>
+    <p>
+      If your dog struggles with car rides beyond just crate comfort, our guide to <a href={ROUTES.calmingCar} data-track="collector_to_converter_click" data-from-page={pageSlug} data-to-page={ROUTES.calmingCar} data-link-position="section">car anxiety for dogs</a> covers targeted calming strategies for travel.
+    </p>
+    <p>
+      If you specifically need a crate for long drives, compare our <a href={ROUTES.comfortTravelCrates} data-track="collector_to_converter_click" data-from-page={pageSlug} data-to-page={ROUTES.comfortTravelCrates} data-link-position="section">travel crates for road trips</a> before choosing between hard-sided and soft folding formats.
+    </p>
+    <p>
+      <strong>Air travel.</strong> Flying a dog in cargo requires a crate that meets IATA (International Air Transport Association) standards: rigid construction (not collapsible), ventilation on at least 3 sides for domestic flights (4 for international), a metal door with secure locks, and sizing that lets the dog stand, turn, and lie down naturally. Most airlines require metal nuts and bolts rather than snap closures, and wheels must be removed or disabled. Begin crate training well in advance of any flight — weeks or months, not days. The ASPCA advises direct flights, never flying brachycephalic (flat-faced) breeds in cargo, and notifying airline staff that a pet is on board.
+    </p>
+    <p>
+      <strong>Everyday portability.</strong> A portable crate simplifies vet visits, grooming, visits to friends' homes, and anywhere else your dog needs a familiar space. This is where lightweight, collapsible designs work best.
+    </p>
+
+    <h2 id="choosing-the-right-crate">Choosing the Right Crate</h2>
+    <p>
+      The right crate depends on how you'll use it. Here's how the main types compare:
+    </p>
+    <p>
+      <strong>Wire crates</strong> offer maximum airflow and visibility, fold flat for storage, and are widely available at every price point. They're a solid default for home use. The downsides: they rattle when a dog moves inside, they don't create the enclosed den feeling that helps anxious dogs settle, and the open design means more visual distraction.
+    </p>
+    <p>
+      For puppies, the main wire-crate decision is usually simple: choose a lighter budget option like iCrate, or a sturdier build like Life Stages if your puppy is strong or especially active. The <a href={ROUTES.comfortPuppyCrates} data-track="collector_to_converter_click" data-from-page={pageSlug} data-to-page={ROUTES.comfortPuppyCrates} data-link-position="section">puppy crates comparison</a> breaks down that choice.
+    </p>
+    <p>
+      Draping a blanket over three sides insulates the crate, absorbs ambient sound, and transforms an open wire frame into something much closer to a den. Many dogs settle noticeably faster with a covered wire crate than an uncovered one.
+    </p>
+    <p>
+      <strong>Plastic and enclosed crates</strong> create a warmer, quieter environment that closely mimics a natural den. They're lighter than they look, easier to clean, and generally preferred for travel. For puppies and anxiety-prone dogs, the reduced stimulation is a real advantage.
+    </p>
+    <p>
+      One option worth noting in this category is the <strong>KindTail PAWD</strong> — a modern collapsible plastic crate that started as a Kickstarter project and has built a strong following among small-dog owners. It collapses flat in seconds without tools, is made from BPA-free non-toxic plastic, weighs 12–14 pounds, and features a hexagonal ventilation pattern that balances airflow with enclosure. It's designed for dogs up to about 25 pounds (medium size) and comes in several colors. Owners consistently note the portability, easy cleanup, and the fact that there are no sharp wire edges for paws or jaws to catch on. It's <AffiliateLink href="https://www.amazon.com/KindTail-Collapsible-Plastic-Washable-Portable/dp/B0CWNXMYW1/?tag=chill-dogs-20" data-asin="B0CWNXMYW1" data-product-name="KindTail PAWD" data-track="amazon_outbound_click">available on Amazon</AffiliateLink>.
+    </p>
+    <p>
+      <strong>Heavy-duty crates</strong> from brands like Impact Dog Crates use reinforced aluminum and escape-proof latches. They're an investment, but for dogs with severe anxiety who have damaged standard crates, they prevent injuries and vet bills.
+    </p>
+    <p>
+      For stronger escape artists, compare <a href={ROUTES.comfortAnxietyCrates} data-track="collector_to_converter_click" data-from-page={pageSlug} data-to-page={ROUTES.comfortAnxietyCrates} data-link-position="section">heavy-duty anxiety crate options</a> before choosing a standard wire crate.
+    </p>
+    <p>
+      <strong>Soft-sided crates</strong> are ultralight and convenient for travel with well-trained, calm dogs. They're not suitable for puppies, chewers, or anxious dogs.
+    </p>
+    <p>
+      Whatever crate type you choose, pairing it with a quality <a href={ROUTES.comfortCalmingBeds} data-track="collector_to_converter_click" data-from-page={pageSlug} data-to-page={ROUTES.comfortCalmingBeds} data-link-position="section">calming dog bed</a> inside can make the space more inviting and help anxious dogs settle faster.
+    </p>
+
+    <h2 id="common-mistakes">Common Mistakes to Avoid</h2>
+    <p>
+      <strong>Using the crate as punishment.</strong> The moment a crate becomes associated with being in trouble, you've undermined the entire foundation. The crate should only ever predict good things.
+    </p>
+    <p>
+      <strong>Going too fast.</strong> Rushing the introduction — closing the door before the dog is ready, leaving for hours on day one — creates negative associations that are harder to undo than to prevent.
+    </p>
+    <p>
+      <strong>Crating for too long.</strong> Puppies need frequent breaks. No adult dog should spend more than 6–8 hours in a crate without exercise and interaction. A dog crated all day and all night isn't being trained — they're being stored.
+    </p>
+    <p>
+      <strong>Choosing the wrong size.</strong> Too big and housetraining stalls. Too small and the dog is physically uncomfortable. Use the stand-turn-lie-down test and measure your dog before buying.
+    </p>
+    <p>
+      <strong>Ignoring signs of distress.</strong> Normal adjustment whining fades within a few minutes. Escalating panic — drooling, escape attempts, self-injury — is a signal to slow down or consult a professional, not push through. If you're unsure, talk to your vet.
+    </p>
+
+  </div>
+
+  <Disclosure showSafety={false} />
+
+  <FAQ faqs={faqs} />
+
+  <InternalLinkStrip links={internalLinks} fromPage={pageSlug} />
+</article>

--- a/src/content/articles/travel-dog-road-trip-gear.mdx
+++ b/src/content/articles/travel-dog-road-trip-gear.mdx
@@ -428,6 +428,7 @@ export const roadTripFaqs = [
   <InternalLinkStrip
     heading="More Dog Travel Guides"
     links={[
+      { label: 'Travel Crates for Road Trips', href: '/comforting/best-travel-crates-for-road-trips/' },
       { label: 'Car Cooling Picks', href: '/cooling/car-cooling-for-dogs/' },
       { label: 'Car Anxiety Picks', href: '/calming/car-anxiety-for-dogs/' },
       { label: 'All Calming Products', href: '/calming/best-calming-products-for-anxious-dogs/' },

--- a/src/data/amazon-products/B0002AT3ME.json
+++ b/src/data/amazon-products/B0002AT3ME.json
@@ -1,0 +1,511 @@
+{
+  "search_metadata": {
+    "id": "search_M92XEY4l2JFg6QjVQkQG3b0J",
+    "status": "Success",
+    "created_at": "2026-04-10T02:38:49Z",
+    "request_time_taken": 2.24,
+    "parsing_time_taken": 0.12,
+    "total_time_taken": 2.35,
+    "request_url": "https://www.amazon.com/dp/B0002AT3ME?th=1&psc=1",
+    "html_url": "https://www.searchapi.io/api/v1/searches/search_M92XEY4l2JFg6QjVQkQG3b0J.html",
+    "json_url": "https://www.searchapi.io/api/v1/searches/search_M92XEY4l2JFg6QjVQkQG3b0J"
+  },
+  "search_parameters": {
+    "engine": "amazon_product",
+    "asin": "B0002AT3ME",
+    "amazon_domain": "amazon.com",
+    "delivery_country": "us"
+  },
+  "product": {
+    "asin": "B0002AT3ME",
+    "title": "MidWest Homes for Pets 42-Inch LifeStages Crate for Large Breeds, 71-90 lbs, Double Door Folding Dog Crate with Divider Panel, Leak-Proof Tray & Secure Latch, Heavy-Duty & Easy to Assemble",
+    "brand_store": {
+      "id": "2A08F8F5-A392-471A-9EE7-EC1B59540DA6",
+      "text": "Visit the MidWest Homes for Pets Store",
+      "link": "https://www.amazon.com/stores/MidWestHomesForPets/page/2A08F8F5-A392-471A-9EE7-EC1B59540DA6?lp_asin=B0002AT3ME&ref_=ast_bln&store_ref=bl_ast_dp_brandlogo_sto&bl_grd_status=override"
+    },
+    "marketplace_id": "ATVPDKIKX0DER",
+    "link": "https://www.amazon.com/s?k=wire+dog+crate",
+    "rating": 4.7,
+    "reviews": 17857,
+    "bought_past_month": "50+ bought in past month",
+    "description": "Give your dog a safe, comfortable place to call their own with the MidWest Homes for Pets LifeStages Two Door Dog Crate. Newly enhanced with added security features, this durable metal wire dog crate now includes a patented Paw Block and locking tips on the slide-bolt latch – so you can feel confident your pet is secure whether they're relaxing at home or hitting the road with you. Reinforced with heavy-duty wire gauge, this crate is ideal for dogs with higher separation anxiety who may need a more durable home. Designed with both pets and parents in mind, LifeStages dog crates come complete with a divider panel (to grow with your puppy), a durable leak-proof pan for easy cleanup, rubber feet to protect your floors, and a carrying handle for added convenience. Plus, you can fold it flat in seconds without tools, making it perfect for travel, storage or quick set-up anywhere you need it – from your living room to a beachside vacation rental. Built from precision-welded metal wire with a black e-coat finish, the LifeStages is durable enough for everyday use while resisting rust and wear over time. Larger openings and low thresholds make it easier for your dog to enter and exit the crate, easing the crate training process and helping them feel more at home. At MidWest Homes for Pets, we know your dog is family. That's why every crate is backed by a 1-Year Manufacturer's Warranty and supported by our Indiana-based customer care team, making the LifeStages a trusted choice for creating a secure, comfortable home for your dog.",
+    "attributes": [
+      {
+        "name": "Brand",
+        "value": "MidWest Homes for Pets"
+      },
+      {
+        "name": "Product Dimensions",
+        "value": "42\"L x 28\"W x 30\"H"
+      },
+      {
+        "name": "Material",
+        "value": "Metal"
+      },
+      {
+        "name": "Specific Uses For Product",
+        "value": "Indoor"
+      },
+      {
+        "name": "Special Feature",
+        "value": "Adjustable, Foldable, Lockable, Secure, Ventilated"
+      }
+    ],
+    "feature_bullets": [
+      "IDEAL FOR 71-90 LB DOGS: Measures 42.5 x 28.5 x 30.5 inches – perfect for Australian Shepherds, Boxers, Golden Retrievers & similar breeds. For dogs near 90 lbs, consider sizing up to our 48-inch model so they have plenty of room to get comfortable.",
+      "WE DON'T CUT CORNERS, WE PERFECT THEM: Precision welding, rounded corner clips & slide-bolt latches with Paw Block mitigate cuts & escapes. With rigorous safety testing, LifeStages provides peace of mind knowing your dog is safe while you're away.",
+      "HEAVY-DUTY CONSTRUCTION: Reinforced with heavier gauge wire than standard crates, LifeStages is built for durability. Complete with leak-proof tray, rubber feet, carry handle, and tool-free assembly, it's ready for years of use.",
+      "SUPPORTS CRATE TRAINING: Included divider panel lets the crate grow with your dog, from puppy kennel to full-size crate. Large openings and low thresholds ease the crate training process and help your dog feel more at home.",
+      "BECAUSE LIFE GOES BETTER WITH PETS: A family-owned business based in Indiana, MidWest Homes for Pets brings over 100 years of pet product expertise and a commitment to quality, rigorous safety testing, and excellent US-based customer service."
+    ],
+    "variants": [
+      {
+        "asin": "B0002AT3ME",
+        "title": "Black 42.0\"L x 28.0\"W x 30.0\"H",
+        "link": "https://www.amazon.com/dp/B0002AT3ME?th=1&pcs=1",
+        "is_current_product": true,
+        "dimensions": [
+          {
+            "name": "Color",
+            "value": "Black"
+          },
+          {
+            "name": "Size",
+            "value": "42.0\"L x 28.0\"W x 30.0\"H"
+          }
+        ]
+      },
+      {
+        "asin": "B0002TKBU8",
+        "title": "Black 23.0\"L x 14.0\"W x 16.0\"H",
+        "link": "https://www.amazon.com/dp/B0002TKBU8?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Color",
+            "value": "Black"
+          },
+          {
+            "name": "Size",
+            "value": "23.0\"L x 14.0\"W x 16.0\"H"
+          }
+        ]
+      },
+      {
+        "asin": "B000HCLDFC",
+        "title": "Black 24.0\"L x 18.0\"W x 19.0\"H",
+        "link": "https://www.amazon.com/dp/B000HCLDFC?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Color",
+            "value": "Black"
+          },
+          {
+            "name": "Size",
+            "value": "24.0\"L x 18.0\"W x 19.0\"H"
+          }
+        ]
+      },
+      {
+        "asin": "B0002AT3M4",
+        "title": "Black 36.0\"L x 23.0\"W x 25.0\"H",
+        "link": "https://www.amazon.com/dp/B0002AT3M4?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Color",
+            "value": "Black"
+          },
+          {
+            "name": "Size",
+            "value": "36.0\"L x 23.0\"W x 25.0\"H"
+          }
+        ]
+      },
+      {
+        "asin": "B0002TKBUS",
+        "title": "Black 30.6\"L x 19.3\"W x 21.4\"H",
+        "link": "https://www.amazon.com/dp/B0002TKBUS?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Color",
+            "value": "Black"
+          },
+          {
+            "name": "Size",
+            "value": "30.6\"L x 19.3\"W x 21.4\"H"
+          }
+        ]
+      },
+      {
+        "asin": "B0002AT3MO",
+        "title": "Black 48.0\"L x 30.0\"W x 33.0\"H",
+        "link": "https://www.amazon.com/dp/B0002AT3MO?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Color",
+            "value": "Black"
+          },
+          {
+            "name": "Size",
+            "value": "48.0\"L x 30.0\"W x 33.0\"H"
+          }
+        ]
+      }
+    ],
+    "search_alias": {
+      "title": "Pet Supplies",
+      "value": "pets"
+    },
+    "buybox": {
+      "price": {
+        "raw": "$108.74",
+        "value": 108.74,
+        "symbol": "$",
+        "currency": "USD"
+      },
+      "original_price": {
+        "raw": "$119.99",
+        "value": 119.99,
+        "symbol": "$",
+        "currency": "USD"
+      },
+      "save": {
+        "percentage": 9
+      },
+      "secondary_buybox": {
+        "title": "Used - Very Good",
+        "price": {
+          "raw": "$90.58",
+          "value": 90.58,
+          "symbol": "$",
+          "currency": "USD"
+        }
+      },
+      "maximum_order_quantity": 27,
+      "offer_listing_id": "jcxeDnAsbOE6iyd9JUar0WG2%2FXXu2PXVFsA5agHGvu3PoMpqR0v1%2BTMI8KSK4QG0ix6c5J0ZAcH%2BFW%2F5oRfscBRRrrrXgKurBa8JuO31Sn%2BhTZrlsSildYouOaGpqjedSh%2BoZQ%2FeeMI%3D",
+      "mixed_offers_from": {
+        "price": {
+          "raw": "$90.58",
+          "value": 90.58,
+          "symbol": "$",
+          "currency": "USD"
+        },
+        "link": "https://www.amazon.com/gp/offer-listing/B0002AT3ME/ref=dp_olp_ALL_mbc?ie=UTF8&condition=ALL"
+      },
+      "fulfillment": {
+        "standard_delivery": {
+          "text": "FREE delivery Tuesday, April 14",
+          "type": "FREE",
+          "date": "Tuesday, April 14"
+        },
+        "fastest_delivery": {
+          "text": "Or Prime members get FREE delivery Saturday, April 11. Order within 2 hrs 21 mins. Join Prime",
+          "type": "FREE",
+          "date": "Saturday, April 11"
+        },
+        "ships_from": "Amazon Resale",
+        "sold_by": "Amazon.com",
+        "is_sold_by_amazon": true
+      },
+      "availability": "In Stock"
+    },
+    "specifications": [
+      {
+        "name": "Brand Name",
+        "value": "MidWest Homes for Pets"
+      },
+      {
+        "name": "Specific Uses For Product",
+        "value": "Indoor"
+      },
+      {
+        "name": "Included Components",
+        "value": "Divider, Removable Tray"
+      },
+      {
+        "name": "Breed Recommendation",
+        "value": "Large"
+      },
+      {
+        "name": "Dog Breed Size",
+        "value": "Large"
+      },
+      {
+        "name": "Manufacturer",
+        "value": "MidWest Homes For Pets"
+      },
+      {
+        "name": "UPC",
+        "value": "027773018902"
+      },
+      {
+        "name": "Global Trade Identification Number",
+        "value": "00027773018902"
+      },
+      {
+        "name": "Item Type Name",
+        "value": "Dog Crate"
+      },
+      {
+        "name": "Unit Count",
+        "value": "1 Count"
+      },
+      {
+        "name": "Warranty Description",
+        "value": "1-Year Manufacturers Warranty"
+      },
+      {
+        "name": "ASIN",
+        "value": "B0002AT3ME"
+      },
+      {
+        "name": "Additional Features",
+        "value": "Adjustable, Foldable, Lockable, Secure, Ventilated"
+      },
+      {
+        "name": "Number of Levels",
+        "value": "1"
+      },
+      {
+        "name": "Number of Doors",
+        "value": "2"
+      },
+      {
+        "name": "Material Type",
+        "value": "Metal"
+      },
+      {
+        "name": "Color",
+        "value": "Black"
+      },
+      {
+        "name": "Item Dimensions L x W x H",
+        "value": "42\"L x 28\"W x 30\"H"
+      },
+      {
+        "name": "Item Weight",
+        "value": "40.7 Pounds"
+      },
+      {
+        "name": "Is Discontinued By Manufacturer",
+        "value": "No"
+      },
+      {
+        "name": "Product Dimensions",
+        "value": "42 x 28 x 31 inches; 40.7 Pounds"
+      },
+      {
+        "name": "Manufacturer recommended age",
+        "value": "1 month and up"
+      },
+      {
+        "name": "Item model number",
+        "value": "1642DDU"
+      },
+      {
+        "name": "Department",
+        "value": "Plastic and Metal Crates"
+      },
+      {
+        "name": "Date First Available",
+        "value": "July 1, 2004"
+      },
+      {
+        "name": "Manufacturer",
+        "value": "MidWest Homes For Pets"
+      },
+      {
+        "name": "ASIN",
+        "value": "B0002AT3ME"
+      }
+    ],
+    "bestsellers_rank": [
+      {
+        "name": "See Top 100 in Pet Supplies",
+        "link": "https://www.amazon.com/gp/bestsellers/pet-supplies/ref=pd_zg_ts_pet-supplies"
+      },
+      {
+        "name": "Basic Dog Crates",
+        "link": "https://www.amazon.com/gp/bestsellers/pet-supplies/3024223011/ref=pd_zg_hrsr_pet-supplies"
+      },
+      {
+        "name": "See Top 100 in Pet Supplies",
+        "link": "https://www.amazon.com/gp/bestsellers/pet-supplies/ref=pd_zg_ts_pet-supplies",
+        "rank": 10278
+      },
+      {
+        "name": "Basic Dog Crates",
+        "link": "https://www.amazon.com/gp/bestsellers/pet-supplies/3024223011/ref=pd_zg_hrsr_pet-supplies",
+        "rank": 27
+      }
+    ],
+    "main_image": "https://m.media-amazon.com/images/I/91NBxSDchXL.jpg",
+    "images": [
+      {
+        "link": "https://m.media-amazon.com/images/I/91NBxSDchXL.jpg",
+        "variant": "MAIN"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/A1b+zkBU2ML.jpg",
+        "variant": "PT01"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/91KElYjM1XL.jpg",
+        "variant": "PT02"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/91hEHU84flL.jpg",
+        "variant": "PT03"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/91U0d-JlbTL.jpg",
+        "variant": "PT04"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/9183BZhkLXL.jpg",
+        "variant": "PT05"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/A1bgAnKLYDL.jpg",
+        "variant": "PT06"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/81EC68URhyL.jpg",
+        "variant": "PT07"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/91niTXNuBlL.jpg",
+        "variant": "PT12"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/41XsiBfwfAL.jpg",
+        "variant": "PT15"
+      }
+    ]
+  },
+  "similar_item": {
+    "asin": "B09G48LHVX",
+    "title": "Amazon Basics Portable, Easy to Assemble, Foldable Metal Wire Dog Crate with Removable Tray, Double Door, Divider Panel, Handle, 36\" x 23\" x 25\", Black",
+    "link": "https://www.amazon.com/dp/B09G48LHVX/ref=vp_d_pb_TIER4_pbxcovv3_lp_B0002AT3ME_pd?_encoding=UTF8&pf_rd_p=833279f6-3822-4089-a177-f6c02b33c169&pf_rd_r=WZ4SX04M2W2CE09FFH75&pd_rd_wg=NWzaA&pd_rd_i=B09G48LHVX&pd_rd_w=BHTRk&content-id=amzn1.sym.833279f6-3822-4089-a177-f6c02b33c169&pd_rd_r=fa7e9773-0a02-4484-8a93-05b1b347c36c&psc=1",
+    "rating": 4.5,
+    "reviews": 11101,
+    "price": {
+      "raw": "$52.74",
+      "value": 52.74,
+      "symbol": "$",
+      "currency": "USD"
+    },
+    "image": "https://m.media-amazon.com/images/I/81um0gokt5L.jpg"
+  },
+  "frequently_bought_together": {
+    "total_price": {
+      "raw": "$177.73",
+      "value": 177.73,
+      "symbol": "$",
+      "currency": "USD"
+    }
+  },
+  "review_results": {
+    "local": [
+      {
+        "id": "R3PDXYZE88XA0K",
+        "asin": "R3PDXYZE88XA0K",
+        "title": "Perfect for litter box training",
+        "link": "https://www.amazon.com/gp/customer-reviews/R3PDXYZE88XA0K/ref=cm_cr_dp_d_rvw_ttl?ie=UTF8",
+        "text": "Reviews help me when I am trying to choose a product to buy, so I want to in turn leave a review for others who are in the market for a crate. This is my first crate experience. A few weeks ago I came across a 4 week old kitten that was abandoned in the middle of a busy road. Without any time to prepare I took the kitten in and soon found out that kittens aren't born knowing what a litter box is. Duh moment here, yeah I know. The kitten started doing her bathroom business all over the house, so I confined her to one room until I could ask rescues and vet techs what to do.Every answer given to me was to crate the kitten with a litter box so she will have no other place to go than in the box. That is where my search for a crate started. A crate needed to be large enough for a litter box, food/water bowls and a bed, plus room to move around- and I also consider future use as well once the kitten is an adult cat. I wanted a crate large enough to hold not only a tiny kitten but also a full grown adult cat, comfortably. The Medium size is what I ordered. What I should have ordered is a large though, because I've recently learned of people crating cats to transport them on long distance road trips- I have 3 adult cats, you never know when a crate will come in handy for them. But this is my first crate experience and for the purpose I needed it for a medium works well. The bars are not spaced so far apart that a kitten would get her head stuck trying to get out. An added bonus is the front and side doors that both open with a large enough space to move around a litter box or clean inside the crate very easily.Set up was very easy, no tools required and it feels sturdy enough that it would hold against a medium size dog, but since I have cats I can't say how strong the crate would be against a dog- I can say that my kitten hasn't managed to jail break though. There is a heft to the crate, it is not light weight and does move easy with 2 handles that are included. I've attached a picture so others can see how much space is inside this crate with a small litter box, a food/water container snapped onto the bars and a medium size dog bed on top. I used the divider to create a 2nd floor to the crate so my kitten won't be sleeping right next to her litter box. So far my kitten is very comfortable spending nights in her crate. I'd recommend this crate to others who have either a small breed or medium size dog and of course those who are litter box training or need to crate a cat/kitten for any reason. Quality is great here and I am very happy with my purchase. In the future I want to get the large crate just in case there's ever a reason to crate my adult cats for either a move or medical. This crate also folds down easy, slips back into the box without hassle and stores away for when not in use.",
+        "rating": 5,
+        "date": "Reviewed in the United States on May 24, 2016",
+        "extracted_date": "2016-05-24",
+        "profile": {
+          "id": "AEMKCMIKAEANIPVGMCKLQ47WKVHQ",
+          "name": "Cat Lady",
+          "link": "https://www.amazon.com/gp/profile/amzn1.account.AEMKCMIKAEANIPVGMCKLQ47WKVHQ"
+        },
+        "helpful_votes": 14,
+        "images": [
+          "https://m.media-amazon.com/images/I/71rAi74EPZL.jpg"
+        ],
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R38NBBYUJZOPH7",
+        "asin": "R38NBBYUJZOPH7",
+        "title": "I love this crate and so does my dog",
+        "link": "https://www.amazon.com/gp/customer-reviews/R38NBBYUJZOPH7/ref=cm_cr_dp_d_rvw_ttl?ie=UTF8",
+        "text": "I purchased many many crates for my dogs in the past 45 years, I bought the cheapest and I bought the most expensive. You used to have to get them at the pet store and pay anywhere from $90-$200 for standard great. Thank goodness for Amazon. I just added to my \"stable\" of dogs with an eight-week-old golden retriever named Bentley. Now he's just a little guy weighing in at 12 pounds but he will get bigger. Right now he fits in a small crate and I mean fits. He can get in it but he can't lay down or turn around. I needed to get him a crate he can grow into so I went online to Amazon and looked around. I saw my old friends Midwest who stood by me with durable crates during my dog show days. They always made a sturdy crate out of heavy-duty material that was well engineered and well put together. It's been a few years since I bought a crate and a few things have changed. Pretty much now everybody offers a folding crate that wasn't so back in the day Midwest was one of the first to offer that feature and they did it well and they still do. They have a variety of sizes more so than most manufacturers so I chose the middle middle size which is a little bigger than other manufacturers middle size. Some of the features I like was this one has double doors, one on the side and one on the end. Each closes and locks sturdily and securely with two hasps on each door. Nowadays the bottom tray is made of plastic instead of steel so with a little lighter and more resistant to corrosion and easily cleaned. I ordered this crate and it came promptly from Amazon as I am an Amazon prime member. It was packaged well and arrived without damage and I had it set up in less than 5 min.. The only problem was the location where I was going to use it was against a wall and the doors were all wrong. Well I solved that by swapping the ends by bending back four hooks on each end, then squeezing them tight again to finish up, this took all of 3 min. to do in my crate or I should say that Bentleys crate was ready to go. One of the big advantages of having the second door is that when I wanted to introduce Bentley to crate I left both doors open so he could wander in and out at his leisure. I placed a few toys and water bowl in their as well as a wee wee pad and some bedding. He was curious and wandered in and out. I will admit however, the first night he was full of screams and barks and crying for most of the night. It was his first night in a crate. The second night I placed him in the crate and he laid down and was quiet until early morning. When he saw me and heard me moving around a little bit he started vocalizing so I took him out. The Crate also comes with a divider so you can change the size as your dog grows. At this point I'm not even using divider and giving Bentley full run of the crate. I am really glad that Amazon is selling these and the price is phenomenal. If you go to a pet store I'm sure you will easily over $150 for this crate or poorly made imitation. I really recommend Midwest and I think you'll be very happy with the quality and the operation of this crate. if you're a first-time buyer, check the AKC standards for how big your dog will be, then buyer accordingly. Don't buy too small as you will have to buy bigger later on. I give this five stars I love it I know you will too and it's recommended buy If you found my review helpful please click yes on the button below I really appreciate your support for that I intend to leave reviews to help others make decisions prior to purchase taste upon my recommendations or disclosure and I utilize your reviews to help me with my purchases as well. my reviews are honest factual and accurate thank you",
+        "rating": 5,
+        "date": "Reviewed in the United States on July 1, 2016",
+        "extracted_date": "2016-07-01",
+        "profile": {
+          "id": "AFZ6NC6RPRA4HR7TTZD7FGHYFI2A",
+          "name": "Mark Bretschneider",
+          "link": "https://www.amazon.com/gp/profile/amzn1.account.AFZ6NC6RPRA4HR7TTZD7FGHYFI2A"
+        },
+        "helpful_votes": 2354,
+        "is_verified_purchase": true
+      }
+    ],
+    "global": [
+      {
+        "id": "R165QJNZ0K334X",
+        "title": "Perfect for our puppy!",
+        "text": "The crate is just as described, well made, easy to assemble, no sharp edges",
+        "rating": 5,
+        "date": "Reviewed in Australia on March 13, 2023",
+        "extracted_date": "2023-03-13",
+        "profile": {
+          "name": "Cassie D"
+        },
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R1I91JMVX1BM6C",
+        "title": "Cage",
+        "text": "Pas facile à déplier et replier",
+        "rating": 2,
+        "date": "Reviewed in Belgium on April 26, 2025",
+        "extracted_date": "2025-04-26",
+        "profile": {
+          "name": "Degive Marie Jeanne"
+        },
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R23COJUU9N5QJ8",
+        "title": "Cache pour chien",
+        "text": "Une cache d appoint pour un petit chiot. Pas une cache pour mettre un chiot toute une journée dedans.A l air de bonne qualité.",
+        "rating": 4,
+        "date": "Reviewed in Belgium on February 10, 2025",
+        "extracted_date": "2025-02-10",
+        "profile": {
+          "name": "christiane papp"
+        },
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R249GAG50MLSMR",
+        "title": "Calidad americana, jaula Made in USA",
+        "text": "Amo la marca Midwest, nunca decepciona. Para comprar una jaula plegable sin duda siempre buscaré de estas o Savic, tienes que invertir algo de tiempo pues Amazon tiene muchisimas opciones, pero vale la pena buscar una a buen precio. Es dura y fiable. Fijaos bien porque Midwest tiene varios modelos bastante parecidos pero cambia el tipo de cierre de la puerta. En mi caso elejí esta pues tiene el gancho de cierre en forma de L hacia abajo y mis perros los de \"palito recto\" los saben abrir. Estoy contentísima y no se ha oxidado ni descascarillado el metal recubierto de negro. La recomiendo. Repetiré.",
+        "rating": 5,
+        "date": "Reviewed in Spain on September 5, 2025",
+        "extracted_date": "2025-09-05",
+        "profile": {
+          "name": "GríM"
+        },
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R35SER20AWNGRP",
+        "title": "Excellent- our dog loves it",
+        "text": "It’s the perfect size for my corgi to stretch out in - good quality and my doggo loves to sleep in it",
+        "rating": 5,
+        "date": "Reviewed in Singapore on July 1, 2023",
+        "extracted_date": "2023-07-01",
+        "profile": {
+          "name": "Satshya T."
+        },
+        "is_verified_purchase": true
+      }
+    ]
+  }
+}

--- a/src/data/amazon-products/B0002TKBU8.json
+++ b/src/data/amazon-products/B0002TKBU8.json
@@ -1,0 +1,514 @@
+{
+  "search_metadata": {
+    "id": "search_d97LXP4moruMYVrBPk03EOrl",
+    "status": "Success",
+    "created_at": "2026-04-10T07:34:11Z",
+    "request_time_taken": 2.26,
+    "parsing_time_taken": 0.12,
+    "total_time_taken": 2.38,
+    "request_url": "https://www.amazon.com/dp/B0002TKBU8?th=1&psc=1",
+    "html_url": "https://www.searchapi.io/api/v1/searches/search_d97LXP4moruMYVrBPk03EOrl.html",
+    "json_url": "https://www.searchapi.io/api/v1/searches/search_d97LXP4moruMYVrBPk03EOrl"
+  },
+  "search_parameters": {
+    "engine": "amazon_product",
+    "asin": "B0002TKBU8",
+    "amazon_domain": "amazon.com",
+    "delivery_country": "us"
+  },
+  "product": {
+    "asin": "B0002TKBU8",
+    "title": "MidWest Homes for Pets 22-Inch LifeStages Crate for Extra-Small Breeds, Up to 15 lbs, Double Door Folding Dog Crate with Divider Panel, Leak-Proof Tray & Secure Latch, Heavy-Duty & Easy to Assemble",
+    "brand_store": {
+      "id": "2A08F8F5-A392-471A-9EE7-EC1B59540DA6",
+      "text": "Visit the MidWest Homes for Pets Store",
+      "link": "https://www.amazon.com/stores/MidWestHomesForPets/page/2A08F8F5-A392-471A-9EE7-EC1B59540DA6?lp_asin=B0002TKBU8&ref_=ast_bln&store_ref=bl_ast_dp_brandlogo_sto&bl_grd_status=override"
+    },
+    "marketplace_id": "ATVPDKIKX0DER",
+    "link": "https://www.amazon.com/s?k=xs+dog+crate",
+    "rating": 4.7,
+    "reviews": 17857,
+    "description": "Give your dog a safe, comfortable place to call their own with the MidWest Homes for Pets LifeStages Two Door Dog Crate. Newly enhanced with added security features, this durable metal wire dog crate now includes a patented Paw Block and locking tips on the slide-bolt latch – so you can feel confident your pet is secure whether they're relaxing at home or hitting the road with you. Reinforced with heavy-duty wire gauge, this crate is ideal for dogs with higher separation anxiety who may need a more durable home. Designed with both pets and parents in mind, LifeStages dog crates come complete with a divider panel (to grow with your puppy), a durable leak-proof pan for easy cleanup, rubber feet to protect your floors, and a carrying handle for added convenience. Plus, you can fold it flat in seconds without tools, making it perfect for travel, storage or quick set-up anywhere you need it – from your living room to a beachside vacation rental. Built from precision-welded metal wire with a black e-coat finish, the LifeStages is durable enough for everyday use while resisting rust and wear over time. Larger openings and low thresholds make it easier for your dog to enter and exit the crate, easing the crate training process and helping them feel more at home. At MidWest Homes for Pets, we know your dog is family. That's why every crate is backed by a 1-Year Manufacturer's Warranty and supported by our Indiana-based customer care team, making the LifeStages a trusted choice for creating a secure, comfortable home for your dog.",
+    "attributes": [
+      {
+        "name": "Brand",
+        "value": "MidWest Homes for Pets"
+      },
+      {
+        "name": "Product Dimensions",
+        "value": "23\"L x 14\"W x 16\"H"
+      },
+      {
+        "name": "Gap Size",
+        "value": "37.5 Millimeters"
+      },
+      {
+        "name": "Material",
+        "value": "Metal"
+      },
+      {
+        "name": "Specific Uses For Product",
+        "value": "Indoor"
+      }
+    ],
+    "feature_bullets": [
+      "IDEAL FOR UP TO 15 LB DOGS: Measures 22.5 x 14 x 16 inches – perfect for Pomeranians, Papillons, Toy Fox Terriers & similar breeds. For dogs near 15 lbs, consider sizing up to our 24-inch model so they have plenty of room to get comfortable.",
+      "WE DON'T CUT CORNERS, WE PERFECT THEM: Precision welding, rounded corner clips & slide-bolt latches with Paw Block mitigate cuts & escapes. With rigorous safety testing, LifeStages provides peace of mind knowing your dog is safe while you're away.",
+      "HEAVY-DUTY CONSTRUCTION: Reinforced with heavier gauge wire than standard crates, LifeStages is built for durability. Complete with leak-proof tray, rubber feet, carry handle, and tool-free assembly, it's ready for years of use.",
+      "SUPPORTS CRATE TRAINING: Included divider panel lets the crate grow with your dog, from puppy kennel to full-size crate. Large openings and low thresholds ease the crate training process and help your dog feel more at home.",
+      "BECAUSE LIFE GOES BETTER WITH PETS: A family-owned business based in Indiana, MidWest Homes for Pets brings over 100 years of pet product expertise and a commitment to quality, rigorous safety testing, and excellent US-based customer service."
+    ],
+    "variants": [
+      {
+        "asin": "B0002AT3ME",
+        "title": "Black 42.0\"L x 28.0\"W x 30.0\"H",
+        "link": "https://www.amazon.com/dp/B0002AT3ME?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Color",
+            "value": "Black"
+          },
+          {
+            "name": "Size",
+            "value": "42.0\"L x 28.0\"W x 30.0\"H"
+          }
+        ]
+      },
+      {
+        "asin": "B0002TKBU8",
+        "title": "Black 23.0\"L x 14.0\"W x 16.0\"H",
+        "link": "https://www.amazon.com/dp/B0002TKBU8?th=1&pcs=1",
+        "is_current_product": true,
+        "dimensions": [
+          {
+            "name": "Color",
+            "value": "Black"
+          },
+          {
+            "name": "Size",
+            "value": "23.0\"L x 14.0\"W x 16.0\"H"
+          }
+        ]
+      },
+      {
+        "asin": "B000HCLDFC",
+        "title": "Black 24.0\"L x 18.0\"W x 19.0\"H",
+        "link": "https://www.amazon.com/dp/B000HCLDFC?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Color",
+            "value": "Black"
+          },
+          {
+            "name": "Size",
+            "value": "24.0\"L x 18.0\"W x 19.0\"H"
+          }
+        ]
+      },
+      {
+        "asin": "B0002AT3M4",
+        "title": "Black 36.0\"L x 23.0\"W x 25.0\"H",
+        "link": "https://www.amazon.com/dp/B0002AT3M4?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Color",
+            "value": "Black"
+          },
+          {
+            "name": "Size",
+            "value": "36.0\"L x 23.0\"W x 25.0\"H"
+          }
+        ]
+      },
+      {
+        "asin": "B0002TKBUS",
+        "title": "Black 30.6\"L x 19.3\"W x 21.4\"H",
+        "link": "https://www.amazon.com/dp/B0002TKBUS?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Color",
+            "value": "Black"
+          },
+          {
+            "name": "Size",
+            "value": "30.6\"L x 19.3\"W x 21.4\"H"
+          }
+        ]
+      },
+      {
+        "asin": "B0002AT3MO",
+        "title": "Black 48.0\"L x 30.0\"W x 33.0\"H",
+        "link": "https://www.amazon.com/dp/B0002AT3MO?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Color",
+            "value": "Black"
+          },
+          {
+            "name": "Size",
+            "value": "48.0\"L x 30.0\"W x 33.0\"H"
+          }
+        ]
+      }
+    ],
+    "search_alias": {
+      "title": "Pet Supplies",
+      "value": "pets"
+    },
+    "buybox": {
+      "price": {
+        "raw": "$44.99",
+        "value": 44.99,
+        "symbol": "$",
+        "currency": "USD"
+      },
+      "original_price": {
+        "raw": "$44.99",
+        "value": 44.99,
+        "symbol": "$",
+        "currency": "USD"
+      },
+      "save": {
+        "percentage": 45
+      },
+      "secondary_buybox": {
+        "title": "Used - Very Good",
+        "price": {
+          "raw": "$24.77",
+          "value": 24.77,
+          "symbol": "$",
+          "currency": "USD"
+        }
+      },
+      "maximum_order_quantity": 30,
+      "offer_listing_id": "rJdYHg17H2cUXZbYSRIStUxcheUH8peOU%2B15Fm5oGVquyp89iHqRjLCY1gcGZoAGfnpsd7KMdZFVWyTCcBd7zKqsiQ0nxkDnXRerAhPFaEruRXVNMUSO8Np3SjyhcZT0NZUJGd90gps%3D",
+      "mixed_offers_from": {
+        "price": {
+          "raw": "$24.77",
+          "value": 24.77,
+          "symbol": "$",
+          "currency": "USD"
+        },
+        "link": "https://www.amazon.com/gp/offer-listing/B0002TKBU8/ref=dp_olp_ALL_mbc?ie=UTF8&condition=ALL"
+      },
+      "fulfillment": {
+        "standard_delivery": {
+          "text": "FREE delivery Wednesday, April 15",
+          "type": "FREE",
+          "date": "Wednesday, April 15"
+        },
+        "fastest_delivery": {
+          "text": "Or Prime members get FREE delivery Tomorrow, April 11. Order within 11 hrs 5 mins. Join Prime",
+          "type": "FREE",
+          "date": "Tomorrow, April 11"
+        },
+        "ships_from": "Amazon Resale",
+        "sold_by": "Amazon.com",
+        "is_sold_by_amazon": true
+      },
+      "availability": "In Stock"
+    },
+    "specifications": [
+      {
+        "name": "Brand Name",
+        "value": "MidWest Homes for Pets"
+      },
+      {
+        "name": "Specific Uses For Product",
+        "value": "Indoor"
+      },
+      {
+        "name": "Included Components",
+        "value": "Divider, Removable Tray"
+      },
+      {
+        "name": "Breed Recommendation",
+        "value": "XS"
+      },
+      {
+        "name": "Dog Breed Size",
+        "value": "Extra Small"
+      },
+      {
+        "name": "Manufacturer",
+        "value": "MidWest Homes For Pets"
+      },
+      {
+        "name": "UPC",
+        "value": "027773005766"
+      },
+      {
+        "name": "Global Trade Identification Number",
+        "value": "00027773005766"
+      },
+      {
+        "name": "Item Type Name",
+        "value": "Dog Crate"
+      },
+      {
+        "name": "Unit Count",
+        "value": "1 Count"
+      },
+      {
+        "name": "Warranty Description",
+        "value": "1-Year Manufacturers Warranty"
+      },
+      {
+        "name": "ASIN",
+        "value": "B0002TKBU8"
+      },
+      {
+        "name": "Gap Size",
+        "value": "37.5 Millimeters"
+      },
+      {
+        "name": "Additional Features",
+        "value": "Adjustable, Foldable, Lockable, Secure, Ventilated"
+      },
+      {
+        "name": "Number of Levels",
+        "value": "1"
+      },
+      {
+        "name": "Number of Doors",
+        "value": "2"
+      },
+      {
+        "name": "Material Type",
+        "value": "Metal"
+      },
+      {
+        "name": "Color",
+        "value": "Black"
+      },
+      {
+        "name": "Item Dimensions L x W x H",
+        "value": "23\"L x 14\"W x 16\"H"
+      },
+      {
+        "name": "Item Weight",
+        "value": "8.6 Pounds"
+      },
+      {
+        "name": "Is Discontinued By Manufacturer",
+        "value": "No"
+      },
+      {
+        "name": "Product Dimensions",
+        "value": "22 x 13 x 16 inches; 8.6 Pounds"
+      },
+      {
+        "name": "Manufacturer recommended age",
+        "value": "1 month and up"
+      },
+      {
+        "name": "Item model number",
+        "value": "1622DD"
+      },
+      {
+        "name": "Department",
+        "value": "Racks/Futons"
+      },
+      {
+        "name": "Date First Available",
+        "value": "July 1, 2004"
+      },
+      {
+        "name": "Manufacturer",
+        "value": "MidWest Homes For Pets"
+      },
+      {
+        "name": "ASIN",
+        "value": "B0002TKBU8"
+      }
+    ],
+    "bestsellers_rank": [
+      {
+        "name": "See Top 100 in Pet Supplies",
+        "link": "https://www.amazon.com/gp/bestsellers/pet-supplies/ref=pd_zg_ts_pet-supplies"
+      },
+      {
+        "name": "Basic Dog Crates",
+        "link": "https://www.amazon.com/gp/bestsellers/pet-supplies/3024223011/ref=pd_zg_hrsr_pet-supplies"
+      },
+      {
+        "name": "See Top 100 in Pet Supplies",
+        "link": "https://www.amazon.com/gp/bestsellers/pet-supplies/ref=pd_zg_ts_pet-supplies",
+        "rank": 10286
+      },
+      {
+        "name": "Basic Dog Crates",
+        "link": "https://www.amazon.com/gp/bestsellers/pet-supplies/3024223011/ref=pd_zg_hrsr_pet-supplies",
+        "rank": 27
+      }
+    ],
+    "main_image": "https://m.media-amazon.com/images/I/91Xxqc6WtBL.jpg",
+    "images": [
+      {
+        "link": "https://m.media-amazon.com/images/I/91Xxqc6WtBL.jpg",
+        "variant": "MAIN"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/91tdgpB73DL.jpg",
+        "variant": "PT01"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/A1+2N4SvR2L.jpg",
+        "variant": "PT02"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/91hEHU84flL.jpg",
+        "variant": "PT03"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/91U0d-JlbTL.jpg",
+        "variant": "PT04"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/9183BZhkLXL.jpg",
+        "variant": "PT05"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/A1bgAnKLYDL.jpg",
+        "variant": "PT06"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/81WfLfBQ6nL.jpg",
+        "variant": "PT07"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/91ciMHfhrXL.jpg",
+        "variant": "PT12"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/41rSAcQ5WjL.jpg",
+        "variant": "PT15"
+      }
+    ]
+  },
+  "similar_item": {
+    "asin": "B09G48J91Y",
+    "title": "Amazon Basics Portable, Foldable Metal Wire Dog Crate with Removable Tray, Double Door, Divider Panel, Easy to Assemble, 22 x 13 x 16 in, Black",
+    "link": "https://www.amazon.com/dp/B09G48J91Y/ref=vp_d_pbs_cmt_lp_B0002TKBU8_pd?_encoding=UTF8&pf_rd_p=f6007f53-9fa1-4c0d-b499-54e844408da9&pf_rd_r=JEAE44K2BMTFDYN2GK4P&pd_rd_wg=53o9S&pd_rd_i=B09G48J91Y&pd_rd_w=ArGt4&content-id=amzn1.sym.f6007f53-9fa1-4c0d-b499-54e844408da9&pd_rd_r=cd3c3cec-2b72-46b4-988c-e29b0351f2f8&psc=1",
+    "rating": 4.5,
+    "reviews": 11100,
+    "price": {
+      "raw": "$36.95",
+      "value": 36.95,
+      "symbol": "$",
+      "currency": "USD"
+    },
+    "image": "https://m.media-amazon.com/images/I/81gt2S6ovCL.jpg"
+  },
+  "frequently_bought_together": {
+    "total_price": {
+      "raw": "$94.98",
+      "value": 94.98,
+      "symbol": "$",
+      "currency": "USD"
+    }
+  },
+  "review_results": {
+    "local": [
+      {
+        "id": "R3PDXYZE88XA0K",
+        "asin": "R3PDXYZE88XA0K",
+        "title": "Perfect for litter box training",
+        "link": "https://www.amazon.com/gp/customer-reviews/R3PDXYZE88XA0K/ref=cm_cr_dp_d_rvw_ttl?ie=UTF8",
+        "text": "Reviews help me when I am trying to choose a product to buy, so I want to in turn leave a review for others who are in the market for a crate. This is my first crate experience. A few weeks ago I came across a 4 week old kitten that was abandoned in the middle of a busy road. Without any time to prepare I took the kitten in and soon found out that kittens aren't born knowing what a litter box is. Duh moment here, yeah I know. The kitten started doing her bathroom business all over the house, so I confined her to one room until I could ask rescues and vet techs what to do.Every answer given to me was to crate the kitten with a litter box so she will have no other place to go than in the box. That is where my search for a crate started. A crate needed to be large enough for a litter box, food/water bowls and a bed, plus room to move around- and I also consider future use as well once the kitten is an adult cat. I wanted a crate large enough to hold not only a tiny kitten but also a full grown adult cat, comfortably. The Medium size is what I ordered. What I should have ordered is a large though, because I've recently learned of people crating cats to transport them on long distance road trips- I have 3 adult cats, you never know when a crate will come in handy for them. But this is my first crate experience and for the purpose I needed it for a medium works well. The bars are not spaced so far apart that a kitten would get her head stuck trying to get out. An added bonus is the front and side doors that both open with a large enough space to move around a litter box or clean inside the crate very easily.Set up was very easy, no tools required and it feels sturdy enough that it would hold against a medium size dog, but since I have cats I can't say how strong the crate would be against a dog- I can say that my kitten hasn't managed to jail break though. There is a heft to the crate, it is not light weight and does move easy with 2 handles that are included. I've attached a picture so others can see how much space is inside this crate with a small litter box, a food/water container snapped onto the bars and a medium size dog bed on top. I used the divider to create a 2nd floor to the crate so my kitten won't be sleeping right next to her litter box. So far my kitten is very comfortable spending nights in her crate. I'd recommend this crate to others who have either a small breed or medium size dog and of course those who are litter box training or need to crate a cat/kitten for any reason. Quality is great here and I am very happy with my purchase. In the future I want to get the large crate just in case there's ever a reason to crate my adult cats for either a move or medical. This crate also folds down easy, slips back into the box without hassle and stores away for when not in use.",
+        "rating": 5,
+        "date": "Reviewed in the United States on May 24, 2016",
+        "extracted_date": "2016-05-24",
+        "profile": {
+          "id": "AEMKCMIKAEANIPVGMCKLQ47WKVHQ",
+          "name": "Cat Lady",
+          "link": "https://www.amazon.com/gp/profile/amzn1.account.AEMKCMIKAEANIPVGMCKLQ47WKVHQ"
+        },
+        "helpful_votes": 14,
+        "images": [
+          "https://m.media-amazon.com/images/I/71rAi74EPZL.jpg"
+        ],
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R38NBBYUJZOPH7",
+        "asin": "R38NBBYUJZOPH7",
+        "title": "I love this crate and so does my dog",
+        "link": "https://www.amazon.com/gp/customer-reviews/R38NBBYUJZOPH7/ref=cm_cr_dp_d_rvw_ttl?ie=UTF8",
+        "text": "I purchased many many crates for my dogs in the past 45 years, I bought the cheapest and I bought the most expensive. You used to have to get them at the pet store and pay anywhere from $90-$200 for standard great. Thank goodness for Amazon. I just added to my \"stable\" of dogs with an eight-week-old golden retriever named Bentley. Now he's just a little guy weighing in at 12 pounds but he will get bigger. Right now he fits in a small crate and I mean fits. He can get in it but he can't lay down or turn around. I needed to get him a crate he can grow into so I went online to Amazon and looked around. I saw my old friends Midwest who stood by me with durable crates during my dog show days. They always made a sturdy crate out of heavy-duty material that was well engineered and well put together. It's been a few years since I bought a crate and a few things have changed. Pretty much now everybody offers a folding crate that wasn't so back in the day Midwest was one of the first to offer that feature and they did it well and they still do. They have a variety of sizes more so than most manufacturers so I chose the middle middle size which is a little bigger than other manufacturers middle size. Some of the features I like was this one has double doors, one on the side and one on the end. Each closes and locks sturdily and securely with two hasps on each door. Nowadays the bottom tray is made of plastic instead of steel so with a little lighter and more resistant to corrosion and easily cleaned. I ordered this crate and it came promptly from Amazon as I am an Amazon prime member. It was packaged well and arrived without damage and I had it set up in less than 5 min.. The only problem was the location where I was going to use it was against a wall and the doors were all wrong. Well I solved that by swapping the ends by bending back four hooks on each end, then squeezing them tight again to finish up, this took all of 3 min. to do in my crate or I should say that Bentleys crate was ready to go. One of the big advantages of having the second door is that when I wanted to introduce Bentley to crate I left both doors open so he could wander in and out at his leisure. I placed a few toys and water bowl in their as well as a wee wee pad and some bedding. He was curious and wandered in and out. I will admit however, the first night he was full of screams and barks and crying for most of the night. It was his first night in a crate. The second night I placed him in the crate and he laid down and was quiet until early morning. When he saw me and heard me moving around a little bit he started vocalizing so I took him out. The Crate also comes with a divider so you can change the size as your dog grows. At this point I'm not even using divider and giving Bentley full run of the crate. I am really glad that Amazon is selling these and the price is phenomenal. If you go to a pet store I'm sure you will easily over $150 for this crate or poorly made imitation. I really recommend Midwest and I think you'll be very happy with the quality and the operation of this crate. if you're a first-time buyer, check the AKC standards for how big your dog will be, then buyer accordingly. Don't buy too small as you will have to buy bigger later on. I give this five stars I love it I know you will too and it's recommended buy If you found my review helpful please click yes on the button below I really appreciate your support for that I intend to leave reviews to help others make decisions prior to purchase taste upon my recommendations or disclosure and I utilize your reviews to help me with my purchases as well. my reviews are honest factual and accurate thank you",
+        "rating": 5,
+        "date": "Reviewed in the United States on July 1, 2016",
+        "extracted_date": "2016-07-01",
+        "profile": {
+          "id": "AFZ6NC6RPRA4HR7TTZD7FGHYFI2A",
+          "name": "Mark Bretschneider",
+          "link": "https://www.amazon.com/gp/profile/amzn1.account.AFZ6NC6RPRA4HR7TTZD7FGHYFI2A"
+        },
+        "helpful_votes": 2354,
+        "is_verified_purchase": true
+      }
+    ],
+    "global": [
+      {
+        "id": "R165QJNZ0K334X",
+        "title": "Perfect for our puppy!",
+        "text": "The crate is just as described, well made, easy to assemble, no sharp edges",
+        "rating": 5,
+        "date": "Reviewed in Australia on March 13, 2023",
+        "extracted_date": "2023-03-13",
+        "profile": {
+          "name": "Cassie D"
+        },
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R1I91JMVX1BM6C",
+        "title": "Cage",
+        "text": "Pas facile à déplier et replier",
+        "rating": 2,
+        "date": "Reviewed in Belgium on April 26, 2025",
+        "extracted_date": "2025-04-26",
+        "profile": {
+          "name": "Degive Marie Jeanne"
+        },
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R23COJUU9N5QJ8",
+        "title": "Cache pour chien",
+        "text": "Une cache d appoint pour un petit chiot. Pas une cache pour mettre un chiot toute une journée dedans.A l air de bonne qualité.",
+        "rating": 4,
+        "date": "Reviewed in Belgium on February 10, 2025",
+        "extracted_date": "2025-02-10",
+        "profile": {
+          "name": "christiane papp"
+        },
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R249GAG50MLSMR",
+        "title": "Calidad americana, jaula Made in USA",
+        "text": "Amo la marca Midwest, nunca decepciona. Para comprar una jaula plegable sin duda siempre buscaré de estas o Savic, tienes que invertir algo de tiempo pues Amazon tiene muchisimas opciones, pero vale la pena buscar una a buen precio. Es dura y fiable. Fijaos bien porque Midwest tiene varios modelos bastante parecidos pero cambia el tipo de cierre de la puerta. En mi caso elejí esta pues tiene el gancho de cierre en forma de L hacia abajo y mis perros los de \"palito recto\" los saben abrir. Estoy contentísima y no se ha oxidado ni descascarillado el metal recubierto de negro. La recomiendo. Repetiré.",
+        "rating": 5,
+        "date": "Reviewed in Spain on September 5, 2025",
+        "extracted_date": "2025-09-05",
+        "profile": {
+          "name": "GríM"
+        },
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R35SER20AWNGRP",
+        "title": "Excellent- our dog loves it",
+        "text": "It’s the perfect size for my corgi to stretch out in - good quality and my doggo loves to sleep in it",
+        "rating": 5,
+        "date": "Reviewed in Singapore on July 1, 2023",
+        "extracted_date": "2023-07-01",
+        "profile": {
+          "name": "Satshya T."
+        },
+        "is_verified_purchase": true
+      }
+    ]
+  }
+}

--- a/src/data/amazon-products/B000QFT1RC.json
+++ b/src/data/amazon-products/B000QFT1RC.json
@@ -1,0 +1,597 @@
+{
+  "search_metadata": {
+    "id": "search_mR5DzpePyDIPrLDBA4YdGQno",
+    "status": "Success",
+    "created_at": "2026-04-10T02:38:46Z",
+    "request_time_taken": 2.58,
+    "parsing_time_taken": 0.17,
+    "total_time_taken": 2.75,
+    "request_url": "https://www.amazon.com/dp/B000QFT1RC?th=1&psc=1",
+    "html_url": "https://www.searchapi.io/api/v1/searches/search_mR5DzpePyDIPrLDBA4YdGQno.html",
+    "json_url": "https://www.searchapi.io/api/v1/searches/search_mR5DzpePyDIPrLDBA4YdGQno"
+  },
+  "search_parameters": {
+    "engine": "amazon_product",
+    "asin": "B000QFT1RC",
+    "amazon_domain": "amazon.com",
+    "delivery_country": "us"
+  },
+  "product": {
+    "asin": "B000QFT1RC",
+    "title": "MidWest Homes for Pets 42-Inch iCrate for Large Breeds, 71-90 lbs, Double Door Folding Dog Crate with Divider Panel, Leak-Proof Tray & Secure Latches, Portable, Durable & Easy to Assemble",
+    "brand_store": {
+      "id": "2A08F8F5-A392-471A-9EE7-EC1B59540DA6",
+      "text": "Visit the MidWest Homes for Pets Store",
+      "link": "https://www.amazon.com/stores/MidWestHomesForPets/page/2A08F8F5-A392-471A-9EE7-EC1B59540DA6?lp_asin=B000QFT1RC&ref_=ast_bln&store_ref=bl_ast_dp_brandlogo_sto&bl_grd_status=override"
+    },
+    "marketplace_id": "ATVPDKIKX0DER",
+    "link": "https://www.amazon.com/s?k=dog+crate&rh=p_85%3A2470955011",
+    "rating": 4.7,
+    "reviews": 80131,
+    "bought_past_month": "2K+ bought in past month",
+    "description": "Give your dog a safe, comfortable place to call their own with the MidWest Homes for Pets iCrate Two Door Dog Crate. Newly enhanced with added security features, this metal wire dog crate now includes a patented Paw Block and locking tips on the slide-bolt latch - so you can feel confident your pet is secure whether they're relaxing at home or hitting the road with you. Front and side doors give you flexible placement options. Tuck it against a wall, in a corner, or anywhere that works for your space. Designed with both pets and parents in mind, iCrate dog crates come complete with a divider panel (to grow with your puppy), a durable leak-proof pan for easy cleanup, rubber feet to protect your floors, and a carrying handle for added convenience. Plus, you can fold it flat in seconds without tools, making it perfect for travel, storage or quick set-up anywhere you need it - from your living room to a beachside vacation rental. Built from precision-welded metal wire with a black e-coat finish, the iCrate is durable enough for everyday use while resisting rust and wear over time. Larger openings and low thresholds make it easier for your dog to enter and exit the crate, easing the crate training process and helping them feel more at home. At MidWest Homes for Pets, we know your dog is family. That's why every crate is backed by a 1-Year Manufacturer's Warranty and supported by our Indiana-based customer care team, making the iCrate a trusted choice for creating a secure, comfortable home for your dog.",
+    "attributes": [
+      {
+        "name": "Brand",
+        "value": "MidWest Homes for Pets"
+      },
+      {
+        "name": "Product Dimensions",
+        "value": "42\"L x 28\"W x 30\"H"
+      },
+      {
+        "name": "Gap Size",
+        "value": "37.5 Millimeters"
+      },
+      {
+        "name": "Material",
+        "value": "Metal"
+      },
+      {
+        "name": "Specific Uses For Product",
+        "value": "Indoor"
+      }
+    ],
+    "feature_bullets": [
+      "IDEAL FOR 71-90 LB DOGS: Measures 42.88 x 28.75 x 30.38 inches - perfect for Australian Shepherds, Boxers, Golden Retrievers & similar breeds. For dogs near 90 lbs, consider sizing up to our 48-inch model so they have plenty of room to get comfortable.",
+      "WE DON'T CUT CORNERS, WE PERFECT THEM: Precision welding, rounded corner clips & slide-bolt latches with Paw Block mitigate snags, cuts & escapes. With rigorous safety testing, iCrate provides peace of mind knowing your dog is safe while you're away.",
+      "DURABLE CONSTRUCTION: Sturdy metal wire design with a protective black e-coat finish, the iCrate resists rust and everyday wear. Complete with leak-proof tray, rubber feet, carry handle, and tool-free assembly, it's ready for years of use.",
+      "SUPPORTS CRATE TRAINING: A divider panel lets the crate grow with your dog, from puppy kennel to full-size crate. Large openings and low thresholds ease the crate training process and help your dog feel more at home.",
+      "BECAUSE LIFE GOES BETTER WITH PETS: A family-owned business based in Indiana, MidWest Homes for Pets brings over 100 years of pet product expertise and a commitment to quality, rigorous safety testing, and excellent US-based customer service."
+    ],
+    "variants": [
+      {
+        "asin": "B000QFT1RC",
+        "title": "42.0\"L x 28.0\"W x 30.0\"H Black",
+        "link": "https://www.amazon.com/dp/B000QFT1RC?th=1&pcs=1",
+        "is_current_product": true,
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "42.0\"L x 28.0\"W x 30.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Black"
+          }
+        ]
+      },
+      {
+        "asin": "B000QFT1R2",
+        "title": "36.0\"L x 23.0\"W x 25.0\"H Black",
+        "link": "https://www.amazon.com/dp/B000QFT1R2?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "36.0\"L x 23.0\"W x 25.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Black"
+          }
+        ]
+      },
+      {
+        "asin": "B000QFWCK0",
+        "title": "30.7\"L x 19.3\"W x 21.5\"H Black",
+        "link": "https://www.amazon.com/dp/B000QFWCK0?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "30.7\"L x 19.3\"W x 21.5\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Black"
+          }
+        ]
+      },
+      {
+        "asin": "B000QFWCJ6",
+        "title": "24.8\"L x 17.9\"W x 19.5\"H Black",
+        "link": "https://www.amazon.com/dp/B000QFWCJ6?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "24.8\"L x 17.9\"W x 19.5\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Black"
+          }
+        ]
+      },
+      {
+        "asin": "B005VVWBVY",
+        "title": "54.0\"L x 37.0\"W x 45.0\"H Black",
+        "link": "https://www.amazon.com/dp/B005VVWBVY?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "54.0\"L x 37.0\"W x 45.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Black"
+          }
+        ]
+      },
+      {
+        "asin": "B000QFUNWY",
+        "title": "23.0\"L x 14.0\"W x 16.2\"H Black",
+        "link": "https://www.amazon.com/dp/B000QFUNWY?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "23.0\"L x 14.0\"W x 16.2\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Black"
+          }
+        ]
+      },
+      {
+        "asin": "B000TZ59ES",
+        "title": "18.0\"L x 12.0\"W x 14.0\"H Black",
+        "link": "https://www.amazon.com/dp/B000TZ59ES?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "18.0\"L x 12.0\"W x 14.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Black"
+          }
+        ]
+      },
+      {
+        "asin": "B000QFWCLY",
+        "title": "48.0\"L x 30.0\"W x 33.0\"H Black",
+        "link": "https://www.amazon.com/dp/B000QFWCLY?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "48.0\"L x 30.0\"W x 33.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Black"
+          }
+        ]
+      }
+    ],
+    "search_alias": {
+      "title": "Pet Supplies",
+      "value": "pets"
+    },
+    "buybox": {
+      "price": {
+        "raw": "$84.99",
+        "value": 84.99,
+        "symbol": "$",
+        "currency": "USD"
+      },
+      "original_price": {
+        "raw": "$84.99",
+        "value": 84.99,
+        "symbol": "$",
+        "currency": "USD"
+      },
+      "save": {
+        "percentage": 18
+      },
+      "secondary_buybox": {
+        "title": "Used - Like New",
+        "price": {
+          "raw": "$69.79",
+          "value": 69.79,
+          "symbol": "$",
+          "currency": "USD"
+        }
+      },
+      "maximum_order_quantity": 30,
+      "offer_listing_id": "Qe%2BFDzHu8ZMntGzmaepFUD9O1onh%2F4goqUpEkpHrySjIr5ZAYGAO44yp%2BdJ87ZmCX7RpLLmro4%2Fejw%2FS7Nxa8AQfGvbAbfrqGtggi4A0HIL2DL7HfZANeVc3tQrKPogWeLJCyi4XJLo%3D",
+      "mixed_offers_from": {
+        "price": {
+          "raw": "$62.12",
+          "value": 62.12,
+          "symbol": "$",
+          "currency": "USD"
+        },
+        "link": "https://www.amazon.com/gp/offer-listing/B000QFT1RC/ref=dp_olp_ALL_mbc?ie=UTF8&condition=ALL"
+      },
+      "fulfillment": {
+        "standard_delivery": {
+          "text": "FREE delivery Tuesday, April 14",
+          "type": "FREE",
+          "date": "Tuesday, April 14"
+        },
+        "fastest_delivery": {
+          "text": "Or Prime members get FREE delivery Saturday, April 11. Order within 1 hr 21 mins. Join Prime",
+          "type": "FREE",
+          "date": "Saturday, April 11"
+        },
+        "ships_from": "Amazon Resale",
+        "sold_by": "Amazon.com",
+        "is_sold_by_amazon": true
+      },
+      "availability": "In Stock"
+    },
+    "specifications": [
+      {
+        "name": "Brand Name",
+        "value": "MidWest Homes for Pets"
+      },
+      {
+        "name": "Target Species",
+        "value": "Dogs"
+      },
+      {
+        "name": "Specific Uses For Product",
+        "value": "Indoor"
+      },
+      {
+        "name": "Included Components",
+        "value": "Divider, Removable Tray"
+      },
+      {
+        "name": "Breed Recommendation",
+        "value": "Large"
+      },
+      {
+        "name": "Dog Breed Size",
+        "value": "Large"
+      },
+      {
+        "name": "Manufacturer",
+        "value": "MidWest Homes For Pets"
+      },
+      {
+        "name": "UPC",
+        "value": "027773018841"
+      },
+      {
+        "name": "Global Trade Identification Number",
+        "value": "00027773018841"
+      },
+      {
+        "name": "Item Type Name",
+        "value": "Double - iCrate"
+      },
+      {
+        "name": "Unit Count",
+        "value": "1 Count"
+      },
+      {
+        "name": "Warranty Description",
+        "value": "1 Year Manufacture"
+      },
+      {
+        "name": "ASIN",
+        "value": "B000QFT1RC"
+      },
+      {
+        "name": "Gap Size",
+        "value": "37.5 Millimeters"
+      },
+      {
+        "name": "Additional Features",
+        "value": "Adjustable, Foldable, Lockable, Secure"
+      },
+      {
+        "name": "Number of Levels",
+        "value": "1"
+      },
+      {
+        "name": "Number of Doors",
+        "value": "2"
+      },
+      {
+        "name": "Material Type",
+        "value": "Metal"
+      },
+      {
+        "name": "Color",
+        "value": "Black"
+      },
+      {
+        "name": "Item Dimensions L x W x H",
+        "value": "42\"L x 28\"W x 30\"H"
+      },
+      {
+        "name": "Item Weight",
+        "value": "37 Pounds"
+      },
+      {
+        "name": "Is Discontinued By Manufacturer",
+        "value": "No"
+      },
+      {
+        "name": "Product Dimensions",
+        "value": "42 x 28 x 30 inches; 37 Pounds"
+      },
+      {
+        "name": "Manufacturer recommended age",
+        "value": "1 month and up"
+      },
+      {
+        "name": "Item model number",
+        "value": "1542DDU"
+      },
+      {
+        "name": "Department",
+        "value": "Racks/Futons"
+      },
+      {
+        "name": "Date First Available",
+        "value": "May 10, 2007"
+      },
+      {
+        "name": "Manufacturer",
+        "value": "MidWest Homes For Pets"
+      },
+      {
+        "name": "ASIN",
+        "value": "B000QFT1RC"
+      }
+    ],
+    "bestsellers_rank": [
+      {
+        "name": "See Top 100 in Pet Supplies",
+        "link": "https://www.amazon.com/gp/bestsellers/pet-supplies/ref=pd_zg_ts_pet-supplies"
+      },
+      {
+        "name": "Basic Dog Crates",
+        "link": "https://www.amazon.com/gp/bestsellers/pet-supplies/3024223011/ref=pd_zg_hrsr_pet-supplies"
+      },
+      {
+        "name": "See Top 100 in Pet Supplies",
+        "link": "https://www.amazon.com/gp/bestsellers/pet-supplies/ref=pd_zg_ts_pet-supplies",
+        "rank": 1097
+      },
+      {
+        "name": "Basic Dog Crates",
+        "link": "https://www.amazon.com/gp/bestsellers/pet-supplies/3024223011/ref=pd_zg_hrsr_pet-supplies",
+        "rank": 4
+      }
+    ],
+    "main_image": "https://m.media-amazon.com/images/I/916OE0sVPqL.jpg",
+    "images": [
+      {
+        "link": "https://m.media-amazon.com/images/I/916OE0sVPqL.jpg",
+        "variant": "MAIN"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/91vez1UCUqL.jpg",
+        "variant": "PT01"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/91hyxpcTZvL.jpg",
+        "variant": "PT02"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/A1PAOgU+ReL.jpg",
+        "variant": "PT03"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/A1yyUdcNgCL.jpg",
+        "variant": "PT04"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/719KsuqDa7L.jpg",
+        "variant": "PT05"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/81ZuFOnPndL.jpg",
+        "variant": "PT06"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/81O+mKKBsfL.jpg",
+        "variant": "PT07"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/91ciMHfhrXL.jpg",
+        "variant": "PT12"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/41XsiBfwfAL.jpg",
+        "variant": "PT15"
+      }
+    ]
+  },
+  "similar_item": {
+    "asin": "B09G4MP29H",
+    "title": "Amazon Basics Portable, Collapsible Metal Wire Dog Crate with Removable Tray, Double Door, Easy to Assemble, Divider Panel for Large Dogs, 42\" x 28\" x 30\", Black",
+    "link": "https://www.amazon.com/dp/B09G4MP29H/ref=vp_d_pb_TIER2_cmt_lp_B000QFT1RC_pd?_encoding=UTF8&pf_rd_p=833279f6-3822-4089-a177-f6c02b33c169&pf_rd_r=N2PZ9T58VNFATNAC8XNS&pd_rd_wg=OtKL1&pd_rd_i=B09G4MP29H&pd_rd_w=HFzKu&content-id=amzn1.sym.833279f6-3822-4089-a177-f6c02b33c169&pd_rd_r=abb0b2c4-73c2-45c2-83d3-5a74d2865265&psc=1",
+    "rating": 4.5,
+    "reviews": 11101,
+    "price": {
+      "raw": "$76.49",
+      "value": 76.49,
+      "symbol": "$",
+      "currency": "USD"
+    },
+    "image": "https://m.media-amazon.com/images/I/81mdnappYBL.jpg"
+  },
+  "frequently_bought_together": {
+    "total_price": {
+      "raw": "$121.97999999999999",
+      "value": 121.98,
+      "symbol": "$",
+      "currency": "USD"
+    }
+  },
+  "review_results": {
+    "local": [
+      {
+        "id": "R28K7RHES0KTRA",
+        "asin": "R28K7RHES0KTRA",
+        "title": "Way Better Than Other Brands!",
+        "link": "https://www.amazon.com/gp/customer-reviews/R28K7RHES0KTRA/ref=cm_cr_dp_d_rvw_ttl?ie=UTF8",
+        "text": "I already had a cage the same size as this one, but it honestly doesn't compare—the iCrate is much better quality.Versatility & Setup:I love that it has multiple doors, which gives you more options for how to set it up and where to place it. It was incredibly easy to put together, and the fact that it’s collapsible makes it perfect for storage or travel.Easy Cleaning:One of my favorite features is the bottom tray. It slides out so easily, making cleaning up any messes a breeze compared to other crates I've used.The Verdict:If you have a small breed, this is the one to get. It’s durable, convenient, and the double-door design is a total game changer!",
+        "rating": 5,
+        "date": "Reviewed in the United States on March 8, 2026",
+        "extracted_date": "2026-03-08",
+        "profile": {
+          "id": "AHN3BI5EE7DHSVHJPWT6J3FGF3RQ",
+          "name": "MAE",
+          "link": "https://www.amazon.com/gp/profile/amzn1.account.AHN3BI5EE7DHSVHJPWT6J3FGF3RQ"
+        },
+        "helpful_votes": 3,
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R3JMQB6ZSXWT75",
+        "asin": "R3JMQB6ZSXWT75",
+        "title": "I Definitely RECOMMEND the iCrate! Roomy, Durable, Easy to unfold/collapse.",
+        "link": "https://www.amazon.com/gp/customer-reviews/R3JMQB6ZSXWT75/ref=cm_cr_dp_d_rvw_ttl?ie=UTF8",
+        "text": "Purchased the 42\" iCrate with divider. PERFECT! Have a 50lb 10mo old Smooth Collie / Cattle Dog (Blue Heeler). He was sleeping in a 36\" crate where his head and rear touched the ends of the crate. The extra 6\" has made a world of difference. Opie can stretch out now... and doesn't come out 'unfolding' and acting like he's been in a vice all night. It's not quite the 'romper room' he has in the 48\" iCrate, but again, this one is for \"Night-Night\"... and gives plenty of room for such. When we first got our puppy, we bought a 36\" Beagle Crate from Walmart for $67. We were using the Beagle as his bed (in the bedroom) and needed a 2nd crate for the Family Room, but wanted a larger crate; one he could play in too. Then we found the iCrate by Midwest. The Beagle was very well made but much more expensive in comparison! After lengthy discussions whether to buy the 42\" or the 48\" we chose the larger 48\"... and use it in the Den. Yes, he had a couple of accidents, but we put the divider in, and the accidents stopped. It's been about 4 months now and we've moved the divider a little at a time and it's finally out! No more accidents! Of course, he's also out of the crate more and has bells at the back door to tell us when he needs to go out. Anyway, we decided to replace the 36\" Night Night crate with a 42\"... and chose to stay with the iCrate because of durability and price. It comes with a divider, which we've not needed, but it's there... and we're thinking about maybe getting another dog (later in 2017). The divider may come in handy then! Double doors. Some have reported that the double doors make the crate weaker. I guess it just depends on the dog and his reaction to being crated. Opie has horrible separation anxiety, but with the help of a loaded Kong, a bone, and a dark room (yup, turn the lights off and say Night Night)... he does quite well. We only use the end door because of the relation to space and placement, but I don't think the double doors decrease the durability or strength at all. FYI --- The doors are large. Not so large to compromise the integrity of the crate, but larger than the doors on other crates I've seen. Nice!!!The latches are really nice. They are straight, which concerned me at first, but after using them I feel confident that they are safe.Also, the plastic pan in the bottom is really nice. It's not flimsy at all. It fits well, removes easily, and cleans up really well with a quick wipe. Collapsibility. Easy enough! It's big, so it's bulky. But it's not hard to collapse or expand.To unfold... Just pull up on a hinge until the box is evident, then pull out one end, then the other, lock it in place, and BAM... you have a crate.To fold... reverse the process. Oh, lock the doors in place first. Then fold in the door and backend walls. The side will fold down practically on it's own.It's like a really big briefcase. Of course, the larger the crate, the heavier, but... it even comes with a couple of 'suitcase' carrying handles. EASY! Breezy! Complaint --- The door actually opens the wrong way into the room I have crate in... and there's no other place to put it. I've turned the care upside down to put the door opening the correct direction for the room. However, the crate was not designed for this. The plastic bottom fits, but the door hangs a little different and is harder to latch. The wiring is tighter on the top than it is on the bottom of the crate, so upside down leaves the (now) top of the crate with large open squares. Some dogs could potentially get caught in their attempt to get out, and strangle themselves or cause damage to their ears. Since my dog is happy in his crate I don't see that as an issue for us... but I still watch for it. I just think it would be safer for the pet, possible make the crate more durable overall, and definitely more versatile for the owners' room arrangement, if the crate was made the same on the top and bottom. Hope my experience helps you in your decision. It's a great crate... Give it try!",
+        "rating": 5,
+        "date": "Reviewed in the United States on March 5, 2017",
+        "extracted_date": "2017-03-05",
+        "profile": {
+          "id": "AGFA45IQAVQOCUTU3XXGCW7ZGWSA",
+          "name": "Yvette",
+          "link": "https://www.amazon.com/gp/profile/amzn1.account.AGFA45IQAVQOCUTU3XXGCW7ZGWSA"
+        },
+        "helpful_votes": 16,
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R25OK6QZT9N6TW",
+        "asin": "R25OK6QZT9N6TW",
+        "title": "Lightweight, very sturdy and quite roomy",
+        "link": "https://www.amazon.com/gp/customer-reviews/R25OK6QZT9N6TW/ref=cm_cr_dp_d_rvw_ttl?ie=UTF8",
+        "text": "This is the perfect size and a great unit for a Pomeranian. Goes well together with a small fence we bought and it’s enough room for her to get up walk around adjust her bed and stretch without being too confined. Very well-made rolls around easily and it’s easy and lightweight enough to move without a problem. This is our second one. We love it just as much as the first.",
+        "rating": 5,
+        "date": "Reviewed in the United States on November 5, 2025",
+        "extracted_date": "2025-11-05",
+        "profile": {
+          "id": "AHLKHSPTESWDTNPX5E7R3UEAS66Q",
+          "name": "RevSpongeBobSP",
+          "link": "https://www.amazon.com/gp/profile/amzn1.account.AHLKHSPTESWDTNPX5E7R3UEAS66Q"
+        },
+        "helpful_votes": 10,
+        "is_verified_purchase": true
+      },
+      {
+        "id": "RB92ZG6Q0EGVD",
+        "asin": "RB92ZG6Q0EGVD",
+        "title": "Great kennel, great price.",
+        "link": "https://www.amazon.com/gp/customer-reviews/RB92ZG6Q0EGVD/ref=cm_cr_dp_d_rvw_ttl?ie=UTF8",
+        "text": "I have purchased three sizes of this kennel. The kennel is easy to set up and taken down. I appreciate the crate having two doors, so you have more options for where you set it up. My only caveat, if you have a dog that struggles with being kenneled and is an escape artist, you may want a more reinforced kennel. For the average person, with a dog that does well in a crate, this is perfect.",
+        "rating": 5,
+        "date": "Reviewed in the United States on December 23, 2025",
+        "extracted_date": "2025-12-23",
+        "profile": {
+          "id": "AEXMIQAOOVSR33NSFQGIMCAXWPMA",
+          "name": "A Krause",
+          "link": "https://www.amazon.com/gp/profile/amzn1.account.AEXMIQAOOVSR33NSFQGIMCAXWPMA"
+        },
+        "helpful_votes": 2,
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R293285JQ2EPZ8",
+        "asin": "R293285JQ2EPZ8",
+        "title": "Great Quality Crate, Just Check Your Measurements!",
+        "link": "https://www.amazon.com/gp/customer-reviews/R293285JQ2EPZ8/ref=cm_cr_dp_d_rvw_ttl?ie=UTF8",
+        "text": "Excellent Construction, But the 48-Inch Was Too Large for My Space.​I purchased this MidWest iCrate based on the brand's reputation for quality, and I was not disappointed with the build.​Quality: The crate is still good quality. The metal wire is thick, the secure latches are reliable, and the folding design, along with the leak-proof tray, confirms its durability and ease of use.​The Issue: Unfortunately, the 48-inch size for XL breeds was too big for the specific area I needed it for in my home. It was an error on my part in measuring my space!​Outcome: I returned it solely due to the size issue and plan to re-order the next size down from the same brand.​If you have a large-to-extra-large dog and the space to accommodate a 48-inch crate, this is a sturdy and well-designed choice. I definitely suggest this brand for quality construction!",
+        "rating": 4,
+        "date": "Reviewed in the United States on November 15, 2025",
+        "extracted_date": "2025-11-15",
+        "profile": {
+          "id": "AF2NM5XXXZUZQXZ5K44BFIIWBUKQ",
+          "name": "Todd",
+          "link": "https://www.amazon.com/gp/profile/amzn1.account.AF2NM5XXXZUZQXZ5K44BFIIWBUKQ"
+        },
+        "helpful_votes": 6,
+        "is_verified_purchase": true
+      }
+    ],
+    "global": [
+      {
+        "id": "R11A9MAVO733ZN",
+        "title": "Great product, bought 2",
+        "text": "This is great, fits in car boot not to bulky. Easy to fold down as well. Folds flat. Room for my x2 small dogs comfortably",
+        "rating": 5,
+        "date": "Reviewed in Ireland on February 6, 2026",
+        "extracted_date": "2026-02-06",
+        "profile": {
+          "name": "Margot & Casper"
+        },
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R1F9FSS1W2EQ35",
+        "title": "Brilliant size.",
+        "text": "Brilliant for transporting small dog in the car.",
+        "rating": 5,
+        "date": "Reviewed in the United Kingdom on June 24, 2025",
+        "extracted_date": "2025-06-24",
+        "profile": {
+          "name": "Teaspoon"
+        },
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R1KCAPEWKSOBL",
+        "title": "Perfetto",
+        "text": "Montaggio facile anche da soli, più difficile separare i singoli pezzi imballati insieme senza forzare le giunzioni, più che altro per le grandi dimensioni dei pannelli.Presa la misura più grande",
+        "rating": 5,
+        "date": "Reviewed in Italy on August 26, 2025",
+        "extracted_date": "2025-08-26",
+        "profile": {
+          "name": "silvia"
+        },
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R1V2DGCXJR450I",
+        "title": "finally big enough",
+        "text": "This kennel might even be too big in my dog's opinion — but it's just right. I upsized (despite his apprehension) to this one due to some pending surgeries that I would need to be able to help him stand up after (which would be impossible in the smaller kennel). It is MASSIVE, I could sit in it with him if needed. But it's also finally the right size for him to stretch and stand. • Incredibly sturdy.• Heavy!!!• Assembly: Not a piece of cake to put together alone, but they warn you to have someone else. But honestly, it wasn't that hard either. Feel 100 percent confident in it's ability to secure my dog — or any dog (mine is gentle and uses it as a place to hide — thus he preferred the smaller one at first). But now he• HUGE — this will take up a chunk of floor space (and height into the room). The footprint isn't so much larger than the size down but it feels bigger in the room due to the height.• NOTE: put it together where you want it. Once it's together, this will not change rooms without taking apart.",
+        "rating": 5,
+        "date": "Reviewed in Germany on August 7, 2024",
+        "extracted_date": "2024-08-07",
+        "profile": {
+          "name": "christina"
+        },
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R1YCUEL3TN4RQN",
+        "title": "Todo",
+        "text": "Espectacular. Calidad total. El montaje es tan fácil que no tengo palabras. El paquete llegó en la fecha indicada. Y la verdad es que estoy sorprendida con lo robusta que es",
+        "rating": 5,
+        "date": "Reviewed in Spain on November 6, 2025",
+        "extracted_date": "2025-11-06",
+        "profile": {
+          "name": "Alicia"
+        },
+        "is_verified_purchase": true
+      }
+    ]
+  }
+}

--- a/src/data/amazon-products/B000TZ59ES.json
+++ b/src/data/amazon-products/B000TZ59ES.json
@@ -1,0 +1,602 @@
+{
+  "search_metadata": {
+    "id": "search_gM5dQzeGq7sEO3wWQvOlAjp3",
+    "status": "Success",
+    "created_at": "2026-04-10T07:36:18Z",
+    "request_time_taken": 2.38,
+    "parsing_time_taken": 0.14,
+    "total_time_taken": 2.53,
+    "request_url": "https://www.amazon.com/dp/B000TZ59ES?th=1&psc=1",
+    "html_url": "https://www.searchapi.io/api/v1/searches/search_gM5dQzeGq7sEO3wWQvOlAjp3.html",
+    "json_url": "https://www.searchapi.io/api/v1/searches/search_gM5dQzeGq7sEO3wWQvOlAjp3"
+  },
+  "search_parameters": {
+    "engine": "amazon_product",
+    "asin": "B000TZ59ES",
+    "amazon_domain": "amazon.com",
+    "delivery_country": "us"
+  },
+  "product": {
+    "asin": "B000TZ59ES",
+    "title": "MidWest Homes for Pets 18-Inch iCrate for Tiny Breeds, Up to 10 lbs, Double Door Folding Dog Crate with Divider Panel, Leak-Proof Tray & Secure Latches, Portable, Durable & Easy to Assemble",
+    "brand_store": {
+      "id": "2A08F8F5-A392-471A-9EE7-EC1B59540DA6",
+      "text": "Visit the MidWest Homes for Pets Store",
+      "link": "https://www.amazon.com/stores/MidWestHomesForPets/page/2A08F8F5-A392-471A-9EE7-EC1B59540DA6?lp_asin=B000TZ59ES&ref_=ast_bln&store_ref=bl_ast_dp_brandlogo_sto&bl_grd_status=override"
+    },
+    "marketplace_id": "ATVPDKIKX0DER",
+    "link": "https://www.amazon.com/s?k=dog+cage+double+door",
+    "rating": 4.7,
+    "reviews": 80131,
+    "bought_past_month": "300+ bought in past month",
+    "description": "Give your dog a safe, comfortable place to call their own with the MidWest Homes for Pets iCrate Two Door Dog Crate. Newly enhanced with added security features, this metal wire dog crate now includes a patented Paw Block and locking tips on the slide-bolt latch - so you can feel confident your pet is secure whether they're relaxing at home or hitting the road with you. Front and side doors give you flexible placement options. Tuck it against a wall, in a corner, or anywhere that works for your space. Designed with both pets and parents in mind, iCrate dog crates come complete with a divider panel (to grow with your puppy), a durable leak-proof pan for easy cleanup, rubber feet to protect your floors, and a carrying handle for added convenience. Plus, you can fold it flat in seconds without tools, making it perfect for travel, storage or quick set-up anywhere you need it - from your living room to a beachside vacation rental. Built from precision-welded metal wire with a black e-coat finish, the iCrate is durable enough for everyday use while resisting rust and wear over time. Larger openings and low thresholds make it easier for your dog to enter and exit the crate, easing the crate training process and helping them feel more at home. At MidWest Homes for Pets, we know your dog is family. That's why every crate is backed by a 1-Year Manufacturer's Warranty and supported by our Indiana-based customer care team, making the iCrate a trusted choice for creating a secure, comfortable home for your dog.",
+    "attributes": [
+      {
+        "name": "Brand",
+        "value": "MidWest Homes for Pets"
+      },
+      {
+        "name": "Product Dimensions",
+        "value": "18.63\"L x 12\"W x 14\"H"
+      },
+      {
+        "name": "Gap Size",
+        "value": "37.5 Millimeters"
+      },
+      {
+        "name": "Material",
+        "value": "Metal"
+      },
+      {
+        "name": "Specific Uses For Product",
+        "value": "Indoor"
+      }
+    ],
+    "feature_bullets": [
+      "IDEAL FOR UP TO 10 LB DOGS: Measures 18.5 x 12.25 x 14.5 inches - perfect for Maltese, Japanese Chin, Brussels Griffon & similar breeds. For dogs near 10 lbs, consider sizing up to our 22-inch model so they have plenty of room to get comfortable.",
+      "WE DON'T CUT CORNERS, WE PERFECT THEM: Precision welding, rounded corner clips & slide-bolt latches with Paw Block mitigate snags, cuts & escapes. With rigorous safety testing, iCrate provides peace of mind knowing your dog is safe while you're away.",
+      "DURABLE CONSTRUCTION: Sturdy metal wire design with a protective black e-coat finish, the iCrate resists rust and everyday wear. Complete with leak-proof tray, rubber feet, carry handle, and tool-free assembly, it's ready for years of use.",
+      "SUPPORTS CRATE TRAINING: A divider panel lets the crate grow with your dog, from puppy kennel to full-size crate. Large openings and low thresholds ease the crate training process and help your dog feel more at home.",
+      "BECAUSE LIFE GOES BETTER WITH PETS: A family-owned business based in Indiana, MidWest Homes for Pets brings over 100 years of pet product expertise and a commitment to quality, rigorous safety testing, and excellent US-based customer service."
+    ],
+    "variants": [
+      {
+        "asin": "B000QFT1RC",
+        "title": "42.0\"L x 28.0\"W x 30.0\"H Black",
+        "link": "https://www.amazon.com/dp/B000QFT1RC?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "42.0\"L x 28.0\"W x 30.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Black"
+          }
+        ]
+      },
+      {
+        "asin": "B000QFT1R2",
+        "title": "36.0\"L x 23.0\"W x 25.0\"H Black",
+        "link": "https://www.amazon.com/dp/B000QFT1R2?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "36.0\"L x 23.0\"W x 25.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Black"
+          }
+        ]
+      },
+      {
+        "asin": "B000QFWCK0",
+        "title": "30.7\"L x 19.3\"W x 21.5\"H Black",
+        "link": "https://www.amazon.com/dp/B000QFWCK0?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "30.7\"L x 19.3\"W x 21.5\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Black"
+          }
+        ]
+      },
+      {
+        "asin": "B000QFWCJ6",
+        "title": "24.8\"L x 17.9\"W x 19.5\"H Black",
+        "link": "https://www.amazon.com/dp/B000QFWCJ6?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "24.8\"L x 17.9\"W x 19.5\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Black"
+          }
+        ]
+      },
+      {
+        "asin": "B005VVWBVY",
+        "title": "54.0\"L x 37.0\"W x 45.0\"H Black",
+        "link": "https://www.amazon.com/dp/B005VVWBVY?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "54.0\"L x 37.0\"W x 45.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Black"
+          }
+        ]
+      },
+      {
+        "asin": "B000QFUNWY",
+        "title": "23.0\"L x 14.0\"W x 16.2\"H Black",
+        "link": "https://www.amazon.com/dp/B000QFUNWY?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "23.0\"L x 14.0\"W x 16.2\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Black"
+          }
+        ]
+      },
+      {
+        "asin": "B000TZ59ES",
+        "title": "18.0\"L x 12.0\"W x 14.0\"H Black",
+        "link": "https://www.amazon.com/dp/B000TZ59ES?th=1&pcs=1",
+        "is_current_product": true,
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "18.0\"L x 12.0\"W x 14.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Black"
+          }
+        ]
+      },
+      {
+        "asin": "B000QFWCLY",
+        "title": "48.0\"L x 30.0\"W x 33.0\"H Black",
+        "link": "https://www.amazon.com/dp/B000QFWCLY?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "48.0\"L x 30.0\"W x 33.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Black"
+          }
+        ]
+      }
+    ],
+    "search_alias": {
+      "title": "All Departments",
+      "value": "aps"
+    },
+    "buybox": {
+      "price": {
+        "raw": "$25.99",
+        "value": 25.99,
+        "symbol": "$",
+        "currency": "USD"
+      },
+      "original_price": {
+        "raw": "$30.99",
+        "value": 30.99,
+        "symbol": "$",
+        "currency": "USD"
+      },
+      "save": {
+        "percentage": 16
+      },
+      "maximum_order_quantity": 27,
+      "offer_listing_id": "SGRtN1E4BsA%2BzXtxbBLcBvwKTWOJq56Vonwd3uW4WLlqu2OBUG%2FHfeyWV4rUWpTvwZtnrN7rUjdCV2FSUMZsUP%2Bm3InTtaDPoSDs3T%2B3zo2UKaykILUF%2FPaGzGQ35PUHWU%2FldbHoP%2B5jvJ%2Fcn3voDg%3D%3D",
+      "mixed_offers_from": {
+        "price": {
+          "raw": "$23.84",
+          "value": 23.84,
+          "symbol": "$",
+          "currency": "USD"
+        },
+        "link": "https://www.amazon.com/gp/offer-listing/B000TZ59ES/ref=dp_olp_ALL_mbc?ie=UTF8&condition=ALL"
+      },
+      "fulfillment": {
+        "standard_delivery": {
+          "text": "FREE delivery Wednesday, April 15 on orders shipped by Amazon over $35",
+          "type": "FREE",
+          "condition": "on orders shipped by Amazon over $35",
+          "date": "Wednesday, April 15"
+        },
+        "fastest_delivery": {
+          "text": "Or Prime members get FREE delivery Sunday, April 12. Join Prime",
+          "type": "FREE",
+          "date": "Sunday, April 12"
+        },
+        "sold_by": "Amazon.com",
+        "is_sold_by_amazon": true
+      },
+      "availability": "In Stock"
+    },
+    "specifications": [
+      {
+        "name": "Brand Name",
+        "value": "MidWest Homes for Pets"
+      },
+      {
+        "name": "Specific Uses For Product",
+        "value": "Indoor"
+      },
+      {
+        "name": "Included Components",
+        "value": "Divider, Removable Tray"
+      },
+      {
+        "name": "Breed Recommendation",
+        "value": "Extra-Small"
+      },
+      {
+        "name": "Dog Breed Size",
+        "value": "Extra Small"
+      },
+      {
+        "name": "Manufacturer",
+        "value": "MidWest Homes For Pets"
+      },
+      {
+        "name": "UPC",
+        "value": "027773007708"
+      },
+      {
+        "name": "Item Type Name",
+        "value": "Double - iCrate"
+      },
+      {
+        "name": "Unit Count",
+        "value": "1 Count"
+      },
+      {
+        "name": "Warranty Description",
+        "value": "1 Year Manufacture"
+      },
+      {
+        "name": "ASIN",
+        "value": "B000TZ59ES"
+      },
+      {
+        "name": "Gap Size",
+        "value": "37.5 Millimeters"
+      },
+      {
+        "name": "Additional Features",
+        "value": "Adjustable, Foldable, Lockable, Secure"
+      },
+      {
+        "name": "Number of Levels",
+        "value": "1"
+      },
+      {
+        "name": "Number of Doors",
+        "value": "1"
+      },
+      {
+        "name": "Material Type",
+        "value": "Metal"
+      },
+      {
+        "name": "Color",
+        "value": "Black"
+      },
+      {
+        "name": "Item Dimensions L x W x H",
+        "value": "18.63\"L x 12\"W x 14\"H"
+      },
+      {
+        "name": "Item Weight",
+        "value": "8 Pounds"
+      },
+      {
+        "name": "Is Discontinued By Manufacturer",
+        "value": "No"
+      },
+      {
+        "name": "Product Dimensions",
+        "value": "18 x 12 x 14 inches; 8 Pounds"
+      },
+      {
+        "name": "Item model number",
+        "value": "1518DD"
+      },
+      {
+        "name": "Date First Available",
+        "value": "July 31, 2007"
+      },
+      {
+        "name": "Manufacturer",
+        "value": "MidWest Homes For Pets"
+      },
+      {
+        "name": "ASIN",
+        "value": "B000TZ59ES"
+      }
+    ],
+    "bestsellers_rank": [
+      {
+        "name": "See Top 100 in Pet Supplies",
+        "link": "https://www.amazon.com/gp/bestsellers/pet-supplies/ref=pd_zg_ts_pet-supplies"
+      },
+      {
+        "name": "Basic Dog Crates",
+        "link": "https://www.amazon.com/gp/bestsellers/pet-supplies/3024223011/ref=pd_zg_hrsr_pet-supplies"
+      },
+      {
+        "name": "See Top 100 in Pet Supplies",
+        "link": "https://www.amazon.com/gp/bestsellers/pet-supplies/ref=pd_zg_ts_pet-supplies",
+        "rank": 1097
+      },
+      {
+        "name": "Basic Dog Crates",
+        "link": "https://www.amazon.com/gp/bestsellers/pet-supplies/3024223011/ref=pd_zg_hrsr_pet-supplies",
+        "rank": 4
+      }
+    ],
+    "main_image": "https://m.media-amazon.com/images/I/81Cpkz5lEPL.jpg",
+    "images": [
+      {
+        "link": "https://m.media-amazon.com/images/I/81Cpkz5lEPL.jpg",
+        "variant": "MAIN"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/91Cbrc26hVL.jpg",
+        "variant": "PT01"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/81nOl-FSAZL.jpg",
+        "variant": "PT02"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/A1yyUdcNgCL.jpg",
+        "variant": "PT03"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/A1PAOgU+ReL.jpg",
+        "variant": "PT04"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/719KsuqDa7L.jpg",
+        "variant": "PT05"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/81ZuFOnPndL.jpg",
+        "variant": "PT06"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/817BRiDKPgL.jpg",
+        "variant": "PT07"
+      }
+    ]
+  },
+  "similar_item": {
+    "asin": "B0DP7FDCBJ",
+    "title": "Simple Deluxe 24-Inch Small Dog Crate with Divider, Double Door Folding Metal Wire Cage with Leak-Proof Plastic Tray, Portable Pet Kennel for Indoor, Outdoor, and Travel",
+    "link": "https://www.amazon.com/dp/B0DP7FDCBJ/ref=vp_d_cpf-substitute-widget-prsubs_pd?_encoding=UTF8&pf_rd_p=3b384b6f-3e1a-4384-bf9e-527aad01ce71&pf_rd_r=EAEG3N7Y742QFXPMK5SZ&pd_rd_wg=LUvh3&pd_rd_i=B0DP7FDCBJ&pd_rd_w=LrMtC&content-id=amzn1.sym.3b384b6f-3e1a-4384-bf9e-527aad01ce71&pd_rd_r=7544026d-597a-44bc-b2ac-d9cf9836f984&psc=1",
+    "rating": 4.5,
+    "reviews": 187,
+    "price": {
+      "raw": "$34.99",
+      "value": 34.99,
+      "symbol": "$",
+      "currency": "USD"
+    },
+    "image": "https://m.media-amazon.com/images/I/71wc8jSGUNL.jpg"
+  },
+  "frequently_bought_together": {
+    "total_price": {
+      "raw": "$47.81",
+      "value": 47.81,
+      "symbol": "$",
+      "currency": "USD"
+    },
+    "products": [
+      {
+        "asin": "B000TZ59ES",
+        "title": "MidWest Homes for Pets 18-Inch iCrate for Tiny Breeds, Up to 10 lbs, Double Door Folding Dog Crate with Divider Panel, Leak-Proof Tray & Secure Latches, Portable, Durable & Easy to Assemble",
+        "link": "https://www.amazon.com/dp/B000TZ59ES",
+        "price": {
+          "symbol": "$",
+          "currency": "USD",
+          "value": 25.99,
+          "raw": "$25.99"
+        },
+        "image": "https://images-na.ssl-images-amazon.com/images/I/81Cpkz5lEPL.jpg"
+      },
+      {
+        "asin": "B004VOBKI2",
+        "title": "MidWest Homes for Pets QuietTime XXS Dog Bed – Gray Faux Fur Bolster, Ultra-Soft and Machine Washable, Fits 18-Inch Crates and Carriers, for Small Dogs and Cats",
+        "link": "https://www.amazon.com/MidWest-Homes-Pets-QuietTime-XXS/dp/B004VOBKI2/ref=pd_bxgy_thbs_d_sccl_1/132-7755984-9170257?pd_rd_w=LPB5o&content-id=amzn1.sym.9bef5913-5870-4504-8883-3ba89d7f8e39&pf_rd_p=9bef5913-5870-4504-8883-3ba89d7f8e39&pf_rd_r=EAEG3N7Y742QFXPMK5SZ&pd_rd_wg=zsrgh&pd_rd_r=f3ed2238-698b-44c4-a9a1-fadadfaa877e&pd_rd_i=B004VOBKI2&psc=1",
+        "price": {
+          "symbol": "$",
+          "currency": "USD",
+          "value": 11.33,
+          "raw": "$11.33"
+        },
+        "image": "https://images-na.ssl-images-amazon.com/images/I/61jGgIHcaeL.jpg"
+      },
+      {
+        "asin": "B00MW8G3YU",
+        "title": "Amazon Basics Leak-Proof Dog and Puppy Potty Training Pee Pads with Quick-Dry 5-Layer Super Absorbent Surface for Dog Training, Floor Protection, Regular Size 22x22\", Blue & White, 50 Count",
+        "link": "https://www.amazon.com/Amazon-Basics-Leak-Proof-Quick-Dry-Absorbency/dp/B00MW8G3YU/ref=pd_bxgy_thbs_d_sccl_2/132-7755984-9170257?pd_rd_w=LPB5o&content-id=amzn1.sym.9bef5913-5870-4504-8883-3ba89d7f8e39&pf_rd_p=9bef5913-5870-4504-8883-3ba89d7f8e39&pf_rd_r=EAEG3N7Y742QFXPMK5SZ&pd_rd_wg=zsrgh&pd_rd_r=f3ed2238-698b-44c4-a9a1-fadadfaa877e&pd_rd_i=B00MW8G3YU&psc=1",
+        "price": {
+          "symbol": "$",
+          "currency": "USD",
+          "value": 10.49,
+          "raw": "$10.49"
+        },
+        "image": "https://images-na.ssl-images-amazon.com/images/I/71Co+yjlWAL.jpg"
+      }
+    ]
+  },
+  "review_results": {
+    "local": [
+      {
+        "id": "R28K7RHES0KTRA",
+        "asin": "R28K7RHES0KTRA",
+        "title": "Way Better Than Other Brands!",
+        "link": "https://www.amazon.com/gp/customer-reviews/R28K7RHES0KTRA/ref=cm_cr_dp_d_rvw_ttl?ie=UTF8",
+        "text": "I already had a cage the same size as this one, but it honestly doesn't compare—the iCrate is much better quality.Versatility & Setup:I love that it has multiple doors, which gives you more options for how to set it up and where to place it. It was incredibly easy to put together, and the fact that it’s collapsible makes it perfect for storage or travel.Easy Cleaning:One of my favorite features is the bottom tray. It slides out so easily, making cleaning up any messes a breeze compared to other crates I've used.The Verdict:If you have a small breed, this is the one to get. It’s durable, convenient, and the double-door design is a total game changer!",
+        "rating": 5,
+        "date": "Reviewed in the United States on March 8, 2026",
+        "extracted_date": "2026-03-08",
+        "profile": {
+          "id": "AHN3BI5EE7DHSVHJPWT6J3FGF3RQ",
+          "name": "MAE",
+          "link": "https://www.amazon.com/gp/profile/amzn1.account.AHN3BI5EE7DHSVHJPWT6J3FGF3RQ"
+        },
+        "helpful_votes": 3,
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R3JMQB6ZSXWT75",
+        "asin": "R3JMQB6ZSXWT75",
+        "title": "I Definitely RECOMMEND the iCrate! Roomy, Durable, Easy to unfold/collapse.",
+        "link": "https://www.amazon.com/gp/customer-reviews/R3JMQB6ZSXWT75/ref=cm_cr_dp_d_rvw_ttl?ie=UTF8",
+        "text": "Purchased the 42\" iCrate with divider. PERFECT! Have a 50lb 10mo old Smooth Collie / Cattle Dog (Blue Heeler). He was sleeping in a 36\" crate where his head and rear touched the ends of the crate. The extra 6\" has made a world of difference. Opie can stretch out now... and doesn't come out 'unfolding' and acting like he's been in a vice all night. It's not quite the 'romper room' he has in the 48\" iCrate, but again, this one is for \"Night-Night\"... and gives plenty of room for such. When we first got our puppy, we bought a 36\" Beagle Crate from Walmart for $67. We were using the Beagle as his bed (in the bedroom) and needed a 2nd crate for the Family Room, but wanted a larger crate; one he could play in too. Then we found the iCrate by Midwest. The Beagle was very well made but much more expensive in comparison! After lengthy discussions whether to buy the 42\" or the 48\" we chose the larger 48\"... and use it in the Den. Yes, he had a couple of accidents, but we put the divider in, and the accidents stopped. It's been about 4 months now and we've moved the divider a little at a time and it's finally out! No more accidents! Of course, he's also out of the crate more and has bells at the back door to tell us when he needs to go out. Anyway, we decided to replace the 36\" Night Night crate with a 42\"... and chose to stay with the iCrate because of durability and price. It comes with a divider, which we've not needed, but it's there... and we're thinking about maybe getting another dog (later in 2017). The divider may come in handy then! Double doors. Some have reported that the double doors make the crate weaker. I guess it just depends on the dog and his reaction to being crated. Opie has horrible separation anxiety, but with the help of a loaded Kong, a bone, and a dark room (yup, turn the lights off and say Night Night)... he does quite well. We only use the end door because of the relation to space and placement, but I don't think the double doors decrease the durability or strength at all. FYI --- The doors are large. Not so large to compromise the integrity of the crate, but larger than the doors on other crates I've seen. Nice!!!The latches are really nice. They are straight, which concerned me at first, but after using them I feel confident that they are safe.Also, the plastic pan in the bottom is really nice. It's not flimsy at all. It fits well, removes easily, and cleans up really well with a quick wipe. Collapsibility. Easy enough! It's big, so it's bulky. But it's not hard to collapse or expand.To unfold... Just pull up on a hinge until the box is evident, then pull out one end, then the other, lock it in place, and BAM... you have a crate.To fold... reverse the process. Oh, lock the doors in place first. Then fold in the door and backend walls. The side will fold down practically on it's own.It's like a really big briefcase. Of course, the larger the crate, the heavier, but... it even comes with a couple of 'suitcase' carrying handles. EASY! Breezy! Complaint --- The door actually opens the wrong way into the room I have crate in... and there's no other place to put it. I've turned the care upside down to put the door opening the correct direction for the room. However, the crate was not designed for this. The plastic bottom fits, but the door hangs a little different and is harder to latch. The wiring is tighter on the top than it is on the bottom of the crate, so upside down leaves the (now) top of the crate with large open squares. Some dogs could potentially get caught in their attempt to get out, and strangle themselves or cause damage to their ears. Since my dog is happy in his crate I don't see that as an issue for us... but I still watch for it. I just think it would be safer for the pet, possible make the crate more durable overall, and definitely more versatile for the owners' room arrangement, if the crate was made the same on the top and bottom. Hope my experience helps you in your decision. It's a great crate... Give it try!",
+        "rating": 5,
+        "date": "Reviewed in the United States on March 5, 2017",
+        "extracted_date": "2017-03-05",
+        "profile": {
+          "id": "AGFA45IQAVQOCUTU3XXGCW7ZGWSA",
+          "name": "Yvette",
+          "link": "https://www.amazon.com/gp/profile/amzn1.account.AGFA45IQAVQOCUTU3XXGCW7ZGWSA"
+        },
+        "helpful_votes": 16,
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R25OK6QZT9N6TW",
+        "asin": "R25OK6QZT9N6TW",
+        "title": "Lightweight, very sturdy and quite roomy",
+        "link": "https://www.amazon.com/gp/customer-reviews/R25OK6QZT9N6TW/ref=cm_cr_dp_d_rvw_ttl?ie=UTF8",
+        "text": "This is the perfect size and a great unit for a Pomeranian. Goes well together with a small fence we bought and it’s enough room for her to get up walk around adjust her bed and stretch without being too confined. Very well-made rolls around easily and it’s easy and lightweight enough to move without a problem. This is our second one. We love it just as much as the first.",
+        "rating": 5,
+        "date": "Reviewed in the United States on November 5, 2025",
+        "extracted_date": "2025-11-05",
+        "profile": {
+          "id": "AHLKHSPTESWDTNPX5E7R3UEAS66Q",
+          "name": "RevSpongeBobSP",
+          "link": "https://www.amazon.com/gp/profile/amzn1.account.AHLKHSPTESWDTNPX5E7R3UEAS66Q"
+        },
+        "helpful_votes": 10,
+        "is_verified_purchase": true
+      },
+      {
+        "id": "RB92ZG6Q0EGVD",
+        "asin": "RB92ZG6Q0EGVD",
+        "title": "Great kennel, great price.",
+        "link": "https://www.amazon.com/gp/customer-reviews/RB92ZG6Q0EGVD/ref=cm_cr_dp_d_rvw_ttl?ie=UTF8",
+        "text": "I have purchased three sizes of this kennel. The kennel is easy to set up and taken down. I appreciate the crate having two doors, so you have more options for where you set it up. My only caveat, if you have a dog that struggles with being kenneled and is an escape artist, you may want a more reinforced kennel. For the average person, with a dog that does well in a crate, this is perfect.",
+        "rating": 5,
+        "date": "Reviewed in the United States on December 23, 2025",
+        "extracted_date": "2025-12-23",
+        "profile": {
+          "id": "AEXMIQAOOVSR33NSFQGIMCAXWPMA",
+          "name": "A Krause",
+          "link": "https://www.amazon.com/gp/profile/amzn1.account.AEXMIQAOOVSR33NSFQGIMCAXWPMA"
+        },
+        "helpful_votes": 2,
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R293285JQ2EPZ8",
+        "asin": "R293285JQ2EPZ8",
+        "title": "Great Quality Crate, Just Check Your Measurements!",
+        "link": "https://www.amazon.com/gp/customer-reviews/R293285JQ2EPZ8/ref=cm_cr_dp_d_rvw_ttl?ie=UTF8",
+        "text": "Excellent Construction, But the 48-Inch Was Too Large for My Space.​I purchased this MidWest iCrate based on the brand's reputation for quality, and I was not disappointed with the build.​Quality: The crate is still good quality. The metal wire is thick, the secure latches are reliable, and the folding design, along with the leak-proof tray, confirms its durability and ease of use.​The Issue: Unfortunately, the 48-inch size for XL breeds was too big for the specific area I needed it for in my home. It was an error on my part in measuring my space!​Outcome: I returned it solely due to the size issue and plan to re-order the next size down from the same brand.​If you have a large-to-extra-large dog and the space to accommodate a 48-inch crate, this is a sturdy and well-designed choice. I definitely suggest this brand for quality construction!",
+        "rating": 4,
+        "date": "Reviewed in the United States on November 15, 2025",
+        "extracted_date": "2025-11-15",
+        "profile": {
+          "id": "AF2NM5XXXZUZQXZ5K44BFIIWBUKQ",
+          "name": "Todd",
+          "link": "https://www.amazon.com/gp/profile/amzn1.account.AF2NM5XXXZUZQXZ5K44BFIIWBUKQ"
+        },
+        "helpful_votes": 6,
+        "is_verified_purchase": true
+      }
+    ],
+    "global": [
+      {
+        "id": "R11A9MAVO733ZN",
+        "title": "Great product, bought 2",
+        "text": "This is great, fits in car boot not to bulky. Easy to fold down as well. Folds flat. Room for my x2 small dogs comfortably",
+        "rating": 5,
+        "date": "Reviewed in Ireland on February 6, 2026",
+        "extracted_date": "2026-02-06",
+        "profile": {
+          "name": "Margot & Casper"
+        },
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R1F9FSS1W2EQ35",
+        "title": "Brilliant size.",
+        "text": "Brilliant for transporting small dog in the car.",
+        "rating": 5,
+        "date": "Reviewed in the United Kingdom on June 24, 2025",
+        "extracted_date": "2025-06-24",
+        "profile": {
+          "name": "Teaspoon"
+        },
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R1KCAPEWKSOBL",
+        "title": "Perfetto",
+        "text": "Montaggio facile anche da soli, più difficile separare i singoli pezzi imballati insieme senza forzare le giunzioni, più che altro per le grandi dimensioni dei pannelli.Presa la misura più grande",
+        "rating": 5,
+        "date": "Reviewed in Italy on August 26, 2025",
+        "extracted_date": "2025-08-26",
+        "profile": {
+          "name": "silvia"
+        },
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R1V2DGCXJR450I",
+        "title": "finally big enough",
+        "text": "This kennel might even be too big in my dog's opinion — but it's just right. I upsized (despite his apprehension) to this one due to some pending surgeries that I would need to be able to help him stand up after (which would be impossible in the smaller kennel). It is MASSIVE, I could sit in it with him if needed. But it's also finally the right size for him to stretch and stand. • Incredibly sturdy.• Heavy!!!• Assembly: Not a piece of cake to put together alone, but they warn you to have someone else. But honestly, it wasn't that hard either. Feel 100 percent confident in it's ability to secure my dog — or any dog (mine is gentle and uses it as a place to hide — thus he preferred the smaller one at first). But now he• HUGE — this will take up a chunk of floor space (and height into the room). The footprint isn't so much larger than the size down but it feels bigger in the room due to the height.• NOTE: put it together where you want it. Once it's together, this will not change rooms without taking apart.",
+        "rating": 5,
+        "date": "Reviewed in Germany on August 7, 2024",
+        "extracted_date": "2024-08-07",
+        "profile": {
+          "name": "christina"
+        },
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R1YCUEL3TN4RQN",
+        "title": "Todo",
+        "text": "Espectacular. Calidad total. El montaje es tan fácil que no tengo palabras. El paquete llegó en la fecha indicada. Y la verdad es que estoy sorprendida con lo robusta que es",
+        "rating": 5,
+        "date": "Reviewed in Spain on November 6, 2025",
+        "extracted_date": "2025-11-06",
+        "profile": {
+          "name": "Alicia"
+        },
+        "is_verified_purchase": true
+      }
+    ]
+  }
+}

--- a/src/data/amazon-products/B003E6YYYK.json
+++ b/src/data/amazon-products/B003E6YYYK.json
@@ -1,0 +1,561 @@
+{
+  "search_metadata": {
+    "id": "search_WDz0ZKeWNOcxDdPpQkQyABpo",
+    "status": "Success",
+    "created_at": "2026-04-10T02:45:07Z",
+    "request_time_taken": 2.19,
+    "parsing_time_taken": 0.13,
+    "total_time_taken": 2.31,
+    "request_url": "https://www.amazon.com/dp/B003E6YYYK?th=1&psc=1",
+    "html_url": "https://www.searchapi.io/api/v1/searches/search_WDz0ZKeWNOcxDdPpQkQyABpo.html",
+    "json_url": "https://www.searchapi.io/api/v1/searches/search_WDz0ZKeWNOcxDdPpQkQyABpo"
+  },
+  "search_parameters": {
+    "engine": "amazon_product",
+    "asin": "B003E6YYYK",
+    "amazon_domain": "amazon.com",
+    "delivery_country": "us"
+  },
+  "product": {
+    "asin": "B003E6YYYK",
+    "title": "Petmate Sky Kennel - For Air and Travel, Airline Compliant Dog Crate for Pets up 70-90 lbs, Heavy Duty Dog Kennel, Made in the USA- 40 Inches",
+    "brand_store": {
+      "id": "B33A6183-0C92-403F-BD06-4916DFDD3B4D",
+      "text": "Visit the Petmate Store",
+      "link": "https://www.amazon.com/stores/Petmate/page/B33A6183-0C92-403F-BD06-4916DFDD3B4D?lp_asin=B003E6YYYK&ref_=ast_bln&store_ref=bl_ast_dp_brandlogo_sto&bl_grd_status=override"
+    },
+    "marketplace_id": "ATVPDKIKX0DER",
+    "link": "https://www.amazon.com/s?k=petmate+sky+kennel",
+    "rating": 4.4,
+    "reviews": 7409,
+    "bought_past_month": "100+ bought in past month",
+    "description": "The Petmate Sky Kennel is great for pet owners seeking reliable dog crates for large dogs. This large dog crate is airline-compliant, making it ideal for both air and car travel. Always check with airlines in advance. Specifically constructed for pets weighing between 70-90 lbs, it serves as a large dog crate for large dogs like Labrador Retrievers, to offer space and comfort during long journeys. As a portable dog crate, it comes equipped with essential travel items including \"\"LIVE ANIMAL\"\" stickers, a food and water cup, and ID stickers, to provide a great experience for both you and your pet. Built from heavy-duty plastic in the USA, its construction includes an easy-squeeze latch door with interlocks and 360-degree ventilation for safety and comfort. With a spacious interior measuring 36.25\"\" L x 24.75\"\" W x 28.8\"\" H, this large dog crate not only fits into your car as a dog crate for car travel but can also be used as a dog cage for large dogs at home. The Sky Kennel's EcoTEC plastic design incorporates a minimum of 90% pre-consumer recycled material. Its large dog carrier capabilities also make it suitable as a dog travel crate or travel crate for large dogs, featuring plastic-covered wing-nuts and bolts, along with integrated side handles for safe and secure transport. Whether used as a large dog kennel for home use or a large pet carrier for travel, the Petmate Sky Kennel remains a great choice for pet parents who value durability and comfort.",
+    "attributes": [
+      {
+        "name": "Color",
+        "value": "Multi"
+      },
+      {
+        "name": "Brand",
+        "value": "Petmate"
+      },
+      {
+        "name": "Product Dimensions",
+        "value": "40\"L x 27\"W x 30\"H"
+      },
+      {
+        "name": "Material",
+        "value": "Polypropylene (PP)"
+      },
+      {
+        "name": "Special Feature",
+        "value": "Airline Approved, Built-In Door, Durable, Heavy Duty, Portable"
+      }
+    ],
+    "feature_bullets": [
+      "FIRST-CLASS COMFORT FOR PETS: The Petmate Sky Kennel meets IATA requirements for live animal transport and meets most airline cargo specifications, providing secure air travel for pets; it includes 360-degree ventilation and tie-down strap holes",
+      "EASY TRAVEL PREPARATION: The Sky Kennel is a travel dog crate that comes with essentials including two 'LIVE ANIMAL' stickers, a food and water cup, ID stickers, and an absorbent pad to provide a great travel experience for you and your pet",
+      "SPACIOUS INTERIOR FOR LARGE DOGS: Ideal for Labrador Retriever or similar, this large dog kennel accommodates pets 70-90 lbs, offering enough room to walk and rest comfortably during travel, with interior dimensions of 36.25\" L x 24.75\" W x 28.8\" H",
+      "DURABLE BUILD QUALITY: Made in the USA from EcoTEC Plastic with a minimum of 90% pre-consumer recycled material, this big dog crate features an easy-squeeze latch door with interlocks and a folding top handle for added security",
+      "PET WELL-BEING: With over 60 years of experience, Petmate designs reliable pet products to improve the lives of pets and their owners by creating high-quality products"
+    ],
+    "variants": [
+      {
+        "asin": "B003E77OG4",
+        "title": "36 Inch Kennel Only",
+        "link": "https://www.amazon.com/dp/B003E77OG4?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "36 Inch"
+          },
+          {
+            "name": "Style",
+            "value": "Kennel Only"
+          }
+        ]
+      },
+      {
+        "asin": "B003E77OEG",
+        "title": "32 Inch Kennel Only",
+        "link": "https://www.amazon.com/dp/B003E77OEG?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "32 Inch"
+          },
+          {
+            "name": "Style",
+            "value": "Kennel Only"
+          }
+        ]
+      },
+      {
+        "asin": "B003WQTT1A",
+        "title": "21 Inch Kennel Only",
+        "link": "https://www.amazon.com/dp/B003WQTT1A?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "21 Inch"
+          },
+          {
+            "name": "Style",
+            "value": "Kennel Only"
+          }
+        ]
+      },
+      {
+        "asin": "B00AAPGA2W",
+        "title": "28 Inch Kennel Only",
+        "link": "https://www.amazon.com/dp/B00AAPGA2W?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "28 Inch"
+          },
+          {
+            "name": "Style",
+            "value": "Kennel Only"
+          }
+        ]
+      },
+      {
+        "asin": "B003E6YYYK",
+        "title": "40 Inch Kennel Only",
+        "link": "https://www.amazon.com/dp/B003E6YYYK?th=1&pcs=1",
+        "is_current_product": true,
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "40 Inch"
+          },
+          {
+            "name": "Style",
+            "value": "Kennel Only"
+          }
+        ]
+      },
+      {
+        "asin": "B003E75LBO",
+        "title": "48 Inch Kennel Only",
+        "link": "https://www.amazon.com/dp/B003E75LBO?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "48 Inch"
+          },
+          {
+            "name": "Style",
+            "value": "Kennel Only"
+          }
+        ]
+      }
+    ],
+    "search_alias": {
+      "title": "Pet Supplies",
+      "value": "pets"
+    },
+    "buybox": {
+      "price": {
+        "raw": "$159.95",
+        "value": 159.95,
+        "symbol": "$",
+        "currency": "USD"
+      },
+      "original_price": {
+        "raw": "$218.35",
+        "value": 218.35,
+        "symbol": "$",
+        "currency": "USD"
+      },
+      "save": {
+        "percentage": 27
+      },
+      "maximum_order_quantity": 3,
+      "offer_listing_id": "KJgCnw84UoZOEJ9Sb%2F6DqMz4aYnKr51%2ByZ%2BpBsGd%2BxNZuJV6Gyz2Ntt38yYYPvLAySSex6nrdXY7F%2FJppredtYQDRziT%2FzRzMHPrUgGacmt5n29Q%2BXtVI9l3nH07u5f8s0ewPYrq5m1LOKxOzxCFog%3D%3D",
+      "fulfillment": {
+        "standard_delivery": {
+          "text": "FREE delivery Wednesday, April 15. Order within 1 hr 14 mins",
+          "type": "FREE",
+          "date": "Wednesday, April 15"
+        },
+        "sold_by": "Amazon.com",
+        "is_sold_by_amazon": true
+      },
+      "availability": "In Stock"
+    },
+    "specifications": [
+      {
+        "name": "Brand Name",
+        "value": "Petmate"
+      },
+      {
+        "name": "Target Audience",
+        "value": "Dog"
+      },
+      {
+        "name": "Manufacturer",
+        "value": "Petmate"
+      },
+      {
+        "name": "UPC",
+        "value": "029695005008"
+      },
+      {
+        "name": "Global Trade Identification Number",
+        "value": "00029695005008"
+      },
+      {
+        "name": "Item Type Name",
+        "value": "Pet Kennel"
+      },
+      {
+        "name": "Included Components",
+        "value": "1 Sticker For Pet Information, 2 \"Live Animal\" Stickers, 40 Inch Sky Kennel, Clip On Water Bowl"
+      },
+      {
+        "name": "Unit Count",
+        "value": "1 Count"
+      },
+      {
+        "name": "Warranty Description",
+        "value": "Limited 1 Year Warranty, Warranted one year from date of retail purchase against defects in material and workmanship. Solely for the benefit of the original consumer purchaser. (Retain your dated sales receipt as proof of purchase)."
+      },
+      {
+        "name": "ASIN",
+        "value": "B003E6YYYK"
+      },
+      {
+        "name": "Material Type",
+        "value": "Polypropylene (PP)"
+      },
+      {
+        "name": "Item Dimensions L x W x H",
+        "value": "40\"L x 27\"W x 30\"H"
+      },
+      {
+        "name": "Item Weight",
+        "value": "30.48 Pounds"
+      },
+      {
+        "name": "Size",
+        "value": "40 Inch"
+      },
+      {
+        "name": "Additional Features",
+        "value": "Airline Approved, Built-In Door, Durable, Heavy Duty, Portable"
+      },
+      {
+        "name": "Compatible with Vehicle Type",
+        "value": "Airplane, Car"
+      },
+      {
+        "name": "Closure Type",
+        "value": "Buckle"
+      },
+      {
+        "name": "Dog Breed Size",
+        "value": "Large"
+      },
+      {
+        "name": "Color",
+        "value": "Multi"
+      },
+      {
+        "name": "Product Style",
+        "value": "Kennel Only"
+      },
+      {
+        "name": "Maximum Weight Recommendation",
+        "value": "90 Pounds"
+      },
+      {
+        "name": "Recommended Uses For Product",
+        "value": "Air Travel, Car Travel"
+      },
+      {
+        "name": "Is Discontinued By Manufacturer",
+        "value": "No"
+      },
+      {
+        "name": "Product Dimensions",
+        "value": "40 x 27 x 30 inches; 30.48 Pounds"
+      },
+      {
+        "name": "Item model number",
+        "value": "00500"
+      },
+      {
+        "name": "Department",
+        "value": "Unisex-Adult"
+      },
+      {
+        "name": "Date First Available",
+        "value": "June 3, 2011"
+      },
+      {
+        "name": "Manufacturer",
+        "value": "Petmate"
+      },
+      {
+        "name": "ASIN",
+        "value": "B003E6YYYK"
+      }
+    ],
+    "bestsellers_rank": [
+      {
+        "name": "See Top 100 in Pet Supplies",
+        "link": "https://www.amazon.com/gp/bestsellers/pet-supplies/ref=pd_zg_ts_pet-supplies"
+      },
+      {
+        "name": "Basic Dog Crates",
+        "link": "https://www.amazon.com/gp/bestsellers/pet-supplies/3024223011/ref=pd_zg_hrsr_pet-supplies"
+      },
+      {
+        "name": "See Top 100 in Pet Supplies",
+        "link": "https://www.amazon.com/gp/bestsellers/pet-supplies/ref=pd_zg_ts_pet-supplies",
+        "rank": 6123
+      },
+      {
+        "name": "Basic Dog Crates",
+        "link": "https://www.amazon.com/gp/bestsellers/pet-supplies/3024223011/ref=pd_zg_hrsr_pet-supplies",
+        "rank": 14
+      }
+    ],
+    "main_image": "https://m.media-amazon.com/images/I/71HTfabbQ3L.jpg",
+    "images": [
+      {
+        "link": "https://m.media-amazon.com/images/I/71HTfabbQ3L.jpg",
+        "variant": "MAIN"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/717FFUiQs8L.jpg",
+        "variant": "PT01"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/718XrES0xaL.jpg",
+        "variant": "PT02"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/71OUhjaS2ML.jpg",
+        "variant": "PT03"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/71sSuP54SuL.jpg",
+        "variant": "PT04"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/71lY-X-WQ1L.jpg",
+        "variant": "PT05"
+      }
+    ]
+  },
+  "similar_item": {
+    "asin": "B07GPHC113",
+    "title": "Amazon Basics Portable Foldable Soft Pet Dog Crate Carrier Kennel with Mesh Windows, Ventilation, Pockets for Large Dogs, 42 x 31 x 31 inches, Grey",
+    "link": "https://www.amazon.com/dp/B07GPHC113/ref=vp_d_pbs_trans_lp_B003E6YYYK_pd?_encoding=UTF8&pf_rd_p=f6007f53-9fa1-4c0d-b499-54e844408da9&pf_rd_r=QAA6R7PDMKAYRWJZ537N&pd_rd_wg=iQcb4&pd_rd_i=B07GPHC113&pd_rd_w=LXvlt&content-id=amzn1.sym.f6007f53-9fa1-4c0d-b499-54e844408da9&pd_rd_r=b1263067-8fe8-4e0f-8b61-73050a9f1735&psc=1",
+    "rating": 4.5,
+    "reviews": 18755,
+    "price": {
+      "raw": "$99.74",
+      "value": 99.74,
+      "symbol": "$",
+      "currency": "USD"
+    },
+    "image": "https://m.media-amazon.com/images/I/A1Ixxr1qhIL.jpg"
+  },
+  "frequently_bought_together": {
+    "total_price": {
+      "raw": "$180.13",
+      "value": 180.13,
+      "symbol": "$",
+      "currency": "USD"
+    },
+    "products": [
+      {
+        "asin": "B003E6YYYK",
+        "title": "Petmate Sky Kennel - For Air and Travel, Airline Compliant Dog Crate for Pets up 70-90 lbs, Heavy Duty Dog Kennel, Made in the USA- 40 Inches",
+        "link": "https://www.amazon.com/dp/B003E6YYYK",
+        "price": {
+          "symbol": "$",
+          "currency": "USD",
+          "value": 159.95,
+          "raw": "$159.95"
+        },
+        "image": "https://images-na.ssl-images-amazon.com/images/I/71HTfabbQ3L.jpg"
+      },
+      {
+        "asin": "B0733FPPV8",
+        "title": "Petmate Kennel Bowl, Large",
+        "link": "https://www.amazon.com/Petmate-29156-Kennel-Bowl-Large/dp/B0733FPPV8/ref=pd_bxgy_thbs_d_sccl_1/147-3061023-7075449?pd_rd_w=3Fisi&content-id=amzn1.sym.9bef5913-5870-4504-8883-3ba89d7f8e39&pf_rd_p=9bef5913-5870-4504-8883-3ba89d7f8e39&pf_rd_r=QAA6R7PDMKAYRWJZ537N&pd_rd_wg=Z25HL&pd_rd_r=615e7075-7e53-4b81-96e6-632921aa4cd3&pd_rd_i=B0733FPPV8&psc=1",
+        "price": {
+          "symbol": "$",
+          "currency": "USD",
+          "value": 4.7,
+          "raw": "$4.70"
+        },
+        "image": "https://images-na.ssl-images-amazon.com/images/I/71yq9qhnjWL.jpg"
+      },
+      {
+        "asin": "B00DT2WN9M",
+        "title": "Petmate 290300 Kennel Travel Kit for Pets",
+        "link": "https://www.amazon.com/Petmate-290300-Kennel-Security-Hardware/dp/B00DT2WN9M/ref=pd_bxgy_thbs_d_sccl_2/147-3061023-7075449?pd_rd_w=3Fisi&content-id=amzn1.sym.9bef5913-5870-4504-8883-3ba89d7f8e39&pf_rd_p=9bef5913-5870-4504-8883-3ba89d7f8e39&pf_rd_r=QAA6R7PDMKAYRWJZ537N&pd_rd_wg=Z25HL&pd_rd_r=615e7075-7e53-4b81-96e6-632921aa4cd3&pd_rd_i=B00DT2WN9M&psc=1",
+        "price": {
+          "symbol": "$",
+          "currency": "USD",
+          "value": 15.48,
+          "raw": "$15.48"
+        },
+        "image": "https://images-na.ssl-images-amazon.com/images/I/71FGo6Yu-oL.jpg"
+      }
+    ]
+  },
+  "review_results": {
+    "local": [
+      {
+        "id": "R3JWBPMDJ5O40Y",
+        "asin": "R3JWBPMDJ5O40Y",
+        "title": "great purchase",
+        "link": "https://www.amazon.com/gp/customer-reviews/R3JWBPMDJ5O40Y/ref=cm_cr_dp_d_rvw_ttl?ie=UTF8",
+        "text": "Really great carrier. It's large enough for my long bodied Cavapoo. I did not think that a cavapoo would have such a long body, but I guess the spaniel in him is a little long. He is a medium sized dog, but this carrier was a little larger than postings said I needed. The good thing is that he can stretch out. It's not very heavy. Easy to put together, tall enough and very good for my dog. We take it on trips all the time so that he can have a quiet, safe place to lay down.",
+        "rating": 5,
+        "date": "Reviewed in the United States on February 16, 2026",
+        "extracted_date": "2026-02-16",
+        "profile": {
+          "id": "AGZGM2MYQCJ5VUFFFOPYO36SS7SQ",
+          "name": "Angie",
+          "link": "https://www.amazon.com/gp/profile/amzn1.account.AGZGM2MYQCJ5VUFFFOPYO36SS7SQ"
+        },
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R3UTHCZUJTB625",
+        "asin": "R3UTHCZUJTB625",
+        "title": "Met most international airline travel requirements",
+        "link": "https://www.amazon.com/gp/customer-reviews/R3UTHCZUJTB625/ref=cm_cr_dp_d_rvw_ttl?ie=UTF8",
+        "text": "I used this and the metal screw additional set to bring my pets to japan. I had a large one for the dog and a medium one for the cat. I didn't have any issues with Japan airlines. The crates were really spacious, and I feel like I could've bought smaller sizes because of how much room they actually had in there. It was easy to assemble and very sturdy. The design fit airline standards for international travel, but you will have to buy the extra kit for the screws. Both pets made it in one piece, so it served its purpose. The downside was that that take up too much space, so carrying them is impossible, you need a luggage cart. And then finding a vehicle to fit them in was expensive. We needed to rent a large van. And then no closet would fit them, so I had to disassemble them and store them outside, until I realized I really didn't need them, then I had to pay for large item pickup to dispose of them.",
+        "rating": 5,
+        "date": "Reviewed in the United States on July 16, 2025",
+        "extracted_date": "2025-07-16",
+        "profile": {
+          "id": "AHNDOHYMUES566Y4CUMVAXRHKPCA",
+          "name": "Shallowpockets",
+          "link": "https://www.amazon.com/gp/profile/amzn1.account.AHNDOHYMUES566Y4CUMVAXRHKPCA"
+        },
+        "helpful_votes": 19,
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R184IMECJ8GQK5",
+        "asin": "R184IMECJ8GQK5",
+        "title": "Perfect for Home Use.",
+        "link": "https://www.amazon.com/gp/customer-reviews/R184IMECJ8GQK5/ref=cm_cr_dp_d_rvw_ttl?ie=UTF8",
+        "text": "I'm very pleased with this burly Sky Kennel.Now for the \"Rest of The Story\". What?I needed something sufficiently portable yet very sturdy and tough that I didn't have to build and give above average security for this nice friendly \"Calico Cat\" that just showed up one day, with a very active inclination to use her claws on everything. Welp, my little Calico Buddy, you're not an \"indoor cat\".... \"Might-a-wuz\", but now you isn't.....The Large \"Myodal\" Feral Cat Shelter for Outdoor Barn Strays fits inside this \"Sky Kennel\" perfectly. I covered the outside of this \"Sky Kennel\" With Single-Sided Sticky Anti Cat Scratch Deterrent Tape Furniture Protector to keep the wind and rain out....I bought a heavy denier Waterproof Outdoor Grill Cart Cover with draw string, off Amazon, to complete the winterizing.Oh, uh, yeah, it snuck past me a concealed surprise. Give you three guesses and the first two won't count. Tasty \"Temptations\" Classic Crunchy and Soft Cat Treats lure \"THEM\" into their mansion each evening,for safety from OWLS and Such. Just Sayin...",
+        "rating": 5,
+        "date": "Reviewed in the United States on November 8, 2025",
+        "extracted_date": "2025-11-08",
+        "profile": {
+          "id": "AFOGPVANLQQSHPVSULOONLYD2BUA",
+          "name": "BBQ Guy",
+          "link": "https://www.amazon.com/gp/profile/amzn1.account.AFOGPVANLQQSHPVSULOONLYD2BUA"
+        },
+        "helpful_votes": 5,
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R1TVG3Q3CN1D2V",
+        "asin": "R1TVG3Q3CN1D2V",
+        "title": "There is NO kennel that is \"airline approved\" w/o modifications. This one comes the closest! Read for International Pet Travel!!",
+        "link": "https://www.amazon.com/gp/customer-reviews/R1TVG3Q3CN1D2V/ref=cm_cr_dp_d_rvw_ttl?ie=UTF8",
+        "text": "This was the only kennel I found that came closest to airline requirements. It is approved by the USDA and IATA. We were on a military move from the states so this a review on the international kennel features and requirements only. Kennel Features:This kennel has 11 plastic bolt holes- This is the only requirement that this kennel does not follow. It came with plastic nuts. Metal nuts and bolts are required now for every flight. This carrier has 11 bolt holes plus an additional 4 tie down holes. My airline specifically said that every hole must have a bolt. So we needed 15 metal nuts and screws for the carrier. Some airlines let you leave the 4 tie down holes empty but check to be sure and order the bolts ahead of time to get the right amount. We dind't do this and had to buy 3 kits because of shipping time limits. Metal bolts on amazon did not have prime option. But these are what you need Pet Carrier Metal Fasteners Nuts Bolts (1-1/4\" Medium Bolts, 16 Pack) 16 pack will ensure a better safe than sorry amount.Has Pre drilled zip tie holes- Hard to find kennels with this already done. It is a requirement to zip tie the kennel doors shut. Quick release are best. Helping Hand Assorted Quick Release Nylon Cable Ties, 8-inch Make sure you insist on zip tying your dogs yourself! I watched the security guy do it wrong and had to redo do it myself. So glad I got the quick release. Same thing happened to a friend only they didn't catch that the attendant only thread it though the hole and not the door. Their dog got loose in the belly of the plane after ripping off the door. This brings me to the next feature. Has single piece metal door- Be sure to follow this guideline, a metal single piece door. No plastic allowed! Some larger kennel doors have a fold in the middle of the door to make packing easier. Some airlines don't specify the type of door needed and some forbid the fold. It gives the dog the ability to pull the door in which will then collapse and allows for escape. This kennel door is a solid one piece. Has protruding bar/side handles- This follows the requirement of \"a spacer rim protruding at least 3/4 on all sides with ventilation openings\"This is so the airline can carry and move the kennel without using the handle (known to fail on some kennels) and prevent a dog from being able to bite or contact movers hands. This kennel states that the rim is designed to work as side handles. Has 4 sides of air holes- Requirement is air holes must be \"on all four sides at least halfway on each side\". This kennel has it and even better metal grates! I had a friend whose dog chewed the space between the plastic holes during flight. Some kennels show in the picture that they have air holes in the back but come to find after ordering they didn't have the air holes on the backside in the smaller sizes. Especially for cat carriers. Note- Domestic flights only requires 2 vent sides but they stack and pack kennels like baggage and airflow will be restricted. Go with ventilation on all sides. Food Dishes- These were actually deep enough to be functional. Kennels with dishes attached inside on the walls are not allowed. Airlines must be able to \"access dishes attached to door without opening the kennel door\" they do this through funnels. On my main international flight with 2 layovers and a total of 20 hours travel they did not feed or water my dogs once. Even though it's the law. My advice freeze water ahead of flight so it doesn't make a mess or even better get a lixit water bottle to ensure your dogs don't dehydrate. We got Lixit Small Dog Water Bottle 16-Ounce Stickers- This kennel came with stickers and that is a requirement but airlines have them and will use their own as well. The stickers included are crap and leave an awful residue. The airlines put the sticker packet of paper work over the \" \"Live Animal\" in 1-inch letters on the crate's top\" required sticker. Upon removal of that it lifted the sticker below mucking up the brand new kennels. My advice, bring the stickers and apply at check in where they are needed once the paperwork covers the entire top of kennel and use airline stickers if possible. Note for size- The length requirement for international travel is [their length + half their leg] so there must be ample room in front and back. This made us need the larger kennel which is much larger than our previous kennel. Some will say that the rule of thumb is as long as they can turn around it's okay. But that is the length rule for IATA. Height for IATA includes ears and ears cannot touch top of kennel while standing. Again, why we had to go up a size (dang chihuahuas). After traveling with my pets on over 6 different flights I can say that most airline attendants are clueless about the pet requirements needed. I had one tell me they don't even receive training on the requirements and offered to let both dogs go into one kennel (a international no no). But I did have had one who knew their stuff and used a tape measure. So better safe than sorry! Traveling with your pet no matter how far is stress full. With international flights being long dogs get anxious and try to escape, sometimes successfully in cheep kennels. So get this one! Airlines have different requirements and regulations. It's better to buy new then to try to modify existing kennels. Save yourself the time! Get this kennel and you only need to purchase zip ties (hand release are best), metal bolts, and some puppy pads. I realize this is much more info than necessary for a review but I know how hard it was getting this information. Please check this as helpful so that it may help others in the complicated kennel requirement process. Safe Travels!",
+        "rating": 5,
+        "date": "Reviewed in the United States on December 14, 2014",
+        "extracted_date": "2014-12-14",
+        "profile": {
+          "id": "AGMELW5HKAOYOSZPGPGCI2BPTP3A",
+          "name": "AmazonJunkie",
+          "link": "https://www.amazon.com/gp/profile/amzn1.account.AGMELW5HKAOYOSZPGPGCI2BPTP3A"
+        },
+        "helpful_votes": 7109,
+        "images": [
+          "https://m.media-amazon.com/images/I/617COCM7rwL.jpg"
+        ],
+        "is_verified_purchase": true
+      }
+    ],
+    "global": [
+      {
+        "id": "R15KE8XPSSUVC2",
+        "title": "La mejor opción en casetas/cajas transportadoras",
+        "text": "Raza mediana.El precio es muy bueno comparado con el mercado (veterinarias, tiendas de mascotas, tiendas de autoservicio, etc), te ahorras una buena diferencia.El material de la transportadora es muy resistente y de buena calidad, es fácil de armar-desarmar en muy poco tiempo.Contiene tornillos y mariposas adicionales de repuesto, sin embargo, no recibí los platitos que se muestran en la fotografía (no importante para mí).La rejita y los seguros para bloquearla son muy buenos, muy dificíl que tu mascota pueda forzarlos para salir.Adicionalmente contiene dos calcomanías de \"live animals\" por separado para poder pegarlas cuando sea necesario - la transportadora ya tiene un par de ellas adheridas.",
+        "rating": 5,
+        "date": "Reviewed in Mexico on October 4, 2017",
+        "extracted_date": "2017-10-04",
+        "profile": {
+          "name": "rponcel"
+        },
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R2YCPECPUGVGW2",
+        "title": "Nickel!",
+        "text": "Caisse taille 1 et 5 reçues aujourd'hui. Montage facile, semble solide, correspond à mes attentes",
+        "rating": 5,
+        "date": "Reviewed in France on February 16, 2023",
+        "extracted_date": "2023-02-16",
+        "profile": {
+          "name": "Alice CHAMAGNE"
+        },
+        "images": [
+          "https://m.media-amazon.com/images/I/71JtT9kilNL.jpg"
+        ],
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R38Q2OFJKDUDMI",
+        "title": "Plastic is very flimsy",
+        "text": "I purchased this product on Amazon.de to have a kennel available in Germany to fly our dog Rexy home to the US. Upon unpacking I already noticed that the plastic seemed very \"soft\" and flimsy.However, I was in a bind and decided to keep the kennel. Sure enough after the flight from FRA-MSP when I took Rexy out there was a hairline crack in the middle of the bottom and soon thereafter the corner broke off on its left side, see pictures. Very disappointing for a kennel that expensive.",
+        "rating": 3,
+        "date": "Reviewed in Germany on June 24, 2022",
+        "extracted_date": "2022-06-24",
+        "profile": {
+          "name": "Eva M. Gallant"
+        },
+        "images": [
+          "https://m.media-amazon.com/images/I/61g5ohZIKeL.jpg",
+          "https://m.media-amazon.com/images/I/619KUMdGVLL.jpg"
+        ],
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R3J29I3PQK94XO",
+        "title": "Mauvaise qualité",
+        "text": "Ne correspond pas à la photo",
+        "rating": 1,
+        "date": "Reviewed in France on November 11, 2023",
+        "extracted_date": "2023-11-11",
+        "profile": {
+          "name": "Millenium security"
+        },
+        "images": [
+          "https://m.media-amazon.com/images/I/61yn7fNYanL.jpg",
+          "https://m.media-amazon.com/images/I/61Gc9lHBaNL.jpg"
+        ],
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R2BBX14LETTEEA",
+        "title": "déçu",
+        "text": "Produit reçu en plastique et non en \"Résine\" comme indiquer dans le descriptif, aucun emballage le produit est arrivé défectueux",
+        "rating": 1,
+        "date": "Reviewed in France on January 23, 2023",
+        "extracted_date": "2023-01-23",
+        "profile": {
+          "name": "Megane Brunet Masson"
+        },
+        "is_verified_purchase": true
+      }
+    ]
+  }
+}

--- a/src/data/amazon-products/B005U6UOEQ.json
+++ b/src/data/amazon-products/B005U6UOEQ.json
@@ -1,0 +1,513 @@
+{
+  "search_metadata": {
+    "id": "search_mR5DzpePyDIPrLD5E4YdGQno",
+    "status": "Success",
+    "created_at": "2026-04-10T02:38:52Z",
+    "request_time_taken": 2.32,
+    "parsing_time_taken": 0.12,
+    "total_time_taken": 2.45,
+    "request_url": "https://www.amazon.com/dp/B005U6UOEQ?th=1&psc=1",
+    "html_url": "https://www.searchapi.io/api/v1/searches/search_mR5DzpePyDIPrLD5E4YdGQno.html",
+    "json_url": "https://www.searchapi.io/api/v1/searches/search_mR5DzpePyDIPrLD5E4YdGQno"
+  },
+  "search_parameters": {
+    "engine": "amazon_product",
+    "asin": "B005U6UOEQ",
+    "amazon_domain": "amazon.com",
+    "delivery_country": "us"
+  },
+  "product": {
+    "asin": "B005U6UOEQ",
+    "title": "PETMATE 2-Door Training Retreat Wire Kennel",
+    "brand_store": {
+      "id": "B33A6183-0C92-403F-BD06-4916DFDD3B4D",
+      "text": "Visit the Petmate Store",
+      "link": "https://www.amazon.com/stores/Petmate/page/B33A6183-0C92-403F-BD06-4916DFDD3B4D?lp_asin=B005U6UOEQ&ref_=ast_bln&store_ref=bl_ast_dp_brandlogo_sto&bl_grd_status=override"
+    },
+    "marketplace_id": "ATVPDKIKX0DER",
+    "link": "https://www.amazon.com/s?k=doskocil+dog+crate",
+    "rating": 4.2,
+    "reviews": 810,
+    "description": "From house-breaking pups to halting behavior problems before they start, to keeping them out of trouble when they’re home alone, Petmate offers a variety of wire kennels to meet any need at any stage of life. Created for both comfort and housetraining, the Two-Door Training Retreat kennel boasts sturdy wire construction for safety, rust-resistant black coating for durability, and a leak-proof removable pan for easy cleaning. The double-latch, single front door and side door helps with control, easy in and out access, as well as versatile positioning. A convenient handle on the top makes it easy for pet parents to move from room to room. Available in six different sizes, it also features an adjustable divider that enables the kennel to easily grow with the pet!",
+    "attributes": [
+      {
+        "name": "Brand",
+        "value": "Petmate"
+      },
+      {
+        "name": "Product Dimensions",
+        "value": "24\"L x 18\"W x 19\"H"
+      },
+      {
+        "name": "Material",
+        "value": "Wire"
+      },
+      {
+        "name": "Specific Uses For Product",
+        "value": "Transport"
+      },
+      {
+        "name": "Special Feature",
+        "value": "Adjustable, Comfortable, Durable, Easy To Clean, Leakproof, Lockable, Removable, Secure, Weather Resistant"
+      }
+    ],
+    "feature_bullets": [
+      "Patented easy and secure door operation with 5-Point Door Lock System - eliminates any gaps in the top, sides and middle of the door increasing the strength and safety of the overall door system",
+      "Perfect tool for house training your pet (Crate Measurements: 24\"L x 18\"W x 19\"H)",
+      "No Assembly Required – Easily Folds Flat for Transport and Storage",
+      "Rust-Resistant Electro-Coat Finish increases the life of the crate",
+      "Includes FREE durable, removable polypropylene pan for easy cleaning + FREE divider panel to adjust crate size as your pet grows"
+    ],
+    "variants": [
+      {
+        "asin": "B005U6UOGY",
+        "title": "30.0\"L x 19.0\"W x 21.0\"H",
+        "link": "https://www.amazon.com/dp/B005U6UOGY?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "30.0\"L x 19.0\"W x 21.0\"H"
+          }
+        ]
+      },
+      {
+        "asin": "B005U6UPGS",
+        "title": "19.0\"L x 12.0\"W x 14.0\"H",
+        "link": "https://www.amazon.com/dp/B005U6UPGS?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "19.0\"L x 12.0\"W x 14.0\"H"
+          }
+        ]
+      },
+      {
+        "asin": "B005U6UOEQ",
+        "title": "24.0\"L x 18.0\"W x 19.0\"H",
+        "link": "https://www.amazon.com/dp/B005U6UOEQ?th=1&pcs=1",
+        "is_current_product": true,
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "24.0\"L x 18.0\"W x 19.0\"H"
+          }
+        ]
+      },
+      {
+        "asin": "B005U6UOF0",
+        "title": "90-125 lbs",
+        "link": "https://www.amazon.com/dp/B005U6UOF0?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "90-125 lbs"
+          }
+        ]
+      },
+      {
+        "asin": "B005U6UOD2",
+        "title": "36.0\"L x 23.0\"W x 25.0\"H",
+        "link": "https://www.amazon.com/dp/B005U6UOD2?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "36.0\"L x 23.0\"W x 25.0\"H"
+          }
+        ]
+      },
+      {
+        "asin": "B005U6UOGE",
+        "title": "38.0\"L x 25.0\"W x 28.0\"H",
+        "link": "https://www.amazon.com/dp/B005U6UOGE?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "38.0\"L x 25.0\"W x 28.0\"H"
+          }
+        ]
+      }
+    ],
+    "search_alias": {
+      "title": "Pet Supplies",
+      "value": "pets"
+    },
+    "buybox": {
+      "price": {
+        "raw": "$93.16",
+        "value": 93.16,
+        "symbol": "$",
+        "currency": "USD"
+      },
+      "maximum_order_quantity": 30,
+      "offer_listing_id": "PfBL%2F6xadZhFj5efmPM5sMzCElswfZaGDPb3GupqKgN1gSmxcLaFIpae%2FtPq4AGMvxCtTxS26FMWdaZoGc4mK%2Fc3j9uOm9VI9v9V0qg%2F6iK3xPy8zHsrmjx7PeMYMPVr1KB5mo8A7VC4%2BYI3Hsy8m9ccGyWJ%2F1DCPzRLTDA%2FQz1n7re7Wi%2BWYA%3D%3D",
+      "fulfillment": {
+        "standard_delivery": {
+          "text": "FREE delivery Saturday, April 25. Details",
+          "type": "FREE",
+          "date": "Saturday, April 25"
+        },
+        "third_party_seller": {
+          "id": "A3VZKFNMHAPZBO",
+          "name": "SGHP",
+          "link": "https://www.amazon.com/gp/help/seller/at-a-glance.html/ref=dp_merchant_link?ie=UTF8&seller=A3VZKFNMHAPZBO&asin=B005U6UOEQ&ref_=dp_merchant_link"
+        },
+        "sold_by": "SGHP",
+        "is_sold_by_amazon": true
+      },
+      "availability": "In Stock"
+    },
+    "specifications": [
+      {
+        "name": "Brand Name",
+        "value": "Petmate"
+      },
+      {
+        "name": "Specific Uses For Product",
+        "value": "Transport"
+      },
+      {
+        "name": "Included Components",
+        "value": "Divider"
+      },
+      {
+        "name": "Breed Recommendation",
+        "value": "Small Breeds"
+      },
+      {
+        "name": "Dog Breed Size",
+        "value": "Small"
+      },
+      {
+        "name": "Manufacturer",
+        "value": "Doskocil"
+      },
+      {
+        "name": "UPC",
+        "value": "029695219528"
+      },
+      {
+        "name": "Global Trade Identification Number",
+        "value": "00029695219528"
+      },
+      {
+        "name": "Item Type Name",
+        "value": "Petmate 24-Inch 2-Door Training Retreats Wire Kennel for Dogs, 25 to 30-Pound"
+      },
+      {
+        "name": "Unit Count",
+        "value": "1 Count"
+      },
+      {
+        "name": "Warranty Description",
+        "value": "As Labeled"
+      },
+      {
+        "name": "ASIN",
+        "value": "B005U6UOEQ"
+      },
+      {
+        "name": "Additional Features",
+        "value": "Adjustable, Comfortable, Durable, Easy To Clean, Leakproof, Lockable, Removable, Secure, Weather Resistant"
+      },
+      {
+        "name": "Number of Levels",
+        "value": "1"
+      },
+      {
+        "name": "Number of Doors",
+        "value": "2"
+      },
+      {
+        "name": "Material Type",
+        "value": "Wire"
+      },
+      {
+        "name": "Color",
+        "value": "Black"
+      },
+      {
+        "name": "Item Dimensions L x W x H",
+        "value": "24\"L x 18\"W x 19\"H"
+      },
+      {
+        "name": "Item Weight",
+        "value": "14.1 Pounds"
+      },
+      {
+        "name": "Is Discontinued By Manufacturer",
+        "value": "No"
+      },
+      {
+        "name": "Product Dimensions",
+        "value": "24 x 18 x 19 inches; 14.1 Pounds"
+      },
+      {
+        "name": "Item model number",
+        "value": "21952"
+      },
+      {
+        "name": "Department",
+        "value": "Carriers, Crates & Kennels"
+      },
+      {
+        "name": "Date First Available",
+        "value": "August 22, 2011"
+      },
+      {
+        "name": "Manufacturer",
+        "value": "Doskocil"
+      },
+      {
+        "name": "ASIN",
+        "value": "B005U6UOEQ"
+      }
+    ],
+    "bestsellers_rank": [
+      {
+        "name": "See Top 100 in Pet Supplies",
+        "link": "https://www.amazon.com/gp/bestsellers/pet-supplies/ref=pd_zg_ts_pet-supplies"
+      },
+      {
+        "name": "Basic Dog Crates",
+        "link": "https://www.amazon.com/gp/bestsellers/pet-supplies/3024223011/ref=pd_zg_hrsr_pet-supplies"
+      },
+      {
+        "name": "See Top 100 in Pet Supplies",
+        "link": "https://www.amazon.com/gp/bestsellers/pet-supplies/ref=pd_zg_ts_pet-supplies",
+        "rank": 143813
+      },
+      {
+        "name": "Basic Dog Crates",
+        "link": "https://www.amazon.com/gp/bestsellers/pet-supplies/3024223011/ref=pd_zg_hrsr_pet-supplies",
+        "rank": 350
+      }
+    ],
+    "main_image": "https://m.media-amazon.com/images/I/81abUgMp5uL.jpg",
+    "images": [
+      {
+        "link": "https://m.media-amazon.com/images/I/81abUgMp5uL.jpg",
+        "variant": "MAIN"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/81abUgMp5uL.jpg",
+        "variant": "PT01"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/61SfDko1sYL.jpg",
+        "variant": "PT05"
+      }
+    ]
+  },
+  "similar_item": {
+    "asin": "B09G48J91Y",
+    "title": "Amazon Basics Portable, Foldable Metal Wire Dog Crate with Removable Tray, Double Door, Divider Panel, Easy to Assemble, 22 x 13 x 16 in, Black",
+    "link": "https://www.amazon.com/dp/B09G48J91Y/ref=vp_d_pbs_trans_lp_B005U6UOEQ_pd?_encoding=UTF8&pf_rd_p=f6007f53-9fa1-4c0d-b499-54e844408da9&pf_rd_r=V9ZE43TWH1WAHRSPZTG7&pd_rd_wg=A9u0J&pd_rd_i=B09G48J91Y&pd_rd_w=9PMqb&content-id=amzn1.sym.f6007f53-9fa1-4c0d-b499-54e844408da9&pd_rd_r=e1ca7986-0745-421c-9316-0514fa538c8c&psc=1",
+    "rating": 4.5,
+    "reviews": 11101,
+    "price": {
+      "raw": "$36.95",
+      "value": 36.95,
+      "symbol": "$",
+      "currency": "USD"
+    },
+    "image": "https://m.media-amazon.com/images/I/81gt2S6ovCL.jpg"
+  },
+  "review_results": {
+    "local": [
+      {
+        "id": "RMBA24ZGZIRW7",
+        "asin": "RMBA24ZGZIRW7",
+        "title": "great buy",
+        "link": "https://www.amazon.com/gp/customer-reviews/RMBA24ZGZIRW7/ref=cm_cr_dp_d_rvw_ttl?ie=UTF8",
+        "text": "very happy with product.Well made easy to assemble.",
+        "rating": 5,
+        "date": "Reviewed in the United States on February 20, 2026",
+        "extracted_date": "2026-02-20",
+        "profile": {
+          "id": "AECJQCUKWSG7BMZCPWFQX3LAEOGQ",
+          "name": "Amazon Customer",
+          "link": "https://www.amazon.com/gp/profile/amzn1.account.AECJQCUKWSG7BMZCPWFQX3LAEOGQ"
+        },
+        "is_verified_purchase": true
+      },
+      {
+        "id": "RW6QP7SU14NQW",
+        "asin": "RW6QP7SU14NQW",
+        "title": "Better than plastic for us.",
+        "link": "https://www.amazon.com/gp/customer-reviews/RW6QP7SU14NQW/ref=cm_cr_dp_d_rvw_ttl?ie=UTF8",
+        "text": "I have a standard poodle puppy, and as she grew, I needed a larger kennel. At first we had a smaller wire kennel by Petmate, about 24 inches long, but she outgrew it. I shopped the pet stores to see what they had for full-size dogs. I came home at first with one of those plastic jobs that comes apart in two sections. Although it's maximum dimensions were quite large, I found that the room inside for the dog was diminished by the angled sides. And they are huge. I couldn't get it fit in the space I had. I returned that and decided on this kennel for a couple reasons.1. It fits in the space I have, yet has plenty of room for the dog. Since the sides are straight, the floor space is maximized. Our pup isn't fully grown yet, but she should fit even at 60 or 65 lb.2. It collapses for travel, and is much easier to get through doors and into the car. The metal seems substantial, and I wouldn't want to carry it very far. Even taken apart, the plastic kennels are unwieldy to transport.3. It has two doors, so it works whether the long or short side faces out, and there is a divider partition for when the puppy isn't kennel trained for toileting. I didn't try it, as our pup had never soiled her kennel.4. It isn't satisfactory for shipping, but most of us aren't going to need that.5. It is much less expensive than the pet store brands, and seems more substantial. The directions say it is not for dogs that aren't kennel-trained and that try to escape. A strong frightened dog might break the kennel or injure itself in a panic. It is great for my pup who has taken to the kennel very readily. My son's dog hated his plastic kennel and damaged his teeth trying to chew through the metal bars on the door. Proper training and temperament are very important, regardless of what kind of kennel you use.6. One should remove the pet's collar before placing her in the kennel. When our pup was about 12 weeks old, she woke us up screaming one night. I thought she had caught her body on the kennel and was hurt. Actually, her dog tags had gotten caught and she couldn't free herself. If we had been away, she could have injured herself struggling to get free. So we always remove the collar now before she gets in the kennel. So far she has loved her new \"bed\" and goes in without a fuss.",
+        "rating": 5,
+        "date": "Reviewed in the United States on September 26, 2014",
+        "extracted_date": "2014-09-26",
+        "profile": {
+          "id": "AFS64NQBU34BKNLTETQF7EXW7K4Q",
+          "name": "R. Krom",
+          "link": "https://www.amazon.com/gp/profile/amzn1.account.AFS64NQBU34BKNLTETQF7EXW7K4Q"
+        },
+        "helpful_votes": 2,
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R2TE9I9FJSDUDU",
+        "asin": "R2TE9I9FJSDUDU",
+        "title": "Quality crate with two-door convenience",
+        "link": "https://www.amazon.com/gp/customer-reviews/R2TE9I9FJSDUDU/ref=cm_cr_dp_d_rvw_ttl?ie=UTF8",
+        "text": "Bought this little crate for our new rescue beagle, who loves it. She goes in without hesitation and sleeps comfortably in it. We like the fact that it has doors on both the end and the side, leaving us options for how she can go in and out. My older dog has a larger crate with the opening only on the end. I wish his had a side door as well. The side opening makes it really easy to remove the bedding in her crate for cleaning. The doors themselves have dual latches, and she has not gotten out on the rare occasions when we have had to shut her in -- 99.9 percent of the time, she has free run of when she wants to go in or out. The floor pan is pretty typical for these types of crates -- basic black heavy-duty plastic -- and we have no complaints about it. Overall, this is a great quality crate for the price and I would not hesitate to buy it again.",
+        "rating": 5,
+        "date": "Reviewed in the United States on March 15, 2017",
+        "extracted_date": "2017-03-15",
+        "profile": {
+          "id": "AESQVMFYCSNZ6CIO43GBKJJXOYCA",
+          "name": "KBC",
+          "link": "https://www.amazon.com/gp/profile/amzn1.account.AESQVMFYCSNZ6CIO43GBKJJXOYCA"
+        },
+        "helpful_votes": 2,
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R2JTT990G5BHJ5",
+        "asin": "R2JTT990G5BHJ5",
+        "title": "Puppies love their new home.",
+        "link": "https://www.amazon.com/gp/customer-reviews/R2JTT990G5BHJ5/ref=cm_cr_dp_d_rvw_ttl?ie=UTF8",
+        "text": "Bought this to crate train our new Mini golden doodle and Cavachon (yeah, we went to pick up one puppy, and ended up with two). This model is nice and sturdy, and we have the divder in so they can lay comfortably in, but not much more. We had one \"accident\"4-5 days in from one of the pups, and none since. The gate is so easy to operate that our almost 5 year odl, and two year old are able to open and close it (which it might be nice if the two year odl could nto figure it out so easily. . but I digress). :-) The Cavachone loves it, but being 9 pounds, it's spacious for him to enter. The Golden Doodle is more free spirit, and at 22 pounds it's not for bouncing around in. . but he goes in easily enough. As they grow, we will continue to move the divder, and at full size, they should still be good in the crate. Happy to get this through Amazon for quite a bit less than the crates were at the local pet store.",
+        "rating": 5,
+        "date": "Reviewed in the United States on March 18, 2014",
+        "extracted_date": "2014-03-18",
+        "profile": {
+          "id": "AGEB63PISSTJS6W56KX6SWYFG6WA",
+          "name": "Thomas Nelson",
+          "link": "https://www.amazon.com/gp/profile/amzn1.account.AGEB63PISSTJS6W56KX6SWYFG6WA"
+        },
+        "helpful_votes": 7,
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R29V3NLA3QG6VW",
+        "asin": "R29V3NLA3QG6VW",
+        "title": "Not sturdy enough.",
+        "link": "https://www.amazon.com/gp/customer-reviews/R29V3NLA3QG6VW/ref=cm_cr_dp_d_rvw_ttl?ie=UTF8",
+        "text": "It is a nice crate but my 7 month old blue nose pit has escaped from it 3x and chewed up a $1000 worth of stuff. I have put up the divider and made it smaller. He is only a puppy at 62 lbs and is able to push the bottom out and escape. I have had to reinforce it with 20 zip ties and use carabiners on the doors to prevent escapes.Not sturdy enough. Otherwise it will fold up nicely but not now that I have 20 zip ties holding it shut.",
+        "rating": 1,
+        "date": "Reviewed in the United States on September 16, 2019",
+        "extracted_date": "2019-09-16",
+        "profile": {
+          "id": "AGQWYMQNPQ5GRMBCKOZJQZC4UMTA",
+          "name": "Kevin",
+          "link": "https://www.amazon.com/gp/profile/amzn1.account.AGQWYMQNPQ5GRMBCKOZJQZC4UMTA"
+        },
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R4X91LFGGK8Z9",
+        "asin": "R4X91LFGGK8Z9",
+        "title": "Handle with care",
+        "link": "https://www.amazon.com/gp/customer-reviews/R4X91LFGGK8Z9/ref=cm_cr_dp_d_rvw_ttl?ie=UTF8",
+        "text": "Great",
+        "rating": 5,
+        "date": "Reviewed in the United States on March 1, 2026",
+        "extracted_date": "2026-03-01",
+        "profile": {
+          "id": "AHVDKK7QW55M2T4ODK72ESDCEQ6Q",
+          "name": "delores g.",
+          "link": "https://www.amazon.com/gp/profile/amzn1.account.AHVDKK7QW55M2T4ODK72ESDCEQ6Q"
+        },
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R6TWAVT2ZKRFY",
+        "asin": "R6TWAVT2ZKRFY",
+        "title": "Great at home crate!",
+        "link": "https://www.amazon.com/gp/customer-reviews/R6TWAVT2ZKRFY/ref=cm_cr_dp_d_rvw_ttl?ie=UTF8",
+        "text": "Wonderful and durable crate. The size we purchased is far to large to Tavel with or take apart. We loved that we could adjust it based on the size of our dog and that it could grow with her. This is a great at home crate to use. We would recommend purchasing a separate crate for travel because it’s a little challenging to assemble and it’s large.",
+        "rating": 4,
+        "date": "Reviewed in the United States on February 17, 2021",
+        "extracted_date": "2021-02-17",
+        "profile": {
+          "id": "AFDWHJ67M3YIEOC4GCGEAFDYAMLA",
+          "name": "Chloe Bambrick",
+          "link": "https://www.amazon.com/gp/profile/amzn1.account.AFDWHJ67M3YIEOC4GCGEAFDYAMLA"
+        },
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R3P95AWVLEA1RS",
+        "asin": "R3P95AWVLEA1RS",
+        "title": "Miniature Pinascher Kennel",
+        "link": "https://www.amazon.com/gp/customer-reviews/R3P95AWVLEA1RS/ref=cm_cr_dp_d_rvw_ttl?ie=UTF8",
+        "text": "My min pin has been kennel trained. She is 16 pounds and this fits her well. She is able to move and turn with her blanket. Min pins burrow in blankets so they need the space. So far everything is working well; one month in. The latch and door are secure. When latching the door, you have to lift up the whole door to secure it the latch. This makes the kennel more secure. I also prefer this kennel over the plastic ones, as those can become very hot for the dogs in summer time. During the colder winter months i just drape a blanket over the kennel to make it warmer. This is a great deal and I would recommend for small dogs.",
+        "rating": 5,
+        "date": "Reviewed in the United States on May 7, 2018",
+        "extracted_date": "2018-05-07",
+        "profile": {
+          "id": "AE25OPLLDI6U4VM3XEIUBVY4OBSQ",
+          "name": "Rebecca Dees",
+          "link": "https://www.amazon.com/gp/profile/amzn1.account.AE25OPLLDI6U4VM3XEIUBVY4OBSQ"
+        },
+        "helpful_votes": 5,
+        "is_verified_purchase": true
+      }
+    ],
+    "global": [
+      {
+        "id": "R20WNCURY5X4NQ",
+        "title": "良品です",
+        "text": "ゴールデンレトリーバー30キロに使用しています。耐久性あります。",
+        "rating": 5,
+        "date": "Reviewed in Japan on April 9, 2021",
+        "extracted_date": "2021-04-09",
+        "profile": {
+          "name": "本田眼科クリニック"
+        },
+        "is_verified_purchase": true
+      },
+      {
+        "id": "RG84EEHB5S0SH",
+        "title": "Exactly what I was needing",
+        "text": "Very sturdy kennel, which is the perfect size for my small chihuahua.",
+        "rating": 5,
+        "date": "Reviewed in Canada on September 6, 2019",
+        "extracted_date": "2019-09-06",
+        "profile": {
+          "name": "J.K."
+        },
+        "is_verified_purchase": true
+      },
+      {
+        "id": "RSOZSRMDWWEWX",
+        "title": "車用",
+        "text": "車用に小さいサイズを購入しました。取っ手の当たる部分の塗装がすぐ剥がれました。錆びました。",
+        "rating": 3,
+        "date": "Reviewed in Japan on October 13, 2023",
+        "extracted_date": "2023-10-13",
+        "profile": {
+          "name": "saaaaaya"
+        },
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R1H4Q5S0STAWEQ",
+        "title": "Great Value",
+        "text": "Came as described, great sturdy crate",
+        "rating": 5,
+        "date": "Reviewed in Canada on March 3, 2021",
+        "extracted_date": "2021-03-03",
+        "profile": {
+          "name": "Jody Mitton"
+        },
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R3BXCB5ZJ24K0T",
+        "title": "Good",
+        "text": "Packaging was very sturdy. Arrived undamaged. Easy to unfold. Very convenient. Quality exceeded expectations.",
+        "rating": 5,
+        "date": "Reviewed in Canada on April 19, 2021",
+        "extracted_date": "2021-04-19",
+        "profile": {
+          "name": "Qi Wu"
+        },
+        "is_verified_purchase": true
+      }
+    ]
+  }
+}

--- a/src/data/amazon-products/B01HKF4AQW.json
+++ b/src/data/amazon-products/B01HKF4AQW.json
@@ -1,0 +1,2009 @@
+{
+  "search_metadata": {
+    "id": "search_yawpDZvY5RcK8QBBAvWPdXoM",
+    "status": "Success",
+    "created_at": "2026-04-10T03:02:55Z",
+    "request_time_taken": 2.5,
+    "parsing_time_taken": 0.15,
+    "total_time_taken": 2.65,
+    "request_url": "https://www.amazon.com/dp/B01HKF4AQW?th=1&psc=1",
+    "html_url": "https://www.searchapi.io/api/v1/searches/search_yawpDZvY5RcK8QBBAvWPdXoM.html",
+    "json_url": "https://www.searchapi.io/api/v1/searches/search_yawpDZvY5RcK8QBBAvWPdXoM"
+  },
+  "search_parameters": {
+    "engine": "amazon_product",
+    "asin": "B01HKF4AQW",
+    "amazon_domain": "amazon.com",
+    "delivery_country": "us"
+  },
+  "product": {
+    "asin": "B01HKF4AQW",
+    "title": "EliteField 3-Door Folding Soft Dog Crate with Carrying Bag and Fleece Bed (2 Year Warranty), Indoor & Outdoor Pet Home (42\" L x 28\" W x 32\" H, Black)",
+    "brand_store": {
+      "text": "Brand: EliteField",
+      "link": "https://www.amazon.com/EliteField/b/ref=bl_dp_s_web_3027493011?ie=UTF8&node=3027493011&field-lbr_brands_browse-bin=EliteField"
+    },
+    "marketplace_id": "ATVPDKIKX0DER",
+    "link": "https://www.amazon.com/s?k=top+paw+crate",
+    "rating": 4.5,
+    "reviews": 14726,
+    "description": "The EliteField 3-door soft dog crate is a lightweight and portable pet crate designed to provide a safe and comfortable space for dogs, whether they are at home, traveling, or camping. It is constructed with high-quality materials, including a sturdy steel tubing frame and a durable, water-resistant fabric cover that can be removed and washed for easy maintenance. The crate features three mesh doors located on the top, front, and side, which provide convenient access and improved sunlight and breathability. Additionally, the front and side doors have zipper locks for safety and security. The crate also includes a removable and washable fleece bed for added comfort. In addition to its impressive features, the crate comes with a free carrying bag for easy transport and can be folded down to a height of just 3 inches, making it easy to store and transport. The EliteField soft dog crates are available in a variety of sizes and colors to suit different breeds and preferences. They are easy to set up and fold down, making them a convenient option for pet owners on the go. Backed by a 2-Year Warranty, our commitment to product quality.",
+    "attributes": [
+      {
+        "name": "Color",
+        "value": "Black"
+      },
+      {
+        "name": "Brand",
+        "value": "EliteField"
+      },
+      {
+        "name": "Product Dimensions",
+        "value": "42\"L x 28\"W x 32\"H"
+      },
+      {
+        "name": "Material",
+        "value": "Fabric and Steel"
+      },
+      {
+        "name": "Special Feature",
+        "value": "Adjustable, Airy, Collapsible, Comfortable, Durable, Lightweight, Padded, Removable, Spacious, Washable"
+      }
+    ],
+    "feature_bullets": [
+      "This 42\" soft crate measures 42\" long x 28\" wide x 32\" high, which is 2\" wider and 4\" higher than most other brand 42\" soft crates. The extra space provides a more spacious and comfortable environment for your dog. The soft crate is fully assembled and can be set up and folded down in seconds, without requiring any tools",
+      "The crate frame is constructed from sturdy steel tubing, while the crate cover is made of high-quality, durable 600D fabric and hex mesh fabric. This makes a well-ventilated, stylish, lightweight, and durable crate that provides a comfortable and secure environment for your dog",
+      "The crate features three mesh doors located on the top, front, and side, providing convenient access, improved sunlight, and breathability. The front and side doors have zipper locks to ensure safety and security. Additionally, the crate has two accessory pockets located on the top and back for added storage. The crate cover and bed cover are both removable and washable, making maintenance and cleaning easy",
+      "The crate comes with a free carrying bag and fleece bed. The crate has a handle and hand carrying straps, while the carrying bag features both hand carrying straps and an adjustable padded shoulder strap, providing many carrying options. The crate can be folded down to a height of just 3 inches, making it easy to transport and store",
+      "You will benefit from a 2-YEAR WARRANTY. Our products come with a quality guarantee, money-back guarantee, and customer satisfaction guarantee"
+    ],
+    "variants": [
+      {
+        "asin": "B01HKF4AJE",
+        "title": "20.0\"L x 14.0\"W x 14.0\"H Black",
+        "link": "https://www.amazon.com/dp/B01HKF4AJE?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "20.0\"L x 14.0\"W x 14.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Black"
+          }
+        ]
+      },
+      {
+        "asin": "B01M5B5O3O",
+        "title": "20.0\"L x 14.0\"W x 14.0\"H Green",
+        "link": "https://www.amazon.com/dp/B01M5B5O3O?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "20.0\"L x 14.0\"W x 14.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Green"
+          }
+        ]
+      },
+      {
+        "asin": "B0F8Q96GQX",
+        "title": "24.0\"L x 18.0\"W x 21.0\"H Light Gray",
+        "link": "https://www.amazon.com/dp/B0F8Q96GQX?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "24.0\"L x 18.0\"W x 21.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Light Gray"
+          }
+        ]
+      },
+      {
+        "asin": "B01M8I9719",
+        "title": "20.0\"L x 14.0\"W x 14.0\"H Navy Blue+Gray",
+        "link": "https://www.amazon.com/dp/B01M8I9719?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "20.0\"L x 14.0\"W x 14.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Navy Blue+Gray"
+          }
+        ]
+      },
+      {
+        "asin": "B01M4J2B5S",
+        "title": "36.0\"L x 24.0\"W x 28.0\"H Navy Blue+Gray",
+        "link": "https://www.amazon.com/dp/B01M4J2B5S?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "36.0\"L x 24.0\"W x 28.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Navy Blue+Gray"
+          }
+        ]
+      },
+      {
+        "asin": "B09Y4VYH1N",
+        "title": "42.0\"L x 28.0\"W x 32.0\"H Gray+4 Door Curtains",
+        "link": "https://www.amazon.com/dp/B09Y4VYH1N?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "42.0\"L x 28.0\"W x 32.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Gray+4 Door Curtains"
+          }
+        ]
+      },
+      {
+        "asin": "B018OVFPAQ",
+        "title": "20.0\"L x 14.0\"W x 14.0\"H Sage Green",
+        "link": "https://www.amazon.com/dp/B018OVFPAQ?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "20.0\"L x 14.0\"W x 14.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Sage Green"
+          }
+        ]
+      },
+      {
+        "asin": "B01HKF4AJY",
+        "title": "24.0\"L x 18.0\"W x 21.0\"H Blue Gray",
+        "link": "https://www.amazon.com/dp/B01HKF4AJY?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "24.0\"L x 18.0\"W x 21.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Blue Gray"
+          }
+        ]
+      },
+      {
+        "asin": "B09Y4W7PJC",
+        "title": "42.0\"L x 28.0\"W x 32.0\"H Purple+4 Door Curtains",
+        "link": "https://www.amazon.com/dp/B09Y4W7PJC?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "42.0\"L x 28.0\"W x 32.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Purple+4 Door Curtains"
+          }
+        ]
+      },
+      {
+        "asin": "B09Y4VGDGX",
+        "title": "30.0\"L x 21.0\"W x 24.0\"H Gray+4 Door Curtains",
+        "link": "https://www.amazon.com/dp/B09Y4VGDGX?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "30.0\"L x 21.0\"W x 24.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Gray+4 Door Curtains"
+          }
+        ]
+      },
+      {
+        "asin": "B01M24IDTB",
+        "title": "30.0\"L x 21.0\"W x 24.0\"H Red+Beige",
+        "link": "https://www.amazon.com/dp/B01M24IDTB?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "30.0\"L x 21.0\"W x 24.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Red+Beige"
+          }
+        ]
+      },
+      {
+        "asin": "B004ZUD6CA",
+        "title": "42.0\"L x 28.0\"W x 32.0\"H Maroon",
+        "link": "https://www.amazon.com/dp/B004ZUD6CA?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "42.0\"L x 28.0\"W x 32.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Maroon"
+          }
+        ]
+      },
+      {
+        "asin": "B004ABCK8K",
+        "title": "24.0\"L x 18.0\"W x 21.0\"H Navy Blue",
+        "link": "https://www.amazon.com/dp/B004ABCK8K?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "24.0\"L x 18.0\"W x 21.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Navy Blue"
+          }
+        ]
+      },
+      {
+        "asin": "B01HKF4AKI",
+        "title": "20.0\"L x 14.0\"W x 14.0\"H Royal Blue",
+        "link": "https://www.amazon.com/dp/B01HKF4AKI?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "20.0\"L x 14.0\"W x 14.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Royal Blue"
+          }
+        ]
+      },
+      {
+        "asin": "B004ABJ8NU",
+        "title": "24.0\"L x 18.0\"W x 21.0\"H Beige",
+        "link": "https://www.amazon.com/dp/B004ABJ8NU?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "24.0\"L x 18.0\"W x 21.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Beige"
+          }
+        ]
+      },
+      {
+        "asin": "B09Y4W44DY",
+        "title": "24.0\"L x 18.0\"W x 21.0\"H Blue Gray+4 Door Curtains",
+        "link": "https://www.amazon.com/dp/B09Y4W44DY?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "24.0\"L x 18.0\"W x 21.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Blue Gray+4 Door Curtains"
+          }
+        ]
+      },
+      {
+        "asin": "B01M6WQUAJ",
+        "title": "20.0\"L x 14.0\"W x 14.0\"H Brown+Beige",
+        "link": "https://www.amazon.com/dp/B01M6WQUAJ?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "20.0\"L x 14.0\"W x 14.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Brown+Beige"
+          }
+        ]
+      },
+      {
+        "asin": "B01HKF4B5C",
+        "title": "30.0\"L x 21.0\"W x 24.0\"H Gray",
+        "link": "https://www.amazon.com/dp/B01HKF4B5C?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "30.0\"L x 21.0\"W x 24.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Gray"
+          }
+        ]
+      },
+      {
+        "asin": "B01MAWIYPF",
+        "title": "30.0\"L x 21.0\"W x 24.0\"H Navy Blue+Gray",
+        "link": "https://www.amazon.com/dp/B01MAWIYPF?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "30.0\"L x 21.0\"W x 24.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Navy Blue+Gray"
+          }
+        ]
+      },
+      {
+        "asin": "B004ZUE70A",
+        "title": "36.0\"L x 24.0\"W x 28.0\"H Maroon",
+        "link": "https://www.amazon.com/dp/B004ZUE70A?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "36.0\"L x 24.0\"W x 28.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Maroon"
+          }
+        ]
+      },
+      {
+        "asin": "B07TJ8H32L",
+        "title": "30.0\"L x 21.0\"W x 24.0\"H Brown",
+        "link": "https://www.amazon.com/dp/B07TJ8H32L?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "30.0\"L x 21.0\"W x 24.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Brown"
+          }
+        ]
+      },
+      {
+        "asin": "B09Y4VZHH3",
+        "title": "24.0\"L x 18.0\"W x 21.0\"H Gray+4 Door Curtains",
+        "link": "https://www.amazon.com/dp/B09Y4VZHH3?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "24.0\"L x 18.0\"W x 21.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Gray+4 Door Curtains"
+          }
+        ]
+      },
+      {
+        "asin": "B01M4J2AET",
+        "title": "20.0\"L x 14.0\"W x 14.0\"H Red+Beige",
+        "link": "https://www.amazon.com/dp/B01M4J2AET?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "20.0\"L x 14.0\"W x 14.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Red+Beige"
+          }
+        ]
+      },
+      {
+        "asin": "B01MA3GZ8O",
+        "title": "24.0\"L x 18.0\"W x 21.0\"H Green",
+        "link": "https://www.amazon.com/dp/B01MA3GZ8O?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "24.0\"L x 18.0\"W x 21.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Green"
+          }
+        ]
+      },
+      {
+        "asin": "B07TKCGF34",
+        "title": "20.0\"L x 14.0\"W x 14.0\"H Brown",
+        "link": "https://www.amazon.com/dp/B07TKCGF34?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "20.0\"L x 14.0\"W x 14.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Brown"
+          }
+        ]
+      },
+      {
+        "asin": "B01HKF4AL2",
+        "title": "30.0\"L x 21.0\"W x 24.0\"H Royal Blue",
+        "link": "https://www.amazon.com/dp/B01HKF4AL2?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "30.0\"L x 21.0\"W x 24.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Royal Blue"
+          }
+        ]
+      },
+      {
+        "asin": "B01MA3LY84",
+        "title": "36.0\"L x 24.0\"W x 28.0\"H Green",
+        "link": "https://www.amazon.com/dp/B01MA3LY84?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "36.0\"L x 24.0\"W x 28.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Green"
+          }
+        ]
+      },
+      {
+        "asin": "B01HKF4ALM",
+        "title": "30.0\"L x 21.0\"W x 24.0\"H Black",
+        "link": "https://www.amazon.com/dp/B01HKF4ALM?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "30.0\"L x 21.0\"W x 24.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Black"
+          }
+        ]
+      },
+      {
+        "asin": "B01M3PQCY4",
+        "title": "36.0\"L x 24.0\"W x 28.0\"H Khaki",
+        "link": "https://www.amazon.com/dp/B01M3PQCY4?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "36.0\"L x 24.0\"W x 28.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Khaki"
+          }
+        ]
+      },
+      {
+        "asin": "B01M63ZAT9",
+        "title": "36.0\"L x 24.0\"W x 28.0\"H Red+Beige",
+        "link": "https://www.amazon.com/dp/B01M63ZAT9?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "36.0\"L x 24.0\"W x 28.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Red+Beige"
+          }
+        ]
+      },
+      {
+        "asin": "B01M63V4EP",
+        "title": "42.0\"L x 28.0\"W x 32.0\"H Green",
+        "link": "https://www.amazon.com/dp/B01M63V4EP?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "42.0\"L x 28.0\"W x 32.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Green"
+          }
+        ]
+      },
+      {
+        "asin": "B004ABC13Y",
+        "title": "36.0\"L x 24.0\"W x 28.0\"H Navy Blue",
+        "link": "https://www.amazon.com/dp/B004ABC13Y?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "36.0\"L x 24.0\"W x 28.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Navy Blue"
+          }
+        ]
+      },
+      {
+        "asin": "B004ABHBWK",
+        "title": "36.0\"L x 24.0\"W x 28.0\"H Beige",
+        "link": "https://www.amazon.com/dp/B004ABHBWK?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "36.0\"L x 24.0\"W x 28.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Beige"
+          }
+        ]
+      },
+      {
+        "asin": "B01HKF4ALW",
+        "title": "36.0\"L x 24.0\"W x 28.0\"H Black",
+        "link": "https://www.amazon.com/dp/B01HKF4ALW?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "36.0\"L x 24.0\"W x 28.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Black"
+          }
+        ]
+      },
+      {
+        "asin": "B089CFQFV7",
+        "title": "42.0\"L x 28.0\"W x 32.0\"H Purple",
+        "link": "https://www.amazon.com/dp/B089CFQFV7?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "42.0\"L x 28.0\"W x 32.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Purple"
+          }
+        ]
+      },
+      {
+        "asin": "B01M24E466",
+        "title": "20.0\"L x 14.0\"W x 14.0\"H Khaki",
+        "link": "https://www.amazon.com/dp/B01M24E466?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "20.0\"L x 14.0\"W x 14.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Khaki"
+          }
+        ]
+      },
+      {
+        "asin": "B01MCTE146",
+        "title": "42.0\"L x 28.0\"W x 32.0\"H Brown+Beige",
+        "link": "https://www.amazon.com/dp/B01MCTE146?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "42.0\"L x 28.0\"W x 32.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Brown+Beige"
+          }
+        ]
+      },
+      {
+        "asin": "B00TDDDG56",
+        "title": "20.0\"L x 14.0\"W x 14.0\"H Beige",
+        "link": "https://www.amazon.com/dp/B00TDDDG56?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "20.0\"L x 14.0\"W x 14.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Beige"
+          }
+        ]
+      },
+      {
+        "asin": "B004ZUFF6A",
+        "title": "24.0\"L x 18.0\"W x 21.0\"H Maroon",
+        "link": "https://www.amazon.com/dp/B004ZUFF6A?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "24.0\"L x 18.0\"W x 21.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Maroon"
+          }
+        ]
+      },
+      {
+        "asin": "B01HKF4AN0",
+        "title": "20.0\"L x 14.0\"W x 14.0\"H Blue Gray",
+        "link": "https://www.amazon.com/dp/B01HKF4AN0?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "20.0\"L x 14.0\"W x 14.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Blue Gray"
+          }
+        ]
+      },
+      {
+        "asin": "B09Y4V2GFJ",
+        "title": "20.0\"L x 14.0\"W x 14.0\"H Blue Gray+4 Door Curtains",
+        "link": "https://www.amazon.com/dp/B09Y4V2GFJ?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "20.0\"L x 14.0\"W x 14.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Blue Gray+4 Door Curtains"
+          }
+        ]
+      },
+      {
+        "asin": "B09Y4W7GCC",
+        "title": "24.0\"L x 18.0\"W x 21.0\"H Black+4 Door Curtains",
+        "link": "https://www.amazon.com/dp/B09Y4W7GCC?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "24.0\"L x 18.0\"W x 21.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Black+4 Door Curtains"
+          }
+        ]
+      },
+      {
+        "asin": "B01MEEVFOX",
+        "title": "36.0\"L x 24.0\"W x 28.0\"H Brown+Beige",
+        "link": "https://www.amazon.com/dp/B01MEEVFOX?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "36.0\"L x 24.0\"W x 28.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Brown+Beige"
+          }
+        ]
+      },
+      {
+        "asin": "B089C69HZ6",
+        "title": "20.0\"L x 14.0\"W x 14.0\"H Purple",
+        "link": "https://www.amazon.com/dp/B089C69HZ6?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "20.0\"L x 14.0\"W x 14.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Purple"
+          }
+        ]
+      },
+      {
+        "asin": "B089C6ZZ1M",
+        "title": "24.0\"L x 18.0\"W x 21.0\"H Purple",
+        "link": "https://www.amazon.com/dp/B089C6ZZ1M?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "24.0\"L x 18.0\"W x 21.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Purple"
+          }
+        ]
+      },
+      {
+        "asin": "B01MAWJFF5",
+        "title": "24.0\"L x 18.0\"W x 21.0\"H Red+Beige",
+        "link": "https://www.amazon.com/dp/B01MAWJFF5?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "24.0\"L x 18.0\"W x 21.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Red+Beige"
+          }
+        ]
+      },
+      {
+        "asin": "B018OV6XDE",
+        "title": "20.0\"L x 14.0\"W x 14.0\"H Navy Blue",
+        "link": "https://www.amazon.com/dp/B018OV6XDE?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "20.0\"L x 14.0\"W x 14.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Navy Blue"
+          }
+        ]
+      },
+      {
+        "asin": "B0F8QC211R",
+        "title": "42.0\"L x 28.0\"W x 32.0\"H Light Gray",
+        "link": "https://www.amazon.com/dp/B0F8QC211R?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "42.0\"L x 28.0\"W x 32.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Light Gray"
+          }
+        ]
+      },
+      {
+        "asin": "B09Y4TXJ3G",
+        "title": "30.0\"L x 21.0\"W x 24.0\"H Purple+4 Door Curtains",
+        "link": "https://www.amazon.com/dp/B09Y4TXJ3G?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "30.0\"L x 21.0\"W x 24.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Purple+4 Door Curtains"
+          }
+        ]
+      },
+      {
+        "asin": "B09Y4V6G2W",
+        "title": "36.0\"L x 24.0\"W x 28.0\"H Blue Gray+4 Door Curtains",
+        "link": "https://www.amazon.com/dp/B09Y4V6G2W?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "36.0\"L x 24.0\"W x 28.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Blue Gray+4 Door Curtains"
+          }
+        ]
+      },
+      {
+        "asin": "B01HKF4ANK",
+        "title": "30.0\"L x 21.0\"W x 24.0\"H Blue Gray",
+        "link": "https://www.amazon.com/dp/B01HKF4ANK?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "30.0\"L x 21.0\"W x 24.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Blue Gray"
+          }
+        ]
+      },
+      {
+        "asin": "B07TJ9SSK8",
+        "title": "36.0\"L x 24.0\"W x 28.0\"H Brown",
+        "link": "https://www.amazon.com/dp/B07TJ9SSK8?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "36.0\"L x 24.0\"W x 28.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Brown"
+          }
+        ]
+      },
+      {
+        "asin": "B004ZUCPUE",
+        "title": "36.0\"L x 24.0\"W x 28.0\"H Sage Green",
+        "link": "https://www.amazon.com/dp/B004ZUCPUE?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "36.0\"L x 24.0\"W x 28.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Sage Green"
+          }
+        ]
+      },
+      {
+        "asin": "B01MAW6QF2",
+        "title": "30.0\"L x 21.0\"W x 24.0\"H Khaki",
+        "link": "https://www.amazon.com/dp/B01MAW6QF2?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "30.0\"L x 21.0\"W x 24.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Khaki"
+          }
+        ]
+      },
+      {
+        "asin": "B01M7PLWCC",
+        "title": "42.0\"L x 28.0\"W x 32.0\"H Navy Blue+Gray",
+        "link": "https://www.amazon.com/dp/B01M7PLWCC?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "42.0\"L x 28.0\"W x 32.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Navy Blue+Gray"
+          }
+        ]
+      },
+      {
+        "asin": "B0F8Q9BRH1",
+        "title": "20.0\"L x 14.0\"W x 14.0\"H Light Gray",
+        "link": "https://www.amazon.com/dp/B0F8Q9BRH1?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "20.0\"L x 14.0\"W x 14.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Light Gray"
+          }
+        ]
+      },
+      {
+        "asin": "B018OUW18Q",
+        "title": "20.0\"L x 14.0\"W x 14.0\"H Maroon",
+        "link": "https://www.amazon.com/dp/B018OUW18Q?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "20.0\"L x 14.0\"W x 14.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Maroon"
+          }
+        ]
+      },
+      {
+        "asin": "B09Y4TCQXZ",
+        "title": "36.0\"L x 24.0\"W x 28.0\"H Gray+4 Door Curtains",
+        "link": "https://www.amazon.com/dp/B09Y4TCQXZ?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "36.0\"L x 24.0\"W x 28.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Gray+4 Door Curtains"
+          }
+        ]
+      },
+      {
+        "asin": "B01MCT6257",
+        "title": "42.0\"L x 28.0\"W x 32.0\"H Khaki",
+        "link": "https://www.amazon.com/dp/B01MCT6257?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "42.0\"L x 28.0\"W x 32.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Khaki"
+          }
+        ]
+      },
+      {
+        "asin": "B01MAWFCK5",
+        "title": "24.0\"L x 18.0\"W x 21.0\"H Brown+Beige",
+        "link": "https://www.amazon.com/dp/B01MAWFCK5?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "24.0\"L x 18.0\"W x 21.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Brown+Beige"
+          }
+        ]
+      },
+      {
+        "asin": "B07TJ9KTCK",
+        "title": "24.0\"L x 18.0\"W x 21.0\"H Brown",
+        "link": "https://www.amazon.com/dp/B07TJ9KTCK?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "24.0\"L x 18.0\"W x 21.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Brown"
+          }
+        ]
+      },
+      {
+        "asin": "B01HKF4ANU",
+        "title": "42.0\"L x 28.0\"W x 32.0\"H Blue Gray",
+        "link": "https://www.amazon.com/dp/B01HKF4ANU?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "42.0\"L x 28.0\"W x 32.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Blue Gray"
+          }
+        ]
+      },
+      {
+        "asin": "B004ABH1LG",
+        "title": "42.0\"L x 28.0\"W x 32.0\"H Beige",
+        "link": "https://www.amazon.com/dp/B004ABH1LG?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "42.0\"L x 28.0\"W x 32.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Beige"
+          }
+        ]
+      },
+      {
+        "asin": "B089CNBMF4",
+        "title": "24.0\"L x 18.0\"W x 21.0\"H Camo",
+        "link": "https://www.amazon.com/dp/B089CNBMF4?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "24.0\"L x 18.0\"W x 21.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Camo"
+          }
+        ]
+      },
+      {
+        "asin": "B01HKF4AO4",
+        "title": "42.0\"L x 28.0\"W x 32.0\"H Gray",
+        "link": "https://www.amazon.com/dp/B01HKF4AO4?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "42.0\"L x 28.0\"W x 32.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Gray"
+          }
+        ]
+      },
+      {
+        "asin": "B089C6G4KD",
+        "title": "42.0\"L x 28.0\"W x 32.0\"H Camo",
+        "link": "https://www.amazon.com/dp/B089C6G4KD?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "42.0\"L x 28.0\"W x 32.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Camo"
+          }
+        ]
+      },
+      {
+        "asin": "B01HKF4AOO",
+        "title": "42.0\"L x 28.0\"W x 32.0\"H Royal Blue",
+        "link": "https://www.amazon.com/dp/B01HKF4AOO?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "42.0\"L x 28.0\"W x 32.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Royal Blue"
+          }
+        ]
+      },
+      {
+        "asin": "B09Y4GS32P",
+        "title": "30.0\"L x 21.0\"W x 24.0\"H Blue Gray+4 Door Curtains",
+        "link": "https://www.amazon.com/dp/B09Y4GS32P?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "30.0\"L x 21.0\"W x 24.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Blue Gray+4 Door Curtains"
+          }
+        ]
+      },
+      {
+        "asin": "B0F8Q7NQK5",
+        "title": "30.0\"L x 21.0\"W x 24.0\"H Light Gray",
+        "link": "https://www.amazon.com/dp/B0F8Q7NQK5?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "30.0\"L x 21.0\"W x 24.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Light Gray"
+          }
+        ]
+      },
+      {
+        "asin": "B089C2N61T",
+        "title": "36.0\"L x 24.0\"W x 28.0\"H Camo",
+        "link": "https://www.amazon.com/dp/B089C2N61T?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "36.0\"L x 24.0\"W x 28.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Camo"
+          }
+        ]
+      },
+      {
+        "asin": "B004ABCBBQ",
+        "title": "30.0\"L x 21.0\"W x 24.0\"H Navy Blue",
+        "link": "https://www.amazon.com/dp/B004ABCBBQ?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "30.0\"L x 21.0\"W x 24.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Navy Blue"
+          }
+        ]
+      },
+      {
+        "asin": "B089CLMDHZ",
+        "title": "36.0\"L x 24.0\"W x 28.0\"H Purple",
+        "link": "https://www.amazon.com/dp/B089CLMDHZ?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "36.0\"L x 24.0\"W x 28.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Purple"
+          }
+        ]
+      },
+      {
+        "asin": "B01M63Z829",
+        "title": "42.0\"L x 28.0\"W x 32.0\"H Red+Beige",
+        "link": "https://www.amazon.com/dp/B01M63Z829?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "42.0\"L x 28.0\"W x 32.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Red+Beige"
+          }
+        ]
+      },
+      {
+        "asin": "B004ABBUKY",
+        "title": "42.0\"L x 28.0\"W x 32.0\"H Navy Blue",
+        "link": "https://www.amazon.com/dp/B004ABBUKY?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "42.0\"L x 28.0\"W x 32.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Navy Blue"
+          }
+        ]
+      },
+      {
+        "asin": "B01HKF4AP8",
+        "title": "36.0\"L x 24.0\"W x 28.0\"H Blue Gray",
+        "link": "https://www.amazon.com/dp/B01HKF4AP8?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "36.0\"L x 24.0\"W x 28.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Blue Gray"
+          }
+        ]
+      },
+      {
+        "asin": "B09Y4TW8JG",
+        "title": "42.0\"L x 28.0\"W x 32.0\"H Blue Gray+4 Door Curtains",
+        "link": "https://www.amazon.com/dp/B09Y4TW8JG?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "42.0\"L x 28.0\"W x 32.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Blue Gray+4 Door Curtains"
+          }
+        ]
+      },
+      {
+        "asin": "B01M2X0WVB",
+        "title": "30.0\"L x 21.0\"W x 24.0\"H Green",
+        "link": "https://www.amazon.com/dp/B01M2X0WVB?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "30.0\"L x 21.0\"W x 24.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Green"
+          }
+        ]
+      },
+      {
+        "asin": "B09Y4WF957",
+        "title": "42.0\"L x 28.0\"W x 32.0\"H Black+4 Door Curtains",
+        "link": "https://www.amazon.com/dp/B09Y4WF957?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "42.0\"L x 28.0\"W x 32.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Black+4 Door Curtains"
+          }
+        ]
+      },
+      {
+        "asin": "B01HKF4AQ2",
+        "title": "36.0\"L x 24.0\"W x 28.0\"H Gray",
+        "link": "https://www.amazon.com/dp/B01HKF4AQ2?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "36.0\"L x 24.0\"W x 28.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Gray"
+          }
+        ]
+      },
+      {
+        "asin": "B09Y4VBXSY",
+        "title": "20.0\"L x 14.0\"W x 14.0\"H Gray+4 Door Curtains",
+        "link": "https://www.amazon.com/dp/B09Y4VBXSY?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "20.0\"L x 14.0\"W x 14.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Gray+4 Door Curtains"
+          }
+        ]
+      },
+      {
+        "asin": "B01MAWBEQD",
+        "title": "24.0\"L x 18.0\"W x 21.0\"H Khaki",
+        "link": "https://www.amazon.com/dp/B01MAWBEQD?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "24.0\"L x 18.0\"W x 21.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Khaki"
+          }
+        ]
+      },
+      {
+        "asin": "B01HKF4API",
+        "title": "24.0\"L x 18.0\"W x 21.0\"H Royal Blue",
+        "link": "https://www.amazon.com/dp/B01HKF4API?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "24.0\"L x 18.0\"W x 21.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Royal Blue"
+          }
+        ]
+      },
+      {
+        "asin": "B07TJ9P1ZS",
+        "title": "42.0\"L x 28.0\"W x 32.0\"H Brown",
+        "link": "https://www.amazon.com/dp/B07TJ9P1ZS?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "42.0\"L x 28.0\"W x 32.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Brown"
+          }
+        ]
+      },
+      {
+        "asin": "B09Y4H2FR1",
+        "title": "30.0\"L x 21.0\"W x 24.0\"H Black+4 Door Curtains",
+        "link": "https://www.amazon.com/dp/B09Y4H2FR1?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "30.0\"L x 21.0\"W x 24.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Black+4 Door Curtains"
+          }
+        ]
+      },
+      {
+        "asin": "B09Y4T44R8",
+        "title": "36.0\"L x 24.0\"W x 28.0\"H Purple+4 Door Curtains",
+        "link": "https://www.amazon.com/dp/B09Y4T44R8?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "36.0\"L x 24.0\"W x 28.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Purple+4 Door Curtains"
+          }
+        ]
+      },
+      {
+        "asin": "B089C6V2LZ",
+        "title": "30.0\"L x 21.0\"W x 24.0\"H Camo",
+        "link": "https://www.amazon.com/dp/B089C6V2LZ?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "30.0\"L x 21.0\"W x 24.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Camo"
+          }
+        ]
+      },
+      {
+        "asin": "B01HKF4AQC",
+        "title": "20.0\"L x 14.0\"W x 14.0\"H Gray",
+        "link": "https://www.amazon.com/dp/B01HKF4AQC?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "20.0\"L x 14.0\"W x 14.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Gray"
+          }
+        ]
+      },
+      {
+        "asin": "B09Y4WHD5R",
+        "title": "24.0\"L x 18.0\"W x 21.0\"H Purple+4 Door Curtains",
+        "link": "https://www.amazon.com/dp/B09Y4WHD5R?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "24.0\"L x 18.0\"W x 21.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Purple+4 Door Curtains"
+          }
+        ]
+      },
+      {
+        "asin": "B0DM4FNNHV",
+        "title": "36.0\"L x 24.0\"W x 28.0\"H Light Gray",
+        "link": "https://www.amazon.com/dp/B0DM4FNNHV?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "36.0\"L x 24.0\"W x 28.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Light Gray"
+          }
+        ]
+      },
+      {
+        "asin": "B004ABHFCG",
+        "title": "30.0\"L x 21.0\"W x 24.0\"H Beige",
+        "link": "https://www.amazon.com/dp/B004ABHFCG?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "30.0\"L x 21.0\"W x 24.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Beige"
+          }
+        ]
+      },
+      {
+        "asin": "B09Y4VLRS4",
+        "title": "36.0\"L x 24.0\"W x 28.0\"H Black+4 Door Curtains",
+        "link": "https://www.amazon.com/dp/B09Y4VLRS4?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "36.0\"L x 24.0\"W x 28.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Black+4 Door Curtains"
+          }
+        ]
+      },
+      {
+        "asin": "B09Y4TH61G",
+        "title": "20.0\"L x 14.0\"W x 14.0\"H Purple+4 Door Curtains",
+        "link": "https://www.amazon.com/dp/B09Y4TH61G?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "20.0\"L x 14.0\"W x 14.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Purple+4 Door Curtains"
+          }
+        ]
+      },
+      {
+        "asin": "B089C9LG48",
+        "title": "20.0\"L x 14.0\"W x 14.0\"H Camo",
+        "link": "https://www.amazon.com/dp/B089C9LG48?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "20.0\"L x 14.0\"W x 14.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Camo"
+          }
+        ]
+      },
+      {
+        "asin": "B004ZUC0FO",
+        "title": "42.0\"L x 28.0\"W x 32.0\"H Sage Green",
+        "link": "https://www.amazon.com/dp/B004ZUC0FO?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "42.0\"L x 28.0\"W x 32.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Sage Green"
+          }
+        ]
+      },
+      {
+        "asin": "B01HKF4AQM",
+        "title": "24.0\"L x 18.0\"W x 21.0\"H Black",
+        "link": "https://www.amazon.com/dp/B01HKF4AQM?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "24.0\"L x 18.0\"W x 21.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Black"
+          }
+        ]
+      },
+      {
+        "asin": "B004ZUCWSY",
+        "title": "30.0\"L x 21.0\"W x 24.0\"H Sage Green",
+        "link": "https://www.amazon.com/dp/B004ZUCWSY?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "30.0\"L x 21.0\"W x 24.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Sage Green"
+          }
+        ]
+      },
+      {
+        "asin": "B004ZL7HKQ",
+        "title": "24.0\"L x 18.0\"W x 21.0\"H Sage Green",
+        "link": "https://www.amazon.com/dp/B004ZL7HKQ?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "24.0\"L x 18.0\"W x 21.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Sage Green"
+          }
+        ]
+      },
+      {
+        "asin": "B01M9AXI5K",
+        "title": "24.0\"L x 18.0\"W x 21.0\"H Navy Blue+Gray",
+        "link": "https://www.amazon.com/dp/B01M9AXI5K?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "24.0\"L x 18.0\"W x 21.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Navy Blue+Gray"
+          }
+        ]
+      },
+      {
+        "asin": "B09Y4VD999",
+        "title": "20.0\"L x 14.0\"W x 14.0\"H Black+4 Door Curtains",
+        "link": "https://www.amazon.com/dp/B09Y4VD999?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "20.0\"L x 14.0\"W x 14.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Black+4 Door Curtains"
+          }
+        ]
+      },
+      {
+        "asin": "B01M63ZB7S",
+        "title": "30.0\"L x 21.0\"W x 24.0\"H Brown+Beige",
+        "link": "https://www.amazon.com/dp/B01M63ZB7S?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "30.0\"L x 21.0\"W x 24.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Brown+Beige"
+          }
+        ]
+      },
+      {
+        "asin": "B01HKF4AIU",
+        "title": "24.0\"L x 18.0\"W x 21.0\"H Gray",
+        "link": "https://www.amazon.com/dp/B01HKF4AIU?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "24.0\"L x 18.0\"W x 21.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Gray"
+          }
+        ]
+      },
+      {
+        "asin": "B089CHHXXB",
+        "title": "30.0\"L x 21.0\"W x 24.0\"H Purple",
+        "link": "https://www.amazon.com/dp/B089CHHXXB?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "30.0\"L x 21.0\"W x 24.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Purple"
+          }
+        ]
+      },
+      {
+        "asin": "B01HKF4AJ4",
+        "title": "36.0\"L x 24.0\"W x 28.0\"H Royal Blue",
+        "link": "https://www.amazon.com/dp/B01HKF4AJ4?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "36.0\"L x 24.0\"W x 28.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Royal Blue"
+          }
+        ]
+      },
+      {
+        "asin": "B004ZUEWNM",
+        "title": "30.0\"L x 21.0\"W x 24.0\"H Maroon",
+        "link": "https://www.amazon.com/dp/B004ZUEWNM?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "30.0\"L x 21.0\"W x 24.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Maroon"
+          }
+        ]
+      },
+      {
+        "asin": "B01HKF4AQW",
+        "title": "42.0\"L x 28.0\"W x 32.0\"H Black",
+        "link": "https://www.amazon.com/dp/B01HKF4AQW?th=1&pcs=1",
+        "is_current_product": true,
+        "dimensions": [
+          {
+            "name": "Size",
+            "value": "42.0\"L x 28.0\"W x 32.0\"H"
+          },
+          {
+            "name": "Color",
+            "value": "Black"
+          }
+        ]
+      }
+    ],
+    "search_alias": {
+      "title": "Pet Supplies",
+      "value": "pets"
+    },
+    "buybox": {
+      "price": {
+        "raw": "$118.99",
+        "value": 118.99,
+        "symbol": "$",
+        "currency": "USD"
+      },
+      "original_price": {
+        "raw": "$118.99",
+        "value": 118.99,
+        "symbol": "$",
+        "currency": "USD"
+      },
+      "save": {
+        "percentage": 15
+      },
+      "secondary_buybox": {
+        "title": "Used - Like New",
+        "price": {
+          "raw": "$101.14",
+          "value": 101.14,
+          "symbol": "$",
+          "currency": "USD"
+        }
+      },
+      "maximum_order_quantity": 30,
+      "offer_listing_id": "H%2BE%2BDQBTEmCzsX%2Bi2UDGbnbCEj0TMm1Z%2BRjY7U66VpEBNTPOEzWHtwwIHeJfMLLzmpz%2FPEkNIRiuLA8x2Qmoyn0MKMNMygta4I1ACPymWyGF9nFrD6aefyrwcdbG%2FgriYPX%2FwHgf45FgaZj6BsNqQMbmksP5Y5Xztsc6xXNc9A9hp696Odknkw%3D%3D",
+      "mixed_offers_from": {
+        "price": {
+          "raw": "$101.14",
+          "value": 101.14,
+          "symbol": "$",
+          "currency": "USD"
+        },
+        "link": "https://www.amazon.com/gp/offer-listing/B01HKF4AQW/ref=dp_olp_ALL_mbc?ie=UTF8&condition=ALL"
+      },
+      "fulfillment": {
+        "standard_delivery": {
+          "text": "FREE delivery Tuesday, April 14",
+          "type": "FREE",
+          "date": "Tuesday, April 14"
+        },
+        "fastest_delivery": {
+          "text": "Or fastest delivery Monday, April 13. Order within 57 mins",
+          "type": "fastest",
+          "date": "Monday, April 13"
+        },
+        "third_party_seller": {
+          "id": "A1M8OLL9WUGD90",
+          "name": "EliteField",
+          "link": "https://www.amazon.com/gp/help/seller/at-a-glance.html/ref=dp_merchant_link?ie=UTF8&seller=A1M8OLL9WUGD90&asin=B01HKF4AQW&ref_=dp_merchant_link&isAmazonFulfilled=1"
+        },
+        "ships_from": "Amazon",
+        "sold_by": "EliteField",
+        "is_sold_by_amazon": true
+      },
+      "availability": "In Stock"
+    },
+    "specifications": [
+      {
+        "name": "Brand Name",
+        "value": "EliteField"
+      },
+      {
+        "name": "Target Audience",
+        "value": "Dog"
+      },
+      {
+        "name": "Target Species",
+        "value": "Dog"
+      },
+      {
+        "name": "Manufacturer",
+        "value": "EliteField"
+      },
+      {
+        "name": "UPC",
+        "value": "609465645261"
+      },
+      {
+        "name": "Included Components",
+        "value": "carrying bag, hand carrying straps, handle"
+      },
+      {
+        "name": "Unit Count",
+        "value": "1.00 Count"
+      },
+      {
+        "name": "ASIN",
+        "value": "B01HKF4AQW"
+      },
+      {
+        "name": "Maximum Weight Recommendation",
+        "value": "90 Pounds"
+      },
+      {
+        "name": "Recommended Uses For Product",
+        "value": "Travelling, Camping, Hiking, Walking, Overnight Stays"
+      },
+      {
+        "name": "Item Dimensions L x W x H",
+        "value": "42\"L x 28\"W x 32\"H"
+      },
+      {
+        "name": "Item Weight",
+        "value": "17 Pounds"
+      },
+      {
+        "name": "Size",
+        "value": "42.0\"L x 28.0\"W x 32.0\"H"
+      },
+      {
+        "name": "Additional Features",
+        "value": "Adjustable, Airy, Collapsible, Comfortable, Durable, Lightweight, Padded, Removable, Spacious, Washable"
+      },
+      {
+        "name": "Compatible with Vehicle Type",
+        "value": "Car"
+      },
+      {
+        "name": "Closure Type",
+        "value": "Zipper"
+      },
+      {
+        "name": "Dog Breed Size",
+        "value": "Large"
+      },
+      {
+        "name": "Color",
+        "value": "Black"
+      },
+      {
+        "name": "Product Style",
+        "value": "Durable"
+      },
+      {
+        "name": "Material Type",
+        "value": "Fabric and Steel"
+      },
+      {
+        "name": "Is Discontinued By Manufacturer",
+        "value": "No"
+      },
+      {
+        "name": "Product Dimensions",
+        "value": "42 x 28 x 32 inches; 17 Pounds"
+      },
+      {
+        "name": "Item model number",
+        "value": "SDC-3042BLK"
+      },
+      {
+        "name": "Date First Available",
+        "value": "June 20, 2016"
+      },
+      {
+        "name": "Manufacturer",
+        "value": "EliteField"
+      },
+      {
+        "name": "ASIN",
+        "value": "B01HKF4AQW"
+      }
+    ],
+    "bestsellers_rank": [
+      {
+        "name": "See Top 100 in Pet Supplies",
+        "link": "https://www.amazon.com/gp/bestsellers/pet-supplies/ref=pd_zg_ts_pet-supplies"
+      },
+      {
+        "name": "Basic Dog Crates",
+        "link": "https://www.amazon.com/gp/bestsellers/pet-supplies/3024223011/ref=pd_zg_hrsr_pet-supplies"
+      },
+      {
+        "name": "See Top 100 in Pet Supplies",
+        "link": "https://www.amazon.com/gp/bestsellers/pet-supplies/ref=pd_zg_ts_pet-supplies",
+        "rank": 5295
+      },
+      {
+        "name": "Basic Dog Crates",
+        "link": "https://www.amazon.com/gp/bestsellers/pet-supplies/3024223011/ref=pd_zg_hrsr_pet-supplies",
+        "rank": 13
+      }
+    ],
+    "main_image": "https://m.media-amazon.com/images/I/81eoHEQHU3L.jpg",
+    "images": [
+      {
+        "link": "https://m.media-amazon.com/images/I/81eoHEQHU3L.jpg",
+        "variant": "MAIN"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/81Cs8lKEt5L.jpg",
+        "variant": "PT02"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/81YgT0So3jL.jpg",
+        "variant": "PT03"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/71Nf+RGTVOL.jpg",
+        "variant": "PT04"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/714h48-b9eL.jpg",
+        "variant": "DIMN"
+      }
+    ]
+  },
+  "similar_item": {
+    "asin": "B0C4X9PYXC",
+    "title": "Lesure Shown on TODAY Show Soft Collapsible Dog Crate - 42 Inch Portable Travel Crate for Extra Large Dogs Indoor & Outdoor, 4-Door Foldable Pet Kennel with Mesh Windows, Black",
+    "link": "https://www.amazon.com/dp/B0C4X9PYXC/ref=vp_d_cpf-substitute-widget-prsubs_pd?_encoding=UTF8&pf_rd_p=3b384b6f-3e1a-4384-bf9e-527aad01ce71&pf_rd_r=T6BRPE0BAFACTP8AMXX6&pd_rd_wg=sLeGH&pd_rd_i=B0C4X9PYXC&pd_rd_w=Mw99V&content-id=amzn1.sym.3b384b6f-3e1a-4384-bf9e-527aad01ce71&pd_rd_r=c87d078e-bbc3-4a21-8bd5-52a5ec0329b9&psc=1",
+    "rating": 4.5,
+    "reviews": 1357,
+    "price": {
+      "raw": "$145.99",
+      "value": 145.99,
+      "symbol": "$",
+      "currency": "USD"
+    },
+    "image": "https://m.media-amazon.com/images/I/91SPxibVGHL.jpg"
+  },
+  "review_results": {
+    "local": [
+      {
+        "id": "R1OIT089AB75Q2",
+        "asin": "R1OIT089AB75Q2",
+        "title": "Great crate!",
+        "link": "https://www.amazon.com/gp/customer-reviews/R1OIT089AB75Q2/ref=cm_cr_dp_d_rvw_ttl?ie=UTF8",
+        "text": "I have had an excellent crate for 15 years that finally broke down and I was looking for a replacement. So disappointed to learn that the company no longer exists and I could not get another for our new puppy. After much searching and review reading, I selected this one and have been very happy with its performance. Good quality construction, easy to set up and fold down. The carrying case with shoulder strap makes it really easy to carry up and down the stair and get into the car. So its super convenient. But best of all, the new puppy loves it. Our Sully sleeps through the night very peacefully in this crate. He looks very comfortable on the cushioned mat that is included. The crate is sturdy enough to contain our high energy puppy easily. Zippers are strong and have clips to anchor them so pokey little noses cannot force the zipper to open. I followed the size guide and he has plenty of room. This has been an excellent purchase and I highly recommend this crate. It is well made, worth the price, and I expect it to last a long time.",
+        "rating": 5,
+        "date": "Reviewed in the United States on February 20, 2026",
+        "extracted_date": "2026-02-20",
+        "profile": {
+          "id": "AF7E32CIUOCR5SGYSV3VDH5JSPEQ",
+          "name": "JLS",
+          "link": "https://www.amazon.com/gp/profile/amzn1.account.AF7E32CIUOCR5SGYSV3VDH5JSPEQ"
+        },
+        "helpful_votes": 2,
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R1SDCWEVHNAPS0",
+        "asin": "R1SDCWEVHNAPS0",
+        "title": "GREAT PURCHASE *****",
+        "link": "https://www.amazon.com/gp/customer-reviews/R1SDCWEVHNAPS0/ref=cm_cr_dp_d_rvw_ttl?ie=UTF8",
+        "text": "I purchased this dog crate a couple of months ago and use it daily. The shipping was very quick and it arrived in good shape from being packed well in the cardboard shipping box. I will give a detailed description of the crate because there are not many times that one truly feels like they got a great bang for your buck on a purchase. My 6 year old 70# lab was crate trained since she was a puppy using a large wire crate. When she was puppy @ times we did shut her door when we had company over but basically the wire crate was her bed/den with the door left open after she was fully potty trained. Happily she did not make messes after being potty trained and never chewed on things to have to contain her all the time when we left the house. Shoes were kept high off floor then. With crate use she never seemed attracted to sleeping on the furniture either. Her crate was her safe and comfortable place to sleep in. I also put a sheet over the crate to make it more private for her. I purchased this soft-sided crate to possibly remove the wire crate and put @ a different house so she would have a 'home' away from home when I was gone. The soft-sided crate would be her main crate @ home affording more options of easily taking it down and transporting to another location. This was/is my goal. This crate will do all of that. It's too big to set up open in the back seat of my sedan (perhaps the size down would). If I had an SUV I know I would be able to comfortably travel with her long distance having it set up for use during travel. I did get the slightly bigger one to make sure it was roomy enough. The next size down was smaller than the wire crate and she would not have had as much room for a large size dog and as she ages and sprawls out. It fits well between the front and back seats to transport for destination use when it is folded flat and in the zippered tote. It does fit in the trunk of my full size car but does not leave room for too much else other than assorted smaller duffle bags and totes. Not a problem for traveling if it's just the 2 of us. My dog no longer chews on anything other than rawhides so I can't speak about how it would stand up to that type of abuse. Or if your dog took their nails and clawed on the screen doors and windows trying to get out. I don't have that problem. I can assure you that the construction of this crate is exceptional in quality and detailing and craftsmanship. Very easy to set-up. Didn't even need the cheat sheet. The crate features an attached and removable pouch with hand-strap for supplies on one end. If you used this for a day trip or camping a handy feature. Another non-removable zippered pouch is attached to the top of the crate for supplies also. The top of the crate is also the zippered ventilating mesh door with crossed X webbed strapping with a Velcro closure like a duffel bag. A nice handle to easily pick the crate up to move. One narrow end of the crate has a zippered mesh door and one of the long sides has a zippered mesh door that you can unzip, roll up and Velcro to keep the door open. 5 sides of this crate have the mesh for ventilation with 3 zippered openings. The top of the crate is also a zippered door for access. I can't see using this feature unless your dog is a light weight. I could see how this crate would be handy if you wanted a secure place for a new litter of puppies although over time the crate would probably be abused with their messes and friskiness. Probably would hold up to a power wash or back yard hose down to clean up rather easily and air dry. But a good quite spot for a birthing I imagine. I've never bred dogs but as a kid we had to give our dog a nice quite place to have her puppies. The floor of the crate is made of the same rubberized canvas material that the rest of the crate is constructed with. Very durable and probably water resistant. Obviously with the mesh top not waterproof unless a tarp was also used. I'm not a camper but I believe if I was, this crate would be exactly what I would want. If it was not mentioned in the other reviews the crate came with a very large zippered tote to store/transport the crate when it is folded flat with hand/shoulder straps. I was pleasantly surprised with this handy addition of the carrier tote. Also included was a small leash and a bottom cushion that is sheep skin like fabric with the underside rubberized. This pad is thin. I have put her very large and thick floor pillow in the crate for her daily use. It fits perfect and what dream bedroom she has. She loves this crate and adapted to it right away when I set it up for home use within hours. The dog has a tendency to nap in her wire crate during the day in a different room and this crate @ night and during the day when I am on the computer. I lightly draped a sheet on this one too to create her 'den'. I can leave the house and know she is in either crate napping and not on the furniture. The construction is superb for the way we use the crate but if you had a high energy, chewing and clawing dog with the doors zippered shut this crate probably would not hold up over time. I did a lot of research before I purchased this crate. I changed from purchasing another wire one to ultimately a more practical 2nd crate that is very high quality and affords more options for portability if we turn into campers or visit friends and family on a road trip. One of the best purchases that I have made. A long review but I wanted to point out the exception quality and extra features that this crate has and that I almost made a mistake buying another clumsy wire crate that would not have been as suitable for our needs. I will mention also that the color is great now that it seems to be permanent in the house and not just for travel. I'm happy it is nice basic beige with black trim instead of a bold color. If you plan to travel/camp with your dog and have enough room I would suggest this crate also for a smaller sized dog giving your pet plenty of room to move around in. If your pet chews or claws I don't think this crate would work out for long. If these are not your issues, the crate will be perfect and you will be very pleased like me with the purchase.",
+        "rating": 5,
+        "date": "Reviewed in the United States on June 1, 2011",
+        "extracted_date": "2011-06-01",
+        "profile": {
+          "id": "AGPRQA7MMYUZISLM3MEA4ANJGD6A",
+          "name": "updiane",
+          "link": "https://www.amazon.com/gp/profile/amzn1.account.AGPRQA7MMYUZISLM3MEA4ANJGD6A"
+        },
+        "helpful_votes": 62,
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R20MLIIBUZPI9X",
+        "asin": "R20MLIIBUZPI9X",
+        "title": "BUY IT! 8 years, and still going!",
+        "link": "https://www.amazon.com/gp/customer-reviews/R20MLIIBUZPI9X/ref=cm_cr_dp_d_rvw_ttl?ie=UTF8",
+        "text": "I love this crate! I purchased the 36\" L x 24\" W x 28\" H size in December 2017, and still use it to this day (Sept 2025). It fits perfectly in my 2018 Subaru Forester. It is ridiculously durable. Easy to setup or take down for storage. I can't even begin to explain how much usage this thing has seen throughout the years with all our trips and moving. It's probably traveled through at least 15 states, if not more. It's my fur babies safe space when we travel. The fleece bed lasted maybe a year before it was replaced with a more cushioned dog bed. I've also since added a fan in it for better air flow, when the car is fully loaded, and a camera. It was first used by my 65lb yellow lab and is now used by my 95lb lab/pyrenees mix. It is spacious and both can stand up and change positions while on the road. They never were uncomfortable since there is enough room to move around in it easily. It's held up so well that even my friends and family have started to buy it and the quality is still the same. Great purchase!! You will not be disappointed!",
+        "rating": 5,
+        "date": "Reviewed in the United States on September 17, 2025",
+        "extracted_date": "2025-09-17",
+        "profile": {
+          "id": "AHOQ7DLT62RSYLHSKFPY6WRBIIRQ",
+          "name": "TN",
+          "link": "https://www.amazon.com/gp/profile/amzn1.account.AHOQ7DLT62RSYLHSKFPY6WRBIIRQ"
+        },
+        "helpful_votes": 30,
+        "images": [
+          "https://m.media-amazon.com/images/I/71cmY8pmlXL.jpg",
+          "https://m.media-amazon.com/images/I/71TcmPiX4qL.jpg",
+          "https://m.media-amazon.com/images/I/819PWoGbq5L.jpg",
+          "https://m.media-amazon.com/images/I/61d80VTkbmL.jpg",
+          "https://m.media-amazon.com/images/I/71XSGUYwaCL.jpg"
+        ],
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R5563Z03BHUTJ",
+        "asin": "R5563Z03BHUTJ",
+        "title": "Just what I wanted",
+        "link": "https://www.amazon.com/gp/customer-reviews/R5563Z03BHUTJ/ref=cm_cr_dp_d_rvw_ttl?ie=UTF8",
+        "text": "Crate is well made. It is lightweight & my dog loves it. Easy to set up & take down. Came with a carrying case, so you can easily transport it. Folds up nicely",
+        "rating": 5,
+        "date": "Reviewed in the United States on December 27, 2025",
+        "extracted_date": "2025-12-27",
+        "profile": {
+          "id": "AE2OA6H4SJDZPFUR5JWUVYRVEQ4A",
+          "name": "Carol",
+          "link": "https://www.amazon.com/gp/profile/amzn1.account.AE2OA6H4SJDZPFUR5JWUVYRVEQ4A"
+        },
+        "helpful_votes": 2,
+        "is_verified_purchase": true
+      }
+    ],
+    "global": [
+      {
+        "id": "R1CCSXDJIV7M8U",
+        "title": "Good quality but chemical smell",
+        "text": "The quality seemed good, but unfortunately the chemical smell never went away, even after a few days. I had to return it in the end.",
+        "rating": 4,
+        "date": "Reviewed in Canada on October 17, 2025",
+        "extracted_date": "2025-10-17",
+        "profile": {
+          "name": "Fadi Choueri"
+        },
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R2R5GY1MC40ZZ0",
+        "title": "Great purchase!",
+        "text": "Easy set up and take down, shoulder strap and mat are included.I like that your 36” option is more spacious than others.Worked out great!",
+        "rating": 5,
+        "date": "Reviewed in Canada on October 16, 2019",
+        "extracted_date": "2019-10-16",
+        "profile": {
+          "name": "Kim"
+        },
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R2RUZFGYO5YS71",
+        "title": "Amazing service and communication",
+        "text": "Thank you so much for being on top of this purchase. Seller contacted me as they saw a concern. Very proactive. They also followed up to ensure things went well. My dog loves the two houses you shipped so well. One for home and one for the office. Fantastic!",
+        "rating": 5,
+        "date": "Reviewed in Canada on January 20, 2024",
+        "extracted_date": "2024-01-20",
+        "profile": {
+          "name": "Zowie"
+        },
+        "images": [
+          "https://m.media-amazon.com/images/I/71Oz8pZ3BkL.jpg",
+          "https://m.media-amazon.com/images/I/71Ie4OJHucL.jpg"
+        ],
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R2SOW9J989MZFD",
+        "title": "Easy to assemble, good quality",
+        "text": "I'm really happy with this kennel. It's easy to assemble and disassemble. The materials appear to be high quality. I would purchase this again. This is in contrast to the amazon basics soft sided kennel that I also purchased. Spend the extra money!!",
+        "rating": 5,
+        "date": "Reviewed in Canada on March 21, 2024",
+        "extracted_date": "2024-03-21",
+        "profile": {
+          "name": "Amazon Customer"
+        },
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R2ZTB5BP0LRX7T",
+        "title": "Excellent crate",
+        "text": "I’ve ordered this crate twice, the first one in January which never arrived and I received a full refund. I was searching for an alternative crate in the UK for my miniature poodle but because she’s quite tall but although not massive I struggled to find one so eventually I ordered this one again. This time it arrived very quickly (dispatched on Friday evening from the US, arrived on Monday morning to me in the UK!), the crate is an excellent quality, seems very sturdy and stylish as well. 24inch first nicely on the back seat of my car. Very pleased with my purchase!",
+        "rating": 5,
+        "date": "Reviewed in the United Kingdom on July 20, 2020",
+        "extracted_date": "2020-07-20",
+        "profile": {
+          "name": "Amazon Customer"
+        },
+        "is_verified_purchase": true
+      }
+    ]
+  }
+}

--- a/src/data/amazon-products/B09T1P2B7J.json
+++ b/src/data/amazon-products/B09T1P2B7J.json
@@ -1,0 +1,482 @@
+{
+  "search_metadata": {
+    "id": "search_o87gAV43YWh6b0qrWk1PwrlO",
+    "status": "Success",
+    "created_at": "2026-04-10T03:02:51Z",
+    "request_time_taken": 2.5,
+    "parsing_time_taken": 0.13,
+    "total_time_taken": 2.63,
+    "request_url": "https://www.amazon.com/dp/B09T1P2B7J?th=1&psc=1",
+    "html_url": "https://www.searchapi.io/api/v1/searches/search_o87gAV43YWh6b0qrWk1PwrlO.html",
+    "json_url": "https://www.searchapi.io/api/v1/searches/search_o87gAV43YWh6b0qrWk1PwrlO"
+  },
+  "search_parameters": {
+    "engine": "amazon_product",
+    "asin": "B09T1P2B7J",
+    "amazon_domain": "amazon.com",
+    "delivery_country": "us"
+  },
+  "product": {
+    "asin": "B09T1P2B7J",
+    "title": "PetSafe Happy Ride Collapsible Travel Crate - Safe Travel Containment with Heavy Duty Aluminum Frame, Mesh Windows, Convenient Storage Pockets & Secure Seat Belt Access - Road Trip Crate",
+    "brand_store": {
+      "id": "98286354-F1CF-4035-931E-969101222584",
+      "text": "Visit the PetSafe Store",
+      "link": "https://www.amazon.com/stores/PetSafe/page/98286354-F1CF-4035-931E-969101222584?lp_asin=B09T1P2B7J&ref_=ast_bln&store_ref=bl_ast_dp_brandlogo_sto"
+    },
+    "marketplace_id": "ATVPDKIKX0DER",
+    "link": "https://www.amazon.com/s?k=portable+pet+crate+for+car",
+    "rating": 4.6,
+    "reviews": 593,
+    "bought_past_month": "200+ bought in past month",
+    "description": "Give your furry co-pilot the comfort and security they deserve with the PetSafe Happy Ride Collapsible Travel Crate, a travel-friendly backseat crate designed for safe travel containment and stress-free road trips. This soft sided dog crate features a durable construction with a heavy duty aluminum frame, mesh windows for ventilation, and dual side doors for easy access from either seat. The spacious pet box fits one back seat, leaving room for passengers while keeping your pet safely contained to reduce driver distraction. A headrest strap and seat belt slits allow you to securely fasten the carrier in place so it won't move when your pet does. The minimalist cabin design includes a removable waterproof fleece cover over a cushioned pad, offering comfortable seating that’s machine washable for easy cleaning. Two convenient storage pockets make it simple to store treats, leashes, and toys, while drawstring openings allow you to give your pup a quick pet without unzipping the crate. With a leather handle and lightweight carrier build, this foldable pet crate is easy to carry, easy to store, and perfect for car travel. Whether you're heading out for a weekend getaway or a cross-country adventure, the PetSafe Happy Ride Collapsible Travel Crate will keep your pet safe, secure, and comfortable wherever the road takes you. Since 1988, PetSafe has been driven by a simple belief: safe, healthy pets lead to happier lives for pets and their families. For over 25 years, we've been dedicated to enhancing the lives of pets and the people who love them, treating every pet as a cherished family member and delivering life-changing innovations designed to enrich every moment. With U.S. roots and a global reach, our vet- and trainer-recommended products are built for every pet and backed by exceptional customer support. From backyards to dog parks, we're on a mission to create fields of joy for happy, healthy, and safe pets.",
+    "attributes": [
+      {
+        "name": "Color",
+        "value": "Gray/Blue"
+      },
+      {
+        "name": "Brand",
+        "value": "PetSafe"
+      },
+      {
+        "name": "Product Dimensions",
+        "value": "27\"L x 19\"W x 28\"H"
+      },
+      {
+        "name": "Material",
+        "value": "Aluminum"
+      },
+      {
+        "name": "Special Feature",
+        "value": "Collapsible"
+      }
+    ],
+    "feature_bullets": [
+      "Safe Travel Containment: The PetSafe Happy Ride Collapsible Travel Crate installs securely into the backseat with seatbelt straps and a headrest loop to keep your pet safely contained during car rides",
+      "Foldable & Travel Friendly: This lightweight carrier with leather handles folds flat for space-saving easy storage, perfect for road trips and compact cars",
+      "Comfort & Convenience: Soft-sided dog crate with mesh windows, a waterproof fleece pad, dual side doors, and convenient storage pockets offers cozy seating and easy access",
+      "Global Mission, Local Care: With U.S. roots and worldwide reach, PetSafe delivers vet- and trainer-recommended solutions and exceptional customer support to create fields of joy for pets",
+      "25 Years of Trust: Since 1998, PetSafe has created safe, innovative, and trusted products that bring joy, enhance pet lives, and support the lifelong bond between pets and their families"
+    ],
+    "search_alias": {
+      "title": "Pet Supplies",
+      "value": "pets"
+    },
+    "buybox": {
+      "price": {
+        "raw": "$137.99",
+        "value": 137.99,
+        "symbol": "$",
+        "currency": "USD"
+      },
+      "original_price": {
+        "raw": "$174.99",
+        "value": 174.99,
+        "symbol": "$",
+        "currency": "USD"
+      },
+      "save": {
+        "percentage": 21
+      },
+      "secondary_buybox": {
+        "title": "Used - Like New",
+        "price": {
+          "raw": "$122.44",
+          "value": 122.44,
+          "symbol": "$",
+          "currency": "USD"
+        }
+      },
+      "maximum_order_quantity": 30,
+      "offer_listing_id": "mK7%2BTrUU7ZObAnq5JgOKuUsnKu9JsGPC5eMjfeUFQ%2BB3lqRsDF6ZM1CkeSUVBDiDKI9UTQVusHpB%2FUlEDYeV%2B0f9Wjr%2F5ty9bVFngjFEPQqDXOE8DZwhh8daTOuhwfJpQ6Eb1igQjAQIGs21krGcbw%3D%3D",
+      "mixed_offers_from": {
+        "price": {
+          "raw": "$121.10",
+          "value": 121.1,
+          "symbol": "$",
+          "currency": "USD"
+        },
+        "link": "https://www.amazon.com/gp/offer-listing/B09T1P2B7J/ref=dp_olp_ALL_mbc?ie=UTF8&condition=ALL"
+      },
+      "fulfillment": {
+        "standard_delivery": {
+          "text": "FREE delivery Tuesday, April 14",
+          "type": "FREE",
+          "date": "Tuesday, April 14"
+        },
+        "fastest_delivery": {
+          "text": "Or Prime members get FREE delivery Saturday, April 11. Order within 57 mins. Join Prime",
+          "type": "FREE",
+          "date": "Saturday, April 11"
+        },
+        "ships_from": "Amazon Resale",
+        "sold_by": "Amazon.com",
+        "is_sold_by_amazon": true
+      },
+      "availability": "In Stock"
+    },
+    "specifications": [
+      {
+        "name": "Brand Name",
+        "value": "PetSafe"
+      },
+      {
+        "name": "Target Audience",
+        "value": "Dog"
+      },
+      {
+        "name": "Target Species",
+        "value": "Dog"
+      },
+      {
+        "name": "Manufacturer",
+        "value": "Radio Systems Corporation"
+      },
+      {
+        "name": "UPC",
+        "value": "729849172890"
+      },
+      {
+        "name": "Item Type Name",
+        "value": "PetSafe® Happy Ride® Collapsible Travel Crate"
+      },
+      {
+        "name": "Included Components",
+        "value": "Collapsible Travel Crate, Quick start guide, Removable floor pad"
+      },
+      {
+        "name": "Unit Count",
+        "value": "1 Count"
+      },
+      {
+        "name": "Warranty Description",
+        "value": "1 Year Limited Warranty"
+      },
+      {
+        "name": "ASIN",
+        "value": "B09T1P2B7J"
+      },
+      {
+        "name": "Material Type",
+        "value": "Aluminum"
+      },
+      {
+        "name": "Item Dimensions L x W x H",
+        "value": "27\"L x 19\"W x 28\"H"
+      },
+      {
+        "name": "Item Weight",
+        "value": "5.69 Kilograms"
+      },
+      {
+        "name": "Size",
+        "value": "Large, Small"
+      },
+      {
+        "name": "Additional Features",
+        "value": "Collapsible"
+      },
+      {
+        "name": "Compatible with Vehicle Type",
+        "value": "Car"
+      },
+      {
+        "name": "Closure Type",
+        "value": "Zipper"
+      },
+      {
+        "name": "Dog Breed Size",
+        "value": "Large, Small"
+      },
+      {
+        "name": "Color",
+        "value": "Gray/Blue"
+      },
+      {
+        "name": "Product Style",
+        "value": "Modern"
+      },
+      {
+        "name": "Maximum Weight Recommendation",
+        "value": "60 Pounds"
+      },
+      {
+        "name": "Recommended Uses For Product",
+        "value": "Traveling"
+      },
+      {
+        "name": "Product Dimensions",
+        "value": "27 x 19 x 28 inches; 12.54 Pounds"
+      },
+      {
+        "name": "Item model number",
+        "value": "ZTV00-17289"
+      },
+      {
+        "name": "Date First Available",
+        "value": "March 5, 2022"
+      },
+      {
+        "name": "Manufacturer",
+        "value": "Radio Systems Corporation"
+      },
+      {
+        "name": "ASIN",
+        "value": "B09T1P2B7J"
+      }
+    ],
+    "bestsellers_rank": [
+      {
+        "name": "See Top 100 in Pet Supplies",
+        "link": "https://www.amazon.com/gp/bestsellers/pet-supplies/ref=pd_zg_ts_pet-supplies"
+      },
+      {
+        "name": "Basic Dog Crates",
+        "link": "https://www.amazon.com/gp/bestsellers/pet-supplies/3024223011/ref=pd_zg_hrsr_pet-supplies"
+      },
+      {
+        "name": "See Top 100 in Pet Supplies",
+        "link": "https://www.amazon.com/gp/bestsellers/pet-supplies/ref=pd_zg_ts_pet-supplies",
+        "rank": 20891
+      },
+      {
+        "name": "Basic Dog Crates",
+        "link": "https://www.amazon.com/gp/bestsellers/pet-supplies/3024223011/ref=pd_zg_hrsr_pet-supplies",
+        "rank": 52
+      }
+    ],
+    "main_image": "https://m.media-amazon.com/images/I/81LvTZeUnwL.jpg",
+    "images": [
+      {
+        "link": "https://m.media-amazon.com/images/I/81LvTZeUnwL.jpg",
+        "variant": "MAIN"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/816dFuAFDML.jpg",
+        "variant": "PT01"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/91HSbZ96gLL.jpg",
+        "variant": "PT02"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/81tQwaAx5qL.jpg",
+        "variant": "PT03"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/91OZc214gyL.jpg",
+        "variant": "PT04"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/81DjK7gtiWL.jpg",
+        "variant": "PT05"
+      }
+    ]
+  },
+  "similar_item": {
+    "asin": "B0722L46DF",
+    "title": "Amazon Basics Portable Folding Soft Dog Crate, Double Door, Collapsible Travel Kennel, Easy to Set Up, Sturdy, Secure, XL 42\" x 31\" x 31\", Tan",
+    "link": "https://www.amazon.com/dp/B0722L46DF/ref=vp_d_pb_TIER2_pbxcovv3_lp_B09T1P2B7J_pd?_encoding=UTF8&pf_rd_p=833279f6-3822-4089-a177-f6c02b33c169&pf_rd_r=YXJ0WA74PEF1M3DPZSQZ&pd_rd_wg=5nLWC&pd_rd_i=B0722L46DF&pd_rd_w=lVbCW&content-id=amzn1.sym.833279f6-3822-4089-a177-f6c02b33c169&pd_rd_r=908b16ec-39ac-416e-84c1-40071c4bbf04&psc=1",
+    "rating": 4.5,
+    "reviews": 18745,
+    "price": {
+      "raw": "$83.99",
+      "value": 83.99,
+      "symbol": "$",
+      "currency": "USD"
+    },
+    "image": "https://m.media-amazon.com/images/I/91p+6sayHyL.jpg"
+  },
+  "frequently_bought_together": {
+    "total_price": {
+      "raw": "$179.33",
+      "value": 179.33,
+      "symbol": "$",
+      "currency": "USD"
+    },
+    "products": [
+      {
+        "asin": "B09T1P2B7J",
+        "title": "PetSafe Happy Ride Collapsible Travel Crate - Safe Travel Containment with Heavy Duty Aluminum Frame, Mesh Windows, Convenient Storage Pockets & Secure Seat Belt Access - Road Trip Crate",
+        "link": "https://www.amazon.com/dp/B09T1P2B7J",
+        "price": {
+          "symbol": "$",
+          "currency": "USD",
+          "value": 137.99,
+          "raw": "$137.99"
+        },
+        "image": "https://images-na.ssl-images-amazon.com/images/I/81LvTZeUnwL.jpg"
+      },
+      {
+        "asin": "B00MW8G3YU",
+        "title": "Amazon Basics Leak-Proof Dog and Puppy Potty Training Pee Pads with Quick-Dry 5-Layer Super Absorbent Surface for Dog Training, Floor Protection, Regular Size 22x22\", Blue & White, 50 Count",
+        "link": "https://www.amazon.com/Amazon-Basics-Leak-Proof-Quick-Dry-Absorbency/dp/B00MW8G3YU/ref=pd_bxgy_thbs_d_sccl_1/134-5295463-4518158?pd_rd_w=j4B97&content-id=amzn1.sym.9bef5913-5870-4504-8883-3ba89d7f8e39&pf_rd_p=9bef5913-5870-4504-8883-3ba89d7f8e39&pf_rd_r=YXJ0WA74PEF1M3DPZSQZ&pd_rd_wg=La4m5&pd_rd_r=6bb6d961-8dad-486d-92e4-607fb57219a6&pd_rd_i=B00MW8G3YU&psc=1",
+        "price": {
+          "symbol": "$",
+          "currency": "USD",
+          "value": 10.49,
+          "raw": "$10.49"
+        },
+        "image": "https://images-na.ssl-images-amazon.com/images/I/71Co+yjlWAL.jpg"
+      },
+      {
+        "asin": "B0CLQLS8D3",
+        "title": "Dog Travel Bag All-in-One Set: DELOMO 25L Airline Approved Dog Travel Backpack with 2 Food Containers + 2 Collapsible Bowls + 1 Waterproof Mat for Weekend to Week-Long Pet Travel, Camping, Road Trips",
+        "link": "https://www.amazon.com/Dog-Travel-Bag-All-One/dp/B0CLQLS8D3/ref=pd_bxgy_thbs_d_sccl_2/134-5295463-4518158?pd_rd_w=j4B97&content-id=amzn1.sym.9bef5913-5870-4504-8883-3ba89d7f8e39&pf_rd_p=9bef5913-5870-4504-8883-3ba89d7f8e39&pf_rd_r=YXJ0WA74PEF1M3DPZSQZ&pd_rd_wg=La4m5&pd_rd_r=6bb6d961-8dad-486d-92e4-607fb57219a6&pd_rd_i=B0CLQLS8D3&psc=1",
+        "price": {
+          "symbol": "$",
+          "currency": "USD",
+          "value": 30.85,
+          "raw": "$30.85"
+        },
+        "image": "https://images-na.ssl-images-amazon.com/images/I/7177W7pkCwL.jpg"
+      }
+    ]
+  },
+  "review_results": {
+    "local": [
+      {
+        "id": "R2U8UD0TCKMJLC",
+        "asin": "R2U8UD0TCKMJLC",
+        "title": "Buy it",
+        "link": "https://www.amazon.com/gp/customer-reviews/R2U8UD0TCKMJLC/ref=cm_cr_dp_d_rvw_ttl?ie=UTF8",
+        "text": "Love this travel crate. We previously tried an open throne type seat for our 2 small dogs but they would not stay in it. Got this because it is for up to 60 pounds so we could use it for both our dogs. Fits snugly in the back seat with plenty of room for them both and they can still see out the window. Sturdy, easy to install and dogs are comfortable in it.",
+        "rating": 5,
+        "date": "Reviewed in the United States on March 12, 2026",
+        "extracted_date": "2026-03-12",
+        "profile": {
+          "id": "AEKAB5UHFGIBMBQMOSO4LJEIEAEA",
+          "name": "MOFlamingo",
+          "link": "https://www.amazon.com/gp/profile/amzn1.account.AEKAB5UHFGIBMBQMOSO4LJEIEAEA"
+        },
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R27OK9CLGB9CCW",
+        "asin": "R27OK9CLGB9CCW",
+        "title": "Escape-Proof Travel Solution",
+        "link": "https://www.amazon.com/gp/customer-reviews/R27OK9CLGB9CCW/ref=cm_cr_dp_d_rvw_ttl?ie=UTF8",
+        "text": "My small dogs are true escape artists and adventurers. I've tried countless solutions to keep them safe during car rides, but nothing worked. Traditional booster seats failed to contain them, and one of my pups chewed through the lead. With my dogs ranging from 16 to 20 pounds, they were small enough to wriggle past most barriers I tried to use to separate the back seat from the front. To my amazement, one of them, a crafty Jack Russell mix, even figured out how to unbuckle the seatbelt restraint I had tried for both of them. In short, I have brat-dogs. I needed a brat-dog-proof solution to my problem. I was almost ready to give up traveling with them, but I stumbled upon this intriguing carrier. I thought, \"Why not give it a shot? After all, Amazon has a good return policy.\" First and foremost, this crate is quite spacious. I drive a Corolla, and while I can fit it in the backseat, it does limit the front seat's ability to provide leg room when positioned behind it, causing the seat only to scoot back halfway. However, the snug fit does add an extra layer of security. If you're tall, I recommend you place it on the passenger side to avoid discomfort during the ride. On the flip side, it works exceptionally well in my father's truck. His 4-door Tundra has ample space in the backseat without compromising the comfort of those riding in the front. Just a word of caution - it won't fit in a front seat due to its size! Quality-wise, this crate is top-notch. It's not constructed from flimsy plastic but boasts a sturdy aluminum frame. As mentioned earlier, it's roomy enough to accommodate a larger dog, although it works perfectly for my smaller dogs when they get along. The crate features a robust zipper that opens from either side, allowing you to install it on your preferred side of the car. The mesh windows are a thoughtful addition; they're durable enough to withstand my dogs' curiosity and provide a clear view outside. Moreover, there are small hand openings on either side of the crate, so you can keep it securely closed or open it to scratch your pups or offer treats without risking a full-scale escape attempt. However, if you have a tiny dog, exercise caution. My 16-pound Chihuahua mix immediately tried to stick his head through the hole, thinking it was a way out when I first introduced him to the carrier. One of the standout features of this carrier is the safety and security it offers your furry friend on the road. The crate is securely fastened to the seat using the seatbelt, and its well-structured design provides additional protection, ensuring your dog's safety during the journey. In conclusion, this product is excellent, and I wholeheartedly recommend it. It's a game-changer for pet owners with spirited, stubborn companions like mine.",
+        "rating": 5,
+        "date": "Reviewed in the United States on August 29, 2023",
+        "extracted_date": "2023-08-29",
+        "profile": {
+          "id": "AH7WP5TZSO2R6RAVY36WK4OOAN5A",
+          "name": "Kim B",
+          "link": "https://www.amazon.com/gp/profile/amzn1.account.AH7WP5TZSO2R6RAVY36WK4OOAN5A"
+        },
+        "helpful_votes": 36,
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R17QQMPQ02DENB",
+        "asin": "R17QQMPQ02DENB",
+        "title": "Amazing quality",
+        "link": "https://www.amazon.com/gp/customer-reviews/R17QQMPQ02DENB/ref=cm_cr_dp_d_rvw_ttl?ie=UTF8",
+        "text": "This was exactly what we needed for our 28lb mini Aussie. We travel the country and this keeps him safe and comfortable for days on end of traveling. There is plenty of space for him to move around, lay down, and see out the window. The abundance of mesh helps keep him cool. It is easy to clean as the bottom removes and the cover comes off for washing. The pockets are kind of useless as anything you put in them falls out when you open the door. Having it unzip on both sides is helpful as it can be placed on either side of the car. The treat holes are handy, though he likes to stick his head through when he was smaller.The colors are holding up well, the material is thick and he hasn’t been able to damage it at all in daily use and a trip from AZ to NH then to CO! The zippers are good quality too. There are 2 per side making them easy to use. The seatbelt goes through the back and behind a panel so the dog can’t eat the seatbelt.If you’re on the fence, I say get it!",
+        "rating": 5,
+        "date": "Reviewed in the United States on September 6, 2025",
+        "extracted_date": "2025-09-06",
+        "profile": {
+          "id": "AF4ZKKI3NOGIKK4HPZVWXYSZXMEQ",
+          "name": "Dom",
+          "link": "https://www.amazon.com/gp/profile/amzn1.account.AF4ZKKI3NOGIKK4HPZVWXYSZXMEQ"
+        },
+        "helpful_votes": 15,
+        "images": [
+          "https://m.media-amazon.com/images/I/71IqciM8hJL.jpg"
+        ],
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R1JH217MGY982J",
+        "asin": "R1JH217MGY982J",
+        "title": "Great Quality, Perfect Size",
+        "link": "https://www.amazon.com/gp/customer-reviews/R1JH217MGY982J/ref=cm_cr_dp_d_rvw_ttl?ie=UTF8",
+        "text": "This is my second attempt at a car seat type situation for my 1.5 year old, 60 lb lab. So far this one is wonderful! Based on reviews, I was nervous it would be too small for her, but she fits! She can sit and lay down comfortably which is perfect for roadtrips (11+ hours in the car). It fits really well in the back seat of my SUV (7-seater Kia Sorento). I love the pockets for her leash, water bottle, and small towel. It feels really sturdy (good quality canvas, zippers, framing). I think it’ll stand up well to her jumping into and out of it. I’m not sure I’ll collapse it very often, but it does fold up easily and pretty flat for easy storage. We’ve only used it once, but so far we REALLY like it. I’ll try to remember to update in a few weeks on how it’s going.",
+        "rating": 5,
+        "date": "Reviewed in the United States on December 28, 2024",
+        "extracted_date": "2024-12-28",
+        "profile": {
+          "id": "AFTAFCUNJ6DZ74HRWGLWQJVJW5DQ",
+          "name": "Brittany F.",
+          "link": "https://www.amazon.com/gp/profile/amzn1.account.AFTAFCUNJ6DZ74HRWGLWQJVJW5DQ"
+        },
+        "helpful_votes": 24,
+        "images": [
+          "https://m.media-amazon.com/images/I/81gLr9qoMxL.jpg",
+          "https://m.media-amazon.com/images/I/81SJ480sxWL.jpg"
+        ],
+        "is_verified_purchase": true
+      }
+    ],
+    "global": [
+      {
+        "id": "R136ICIVRK6239",
+        "title": "Awesome crate, my dogs love it!",
+        "text": "It is abit taller than I expected. So it does block the back window slightly. Other than that, it is really good. I was deliberating whether to get it because I’d the price point, and am so glad that I did. The material is of good quality. Both my dogs are able to fit inside comfortably, and they love it! Very well ventilated and they can look around. Highly recommended! 👍🏻",
+        "rating": 5,
+        "date": "Reviewed in Singapore on July 30, 2023",
+        "extracted_date": "2023-07-30",
+        "profile": {
+          "name": "Violet L"
+        },
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R1N62NCMQ2YNZK",
+        "title": "Super einfache Box",
+        "text": "Tolle Box sehr zu empfehlen. Wir fahren viel und unser Hund ist nicht begeistert, hat keine Angst aber neigt dazu durchs Auto zu rennen. Das passiert hier nicht und sie kann zur Ruhe kommen. Aufbau und Anbau ist super einfach. Sowie die Sicherung des Hundes.",
+        "rating": 5,
+        "date": "Reviewed in Germany on January 2, 2026",
+        "extracted_date": "2026-01-02",
+        "profile": {
+          "name": "Ursula Herrmann"
+        },
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R2D5HMZPSIPZD7",
+        "title": "Génial !",
+        "text": "J'ai pris 2 caisses parce que j'ai 2 chiens, 2 bouledogues 24 et 26 kg. Ils ont un espace de fou. Ils peuvent s'asseoir et voir dehors, se coucher, tourner sur eux mêmes. Et en même temps, ils sont en sécurité. La cabine se déplie et se replie facilement. Le seul hic, je dirais, c'est pour installer la ceinture de sécurité, mais pas pire que les sièges bébés.",
+        "rating": 5,
+        "date": "Reviewed in France on September 13, 2024",
+        "extracted_date": "2024-09-13",
+        "profile": {
+          "name": "CBR"
+        },
+        "images": [
+          "https://m.media-amazon.com/images/I/81CxLoCitOL.jpg",
+          "https://m.media-amazon.com/images/I/716wNxxjvKL.jpg",
+          "https://m.media-amazon.com/images/I/81xVSoMsI4L.jpg"
+        ],
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R2LNUKIZI9XAC",
+        "title": "Ottimo, è proprio quello che cercavo!",
+        "text": "Lo utilizzo in macchina ed è proprio come lo cercavo, ho un levriero quindi piuttosto alta. Riesce a starci sia in piedi e guardare fuori dal finestrino che sdraiata e nonostante tutto occupa il posto di un sedile. Ora posso viaggiare in sicurezza con cane e bimbo nei sedili posteriori, un po' caro ma lo straconsiglio! Prossimamente lo proverò a mettere su un carrellino per utilizzarlo anche in bici",
+        "rating": 5,
+        "date": "Reviewed in Italy on November 24, 2022",
+        "extracted_date": "2022-11-24",
+        "profile": {
+          "name": "Cliente Amazon"
+        },
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R2OH5JD669VTIC",
+        "title": "Super fácil y cómodo para ambos",
+        "text": "Es una solución cómoda y segura para llevar a tu perro en tus viajes. Con forro polar impermeable y super cómodo tanto para ti como para tu mascota. Listos para la aventura.",
+        "rating": 5,
+        "date": "Reviewed in Spain on April 14, 2024",
+        "extracted_date": "2024-04-14",
+        "profile": {
+          "name": "Jacobo Azmani"
+        },
+        "is_verified_purchase": true
+      }
+    ]
+  }
+}

--- a/src/data/amazon-products/B0CV4KXTPR.json
+++ b/src/data/amazon-products/B0CV4KXTPR.json
@@ -1,0 +1,436 @@
+{
+  "search_metadata": {
+    "id": "search_jOZRYa4201H2KzOMQklD6mVx",
+    "status": "Success",
+    "created_at": "2026-04-10T02:45:04Z",
+    "request_time_taken": 2.32,
+    "parsing_time_taken": 0.09,
+    "total_time_taken": 2.42,
+    "request_url": "https://www.amazon.com/dp/B0CV4KXTPR?th=1&psc=1",
+    "html_url": "https://www.searchapi.io/api/v1/searches/search_jOZRYa4201H2KzOMQklD6mVx.html",
+    "json_url": "https://www.searchapi.io/api/v1/searches/search_jOZRYa4201H2KzOMQklD6mVx"
+  },
+  "search_parameters": {
+    "engine": "amazon_product",
+    "asin": "B0CV4KXTPR",
+    "amazon_domain": "amazon.com",
+    "delivery_country": "us"
+  },
+  "product": {
+    "asin": "B0CV4KXTPR",
+    "title": "Impact Indestructible High Anxiety Dog Crate for XXL Dogs - Heavy Duty Escape Proof Indoor Dog Kennel with Powder-Coated Aluminum - Ideal for Escape Artists (White, 48\" (48.5\" L x 27\" W x 33\" H)",
+    "brand_store": {
+      "id": "8CA9DE26-5302-4D34-A55E-8F5A6CE839BA",
+      "text": "Visit the Impact Dog Crates Store",
+      "link": "https://www.amazon.com/stores/ImpactDogCrates/page/8CA9DE26-5302-4D34-A55E-8F5A6CE839BA?lp_asin=B0CV4KXTPR&ref_=ast_bln&store_ref=bl_ast_dp_brandlogo_sto"
+    },
+    "marketplace_id": "ATVPDKIKX0DER",
+    "link": "https://www.amazon.com/s?k=dog+crate&rh=p_85%3A2470955011",
+    "rating": 4,
+    "reviews": 55,
+    "attributes": [
+      {
+        "name": "Brand",
+        "value": "Impact Dog Crates"
+      },
+      {
+        "name": "Product Dimensions",
+        "value": "48.5\"L x 27\"W x 33\"H"
+      },
+      {
+        "name": "Gap Size",
+        "value": "0.5 Inches"
+      },
+      {
+        "name": "Material",
+        "value": "Aluminum"
+      },
+      {
+        "name": "Specific Uses For Product",
+        "value": "Dog Crate, Dog Kennel, Dog Training, Houdini Dogs"
+      }
+    ],
+    "feature_bullets": [
+      "Impact Dog Crate's Best Warranty - Backed by Impact Dog Crate's 10-Year manufacturer dog damage warranty.",
+      "Zinc Steel Paddle Latch - Zinc-plated steel paddle latch which provides a robust mechanism for added security against the toughest escape attempts. This latch mechanism is designed to withstand high-stress forces.",
+      "Four Additional Butterfly Latches - It features four additional butterfly latches, providing maximum strength and security. These latches are easy to operate and provide an added level of protection.",
+      "Small Circle Ventilation Holes - The small circle ventilation holes, measuring at 0.5 inches, are specifically designed to prevent dogs from getting their K9 teeth in and potentially harming themselves. These ventilation holes provide adequate air flow while ensuring your pet's safety.",
+      "Over 62% Thicker Aluminum - Constructed with 62% thicker aluminum alloy. The thicker aluminum material increases the structural integrity of the crate, ensuring that it remains stable and secure under pressure."
+    ],
+    "variants": [
+      {
+        "asin": "B0CV4LCD82",
+        "title": "Gray 30\" (30.5\"L x 20.5\"W x 26\"H)",
+        "link": "https://www.amazon.com/dp/B0CV4LCD82?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Color",
+            "value": "Gray"
+          },
+          {
+            "name": "Size",
+            "value": "30\" (30.5\"L x 20.5\"W x 26\"H)"
+          }
+        ]
+      },
+      {
+        "asin": "B0CV4J8K51",
+        "title": "Gray 40\" (40.5\"L x 23\"W x 29\"H)",
+        "link": "https://www.amazon.com/dp/B0CV4J8K51?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Color",
+            "value": "Gray"
+          },
+          {
+            "name": "Size",
+            "value": "40\" (40.5\"L x 23\"W x 29\"H)"
+          }
+        ]
+      },
+      {
+        "asin": "B0CV4KMBX9",
+        "title": "White 30\" (30.5\"L x 20.5\"W x 26\"H)",
+        "link": "https://www.amazon.com/dp/B0CV4KMBX9?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Color",
+            "value": "White"
+          },
+          {
+            "name": "Size",
+            "value": "30\" (30.5\"L x 20.5\"W x 26\"H)"
+          }
+        ]
+      },
+      {
+        "asin": "B0CV4KXTPR",
+        "title": "White 48.5\"L x 27.0\"W x 33.0\"H",
+        "link": "https://www.amazon.com/dp/B0CV4KXTPR?th=1&pcs=1",
+        "is_current_product": true,
+        "dimensions": [
+          {
+            "name": "Color",
+            "value": "White"
+          },
+          {
+            "name": "Size",
+            "value": "48.5\"L x 27.0\"W x 33.0\"H"
+          }
+        ]
+      },
+      {
+        "asin": "B0CV4JHYW6",
+        "title": "Black 30\" (30.5\"L x 20.5\"W x 26\"H)",
+        "link": "https://www.amazon.com/dp/B0CV4JHYW6?th=1&pcs=1",
+        "dimensions": [
+          {
+            "name": "Color",
+            "value": "Black"
+          },
+          {
+            "name": "Size",
+            "value": "30\" (30.5\"L x 20.5\"W x 26\"H)"
+          }
+        ]
+      }
+    ],
+    "search_alias": {
+      "title": "Pet Supplies",
+      "value": "pets"
+    },
+    "buybox": {
+      "price": {
+        "raw": "$1,367.99",
+        "value": 1367.99,
+        "symbol": "$",
+        "currency": "USD"
+      },
+      "maximum_order_quantity": 2,
+      "offer_listing_id": "JOdh6VciNuFAEgShDPZSoLpnTvdAov54%2BqW0K4diza%2B2h88JgGAn0TPl%2BlWS49VaZz1pUc1nILztEV4pwmkUJVSC5Xj7WcTy3I6H3PacdPhO1nw4xe8DDWXVz94u09SzvvQrIVEj%2BDsfDD0a42RNfZWL6jzywPgCjosG5OlHxfmII021ibMkNU1dl52L5bNw",
+      "fulfillment": {
+        "standard_delivery": {
+          "text": "FREE delivery Thursday, April 16. Details",
+          "type": "FREE",
+          "date": "Thursday, April 16"
+        },
+        "third_party_seller": {
+          "id": "A2OGALEBX823MP",
+          "name": "Impact Dog Crates",
+          "link": "https://www.amazon.com/gp/help/seller/at-a-glance.html/ref=dp_merchant_link?ie=UTF8&seller=A2OGALEBX823MP&asin=B0CV4KXTPR&ref_=dp_merchant_link"
+        },
+        "sold_by": "Impact Dog Crates",
+        "is_sold_by_amazon": true
+      },
+      "availability": "Only 2 left in stock - order soon."
+    },
+    "specifications": [
+      {
+        "name": "Brand Name",
+        "value": "Impact Dog Crates"
+      },
+      {
+        "name": "Target Species",
+        "value": "Dog"
+      },
+      {
+        "name": "Specific Uses For Product",
+        "value": "Dog Crate, Dog Kennel, Dog Training, Houdini Dogs"
+      },
+      {
+        "name": "Included Components",
+        "value": "Crate"
+      },
+      {
+        "name": "Breed Recommendation",
+        "value": "All Breed Sizes"
+      },
+      {
+        "name": "Dog Breed Size",
+        "value": "Large"
+      },
+      {
+        "name": "Manufacturer",
+        "value": "Impact Dog Crates"
+      },
+      {
+        "name": "UPC",
+        "value": "810156130267"
+      },
+      {
+        "name": "Unit Count",
+        "value": "1.0 Count"
+      },
+      {
+        "name": "Warranty Description",
+        "value": "All Impact Dog Crates include a lifetime warranty for the original owner against defects in materials or workmanship. This warranty does not cover dog damage, paint issues, or normal wear and tear, such as scratches. The Impact HA Crate includes a Lifetime Dog Damage Guarantee, which is non-transferable and requires proof of purchase."
+      },
+      {
+        "name": "ASIN",
+        "value": "B0CV4KXTPR"
+      },
+      {
+        "name": "Gap Size",
+        "value": "0.5 Inches"
+      },
+      {
+        "name": "Additional Features",
+        "value": "Durable, Safe, Secure, Stackable"
+      },
+      {
+        "name": "Number of Levels",
+        "value": "1"
+      },
+      {
+        "name": "Number of Doors",
+        "value": "1"
+      },
+      {
+        "name": "Material Type",
+        "value": "Aluminum"
+      },
+      {
+        "name": "Color",
+        "value": "White"
+      },
+      {
+        "name": "Item Dimensions L x W x H",
+        "value": "48.5\"L x 27\"W x 33\"H"
+      },
+      {
+        "name": "Item Weight",
+        "value": "66 Pounds"
+      },
+      {
+        "name": "Product Dimensions",
+        "value": "48.5 x 27 x 33 inches; 66 Pounds"
+      },
+      {
+        "name": "Item model number",
+        "value": "HA"
+      },
+      {
+        "name": "Date First Available",
+        "value": "September 23, 2024"
+      },
+      {
+        "name": "Manufacturer",
+        "value": "Impact Dog Crates"
+      },
+      {
+        "name": "ASIN",
+        "value": "B0CV4KXTPR"
+      }
+    ],
+    "bestsellers_rank": [
+      {
+        "name": "See Top 100 in Pet Supplies",
+        "link": "https://www.amazon.com/gp/bestsellers/pet-supplies/ref=pd_zg_ts_pet-supplies"
+      },
+      {
+        "name": "Basic Dog Crates",
+        "link": "https://www.amazon.com/gp/bestsellers/pet-supplies/3024223011/ref=pd_zg_hrsr_pet-supplies"
+      },
+      {
+        "name": "See Top 100 in Pet Supplies",
+        "link": "https://www.amazon.com/gp/bestsellers/pet-supplies/ref=pd_zg_ts_pet-supplies",
+        "rank": 128089
+      },
+      {
+        "name": "Basic Dog Crates",
+        "link": "https://www.amazon.com/gp/bestsellers/pet-supplies/3024223011/ref=pd_zg_hrsr_pet-supplies",
+        "rank": 309
+      }
+    ],
+    "main_image": "https://m.media-amazon.com/images/I/71PqD1QxTFL.jpg",
+    "images": [
+      {
+        "link": "https://m.media-amazon.com/images/I/71PqD1QxTFL.jpg",
+        "variant": "MAIN"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/61v4-xe9dwL.jpg",
+        "variant": "PT01"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/61n4gRc-xFL.jpg",
+        "variant": "PT02"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/81TyGAu+fDL.jpg",
+        "variant": "PT03"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/81Ug+I2o2ML.jpg",
+        "variant": "PT04"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/61WcRTgwshL.jpg",
+        "variant": "PT05"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/71eustaU4lL.jpg",
+        "variant": "PT06"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/71-hW-+S3zL.jpg",
+        "variant": "PT07"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/81l8ikNgRUL.jpg",
+        "variant": "PT08"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/51NP-4fm1RL.jpg",
+        "variant": "DIMN"
+      }
+    ]
+  },
+  "similar_item": {
+    "asin": "B07TPPVYLV",
+    "title": "Amazon Basics - Portable Heavy Duty Stackable Dog Pet Kennel with Tray, Black, 48.2\" L x 37.8\" W x 42.5\" H",
+    "link": "https://www.amazon.com/dp/B07TPPVYLV/ref=vp_d_pbs_trans_lp_B0CV4KXTPR_pd?_encoding=UTF8&pf_rd_p=f6007f53-9fa1-4c0d-b499-54e844408da9&pf_rd_r=5RE529P8KYS1X47EDJ3F&pd_rd_wg=RvKtn&pd_rd_i=B07TPPVYLV&pd_rd_w=t6jXZ&content-id=amzn1.sym.f6007f53-9fa1-4c0d-b499-54e844408da9&pd_rd_r=0c4e8dab-34c0-4282-b398-7079f1e05197&psc=1",
+    "rating": 4,
+    "reviews": 1043,
+    "price": {
+      "raw": "$212.58",
+      "value": 212.58,
+      "symbol": "$",
+      "currency": "USD"
+    },
+    "image": "https://m.media-amazon.com/images/I/910osIQmKbL.jpg"
+  },
+  "review_results": {
+    "local": [
+      {
+        "id": "R2YZ0LIW4GC6GK",
+        "asin": "R2YZ0LIW4GC6GK",
+        "title": "Game Changer for our Anxious Dog",
+        "link": "https://www.amazon.com/gp/customer-reviews/R2YZ0LIW4GC6GK/ref=cm_cr_dp_d_rvw_ttl?ie=UTF8",
+        "text": "I believe i have left a first review already, but this is an updated review over a month later, and it is perfect. our dog who is a very good boy in all aspects hates being crated, but as he is young and we had a scare where he was chewing on a cord that was, thankfully, only plugged into a power strip that was currently powered off, he needs to be crated when we are not around to watch him. he broke two kennels, one of the common ones you see everywhere that works for most dogs, and a second heavy duty one that was very nice, completely ripped the door off from the inside, and ripped out the bars. He does get anxiety when i am not home, so he needs somewhere safe to be, and this kennel has provided that space. It used to be when i would get home he would be crying, and i'd come home to more damage to the old crate, and after a while, to the floor that he was tearing up if he couldn't get out. He would frequently urinate on himself from the stress of not having someone home with him, which would also make him stressed and overly pushy/jumping on you, grabbing your hands when he was let out, and it would make his need to be velcroed to my side even worse. With this crate, i arrive home and he's usually sleeping and calm, even though he's only ever in it for a couple of hours when my husbands and my shifts overlap. it's no longer a bad thing for him, and we leave it open for him, and for our other dog, to go into when overwhelmed and needing to be left alone or destress. He will actually go in it on his own now. no issue with him urinating on himself anymore, and he has several blankets in it for padding because he likes to make a little nest in it when he lays in it. he's no longer even attempting to get out or break down the door, which i don't think is possible even if he tried. We got a crate much larger than he needed as our other dog also likes to have somewhere to go when overwhelmed, and the kids are taught to leave them alone if they go to the crate, and she is a good 4 or 5 inches taller than he is. It functions great, i love the extra locks, it's not too heavy to move, though it's not exactly light, it was expensive, but worth every penny spent on getting it. it was a bit difficult to put together, but the instructions were easy to follow. i suggest having two people there to build it, as that would have made the job much simpler and faster, as i put it together by myself. Includes all the tools you need and extra hardware for if you drop and lose a screw, nut, or lock washer. It came on time, and is absolutely perfect. It's always dark inside, which i think helps. if your dog has separation anxiety this is a wonderful crate option for them. Another tip is if you put on a radio station or the TV on low volume to a show where people talk on it a lot, it will also help keep the dog calm and relaxed, as they cant see out of the crate to know you're not there, and will think that someone is home with them. Train them on going in and out with a command such as \"Go to bed\" and \"Good Morning\" with lots of treats and praise, as well as having that be where they go for about 20 minutes after eating (Have a GSD mix and didn't want to risk her stomach flipping so we started doing this with our dogs) and it's no longer scary or a bad thing. Just don't use it as a punishment or yell at them then toss them in, or yell at them while in it or it will be associated with bad things and you'll have difficulty with it. Other tips for anxious dogs not to do with the crate include a set routine they can count on. (Such as this rough example: Wake up at this time and outside to potty. Then breakfast, rest for 20 minutes, then go on a walk. After the walk it's outside time to play or sunbathe, then inside for the hot hours, going outside once an hour to potty. Then go through 20 minutes training on basic, then intermediate and advanced commands at 4, followed by an afternoon walk or trip to the dog park to run and play, then dinner, 20 minute quiet time, then outside to potty. Then rest and cuddles on the couch and bedtime after that.) A set routine, which does not have to be exactly as described above, I'm aware people have jobs and their shifts are not always going to cooperate, but any set, predictable routine greatly helps anxious dogs and relieves stress for them.",
+        "rating": 5,
+        "date": "Reviewed in the United States on April 2, 2025",
+        "extracted_date": "2025-04-02",
+        "profile": {
+          "id": "AFTCZXTLN53MWNHJ3OZQ2KFPGBAQ",
+          "name": "Amazon Customer",
+          "link": "https://www.amazon.com/gp/profile/amzn1.account.AFTCZXTLN53MWNHJ3OZQ2KFPGBAQ"
+        },
+        "helpful_votes": 11,
+        "images": [
+          "https://m.media-amazon.com/images/I/515AXJR2TbL.jpg",
+          "https://m.media-amazon.com/images/I/61k3ZiH1taL.jpg"
+        ],
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R21DIDGZ5V96SJ",
+        "asin": "R21DIDGZ5V96SJ",
+        "title": "Safety and Security.",
+        "link": "https://www.amazon.com/gp/customer-reviews/R21DIDGZ5V96SJ/ref=cm_cr_dp_d_rvw_ttl?ie=UTF8",
+        "text": "Great product. Very sturdy and the video makes assembly much easier than the paper instructions. The price is higher than other crates but the quality, safety and long term use makes this an excellent option. One purchase and your good to go without having to purchase other crates after they wear out.",
+        "rating": 5,
+        "date": "Reviewed in the United States on December 7, 2025",
+        "extracted_date": "2025-12-07",
+        "profile": {
+          "id": "AF5HJWXGYW3V5TENQRZAGSOVFQVQ",
+          "name": "Wayne G.",
+          "link": "https://www.amazon.com/gp/profile/amzn1.account.AF5HJWXGYW3V5TENQRZAGSOVFQVQ"
+        },
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R9O66514M44GO",
+        "asin": "R9O66514M44GO",
+        "title": "Be warned - my dog injured himself in this crate",
+        "link": "https://www.amazon.com/gp/customer-reviews/R9O66514M44GO/ref=cm_cr_dp_d_rvw_ttl?ie=UTF8",
+        "text": "This crate is not the crate for dogs with severe separation anxiety. My poor dog damaged his mouth in this crate. He removed some of the screws, and cut his gum trying to put his teeth through the holes. This crate did not keep my dog safe, it only intensified the anxiety. Unfortunately customer service does not refund your money if you have this experience. I bought this crate while trying to train my dog so he would at least be safe when I needed to leave but it has been a disaster and I’m so upset because I spent $1,285 with tax on this product and now I am out that money and needed to purchase a different product for him. I would think this company would do something to make this right. They will not take it back because it is past the 30 day window but I was not able to train my dog in 30 days and this whole experience has been awful, just awful. The description says:“ Small Circle Ventilation Holes - The small circle ventilation holes, measuring at 0.5 inches, are specifically designed to prevent dogs from getting their K9 teeth in and potentially harming themselves. These ventilation holes provide adequate air flow while ensuring your pet's safety.” But it just isn’t true - my dog DID injure himself. You can see the photo of what happened to him in the Impact crate. If I had known this was possible I never would have purchased this crate so please be careful. Your dog CAN be injured in this crate. I don’t like leaving negative reviews but I’m really, really furious with this company. I suggest checking out Ruffland Performace Kennels before purchasing an Impact crate. My dog is much happier in their crate because he can see out of it.",
+        "rating": 1,
+        "date": "Reviewed in the United States on January 7, 2026",
+        "extracted_date": "2026-01-07",
+        "profile": {
+          "id": "AGZ2NCHJKHQKPWT5GIYUDZWVOMIA",
+          "name": "daniel r miller",
+          "link": "https://www.amazon.com/gp/profile/amzn1.account.AGZ2NCHJKHQKPWT5GIYUDZWVOMIA"
+        },
+        "helpful_votes": 5,
+        "images": [
+          "https://m.media-amazon.com/images/I/71oT99Pm8HL.jpg"
+        ],
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R2JXY1TLPQXOWV",
+        "asin": "R2JXY1TLPQXOWV",
+        "title": "Relief, Finally!!",
+        "link": "https://www.amazon.com/gp/customer-reviews/R2JXY1TLPQXOWV/ref=cm_cr_dp_d_rvw_ttl?ie=UTF8",
+        "text": "Just buy it. I cannot tell you how much money I wasted on plastic, wire, and wide bar metal kennels before finally purchasing this one. Trust me, I understand the price is off putting at first, but you will not be disappointed. I have a high anxiety cur… he is not a dog you would look at and think “escape artist”. He looks sweet & innocent… he’s 45 pounds, what’s the worst he could do? You would be surprised, but after purchasing this kennel, I have a brand new dog. He has tried and tried and tried some more, he cannot get out of this kennel. He doesn’t use the bathroom in the kennel or my house anymore. I could go on and on but in short- I wish I would’ve saved myself the money & tears and bought this sooner.",
+        "rating": 5,
+        "date": "Reviewed in the United States on November 5, 2025",
+        "extracted_date": "2025-11-05",
+        "profile": {
+          "id": "AFQ74BAVKEBQJGLOHRLO7FXH2PGQ",
+          "name": "Macyy",
+          "link": "https://www.amazon.com/gp/profile/amzn1.account.AFQ74BAVKEBQJGLOHRLO7FXH2PGQ"
+        },
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R29CP9LOXYR7O7",
+        "asin": "R29CP9LOXYR7O7",
+        "title": "It does its job, but a lot of money is involved",
+        "link": "https://www.amazon.com/gp/customer-reviews/R29CP9LOXYR7O7/ref=cm_cr_dp_d_rvw_ttl?ie=UTF8",
+        "text": "Even though this crate do cost a lot. My dog had real bad anxiety and we went through medications and the vet gave him four whole pills and my dog still got out of his old crate and it was bad where he destroyed my door and I was scared that he will mess up his teeth and get hurt so I brought this crate and it works. It keeps him inside. The only problem I have is that is not easy to assemble. It takes two people unless you have someone helping you. It’s hard to do it by yourself. The latch works, and he is safe in in this crate and it’s sturdy too. How it looks outside I can’t understand why people do not want to buy the crate. That’s another problem. You can make it look friendlier or something that don’t look like most people I heard from other reviews that it looks like a prison so they might need to redesign it where it don’t look that way. And it is a lot of money. I know it supposed to keep your dog safe but it’s like paying for a down payment on a house so that’s another problem. I have with this and I’m still paying for this crate but it was kind of worth it so I can not worry when I get home that he escaped, and I cannot find my dog.",
+        "rating": 5,
+        "date": "Reviewed in the United States on September 20, 2025",
+        "extracted_date": "2025-09-20",
+        "profile": {
+          "id": "AHTWYQ77GITLFOXVNWUOLRS4GYHQ",
+          "name": "Hope Gardner",
+          "link": "https://www.amazon.com/gp/profile/amzn1.account.AHTWYQ77GITLFOXVNWUOLRS4GYHQ"
+        },
+        "is_verified_purchase": true
+      }
+    ]
+  }
+}

--- a/src/data/amazon-products/B0CWNXMYW1.json
+++ b/src/data/amazon-products/B0CWNXMYW1.json
@@ -1,0 +1,452 @@
+{
+  "search_metadata": {
+    "id": "search_Z18NJlvnOYIYNjdm1k3BOm7g",
+    "status": "Success",
+    "created_at": "2026-04-10T07:36:19Z",
+    "request_time_taken": 2.22,
+    "parsing_time_taken": 0.15,
+    "total_time_taken": 2.36,
+    "request_url": "https://www.amazon.com/dp/B0CWNXMYW1?th=1&psc=1",
+    "html_url": "https://www.searchapi.io/api/v1/searches/search_Z18NJlvnOYIYNjdm1k3BOm7g.html",
+    "json_url": "https://www.searchapi.io/api/v1/searches/search_Z18NJlvnOYIYNjdm1k3BOm7g"
+  },
+  "search_parameters": {
+    "engine": "amazon_product",
+    "asin": "B0CWNXMYW1",
+    "amazon_domain": "amazon.com",
+    "delivery_country": "us"
+  },
+  "product": {
+    "asin": "B0CWNXMYW1",
+    "title": "KindTail PAWD Collapsible Dog Crate with Washable Bed, for Pets Between 15 and 25 lbs, Such as French Bulldog, Maltese, Pomeranian, Portable Indoor Kennel, 26” L x 20” W x 21” H, 14 LB, Medium White",
+    "brand_store": {
+      "id": "8A6D30B8-0C63-4912-B69B-5E0A2986318C",
+      "text": "Visit the KindTail Store",
+      "link": "https://www.amazon.com/stores/KindTail/page/8A6D30B8-0C63-4912-B69B-5E0A2986318C?lp_asin=B0CWNXMYW1&ref_=ast_bln&store_ref=bl_ast_dp_brandlogo_sto"
+    },
+    "marketplace_id": "ATVPDKIKX0DER",
+    "link": "https://www.amazon.com/s?k=kindtail+dog+crate",
+    "rating": 3.7,
+    "reviews": 32,
+    "bought_past_month": "50+ bought in past month",
+    "attributes": [
+      {
+        "name": "Color",
+        "value": "White"
+      },
+      {
+        "name": "Brand",
+        "value": "KindTail"
+      },
+      {
+        "name": "Product Dimensions",
+        "value": "26\"L x 20\"W x 21\"H"
+      },
+      {
+        "name": "Material",
+        "value": "Polypropylene (PP)"
+      },
+      {
+        "name": "Special Feature",
+        "value": "Travel, Lightweight"
+      }
+    ],
+    "feature_bullets": [
+      "Sized for Small & Medium Pets – Medium PAWD crate measures 26” L x 20” W x 21” H when assembled and is ideal for dogs between 15 lbs and 25 lbs such as French Bulldogs, Maltese, Pomeranian, or similar breeds. Please measure your dog’s length (nose to base of tail) and height (floor to top of head) before purchase. Product photos include a size guide and comparison images to help you select the correct crate size for your pet.",
+      "Lightweight & Portable – Weighs only 14 lbs and folds flat for easy transport or storage, making it perfect for travel, visiting friends, or moving around the house. It measures 26 x 4 x 20 inches when collapsed flat for space-saving storage when not in use.",
+      "Simple, Tool-Free Assembly – Crate arrives in collapsed format. Crate features snap-together panels with strong joints and snug connection points for strength and stability. First time assembly takes approximately 5 to 7 minutes with no tools required. Panels snap together by hand. Move the panels by hand to align the connection points. Assembly instructions included in the box. The Amazon product page features an assembly video.",
+      "Stylish & Comfortable Design – Modern look blends with home décor, and includes a washable padded bed to keep your pup cozy indoors.",
+      "Safe & Durable – Made from premium, strong, pet-safe materials designed for everyday use, while still being lightweight and easy to handle."
+    ],
+    "variants": [
+      {
+        "asin": "B0CWNXMYW1",
+        "title": "White 26.0\"L x 20.0\"W x 21.0\"H",
+        "link": "https://www.amazon.com/dp/B0CWNXMYW1?th=1&pcs=1",
+        "is_current_product": true,
+        "dimensions": [
+          {
+            "name": "Color",
+            "value": "White"
+          },
+          {
+            "name": "Size",
+            "value": "26.0\"L x 20.0\"W x 21.0\"H"
+          }
+        ]
+      }
+    ],
+    "search_alias": {
+      "title": "Pet Supplies",
+      "value": "pets"
+    },
+    "buybox": {
+      "price": {
+        "raw": "$239.99",
+        "value": 239.99,
+        "symbol": "$",
+        "currency": "USD"
+      },
+      "maximum_order_quantity": 20,
+      "offer_listing_id": "pSuzD72gNqLM730fIS2c%2BXX3vfrk0E59wSU4hHtwTWOU49%2FtcsvnINk7v62Q%2FliImVIRaAKgf9P7B8Dzyw%2F%2FgIxa88hi7PcSdeE3vQpXUJ10qlR88tihavbCIHfASegBvBOZFLYq00MWpq1K5XLnRtXUH21l9mDaJKD5unv14CbKceclmOBnMWBP3WFfKePk",
+      "fulfillment": {
+        "standard_delivery": {
+          "text": "FREE delivery Wednesday, April 15",
+          "type": "FREE",
+          "date": "Wednesday, April 15"
+        },
+        "fastest_delivery": {
+          "text": "Or fastest delivery Tuesday, April 14",
+          "type": "fastest",
+          "date": "Tuesday, April 14"
+        },
+        "third_party_seller": {
+          "id": "A2AN7ES8S4L4AG",
+          "name": "KindTail",
+          "link": "https://www.amazon.com/gp/help/seller/at-a-glance.html/ref=dp_merchant_link?ie=UTF8&seller=A2AN7ES8S4L4AG&asin=B0CWNXMYW1&ref_=dp_merchant_link&isAmazonFulfilled=1"
+        },
+        "ships_from": "Amazon",
+        "sold_by": "KindTail",
+        "is_sold_by_amazon": true
+      },
+      "availability": "Only 20 left in stock - order soon."
+    },
+    "specifications": [
+      {
+        "name": "Brand Name",
+        "value": "KindTail"
+      },
+      {
+        "name": "Target Species",
+        "value": "Dog, Puppy, Cat, Kitten, Small Animals"
+      },
+      {
+        "name": "Manufacturer",
+        "value": "KindTail"
+      },
+      {
+        "name": "UPC",
+        "value": "850032391399"
+      },
+      {
+        "name": "Included Components",
+        "value": "Collapsible Crate and Crate Pad"
+      },
+      {
+        "name": "Unit Count",
+        "value": "1.0 Count"
+      },
+      {
+        "name": "ASIN",
+        "value": "B0CWNXMYW1"
+      },
+      {
+        "name": "Maximum Weight Recommendation",
+        "value": "25 Pounds"
+      },
+      {
+        "name": "Recommended Uses For Product",
+        "value": "Traveling with pets, Providing a safe and cozy space for dogs"
+      },
+      {
+        "name": "Item Dimensions L x W x H",
+        "value": "26\"L x 20\"W x 21\"H"
+      },
+      {
+        "name": "Item Weight",
+        "value": "9.71 Kilograms"
+      },
+      {
+        "name": "Size",
+        "value": "26.0\"L x 20.0\"W x 21.0\"H"
+      },
+      {
+        "name": "Additional Features",
+        "value": "Travel, Lightweight"
+      },
+      {
+        "name": "Compatible with Vehicle Type",
+        "value": "Car"
+      },
+      {
+        "name": "Closure Type",
+        "value": "Latch"
+      },
+      {
+        "name": "Dog Breed Size",
+        "value": "Medium"
+      },
+      {
+        "name": "Color",
+        "value": "White"
+      },
+      {
+        "name": "Product Style",
+        "value": "Modern"
+      },
+      {
+        "name": "Material Type",
+        "value": "Polypropylene (PP)"
+      },
+      {
+        "name": "Product Dimensions",
+        "value": "26 x 20 x 21 inches; 21.4 Pounds"
+      },
+      {
+        "name": "Item model number",
+        "value": "66597"
+      },
+      {
+        "name": "Date First Available",
+        "value": "February 28, 2024"
+      },
+      {
+        "name": "Manufacturer",
+        "value": "KindTail"
+      },
+      {
+        "name": "ASIN",
+        "value": "B0CWNXMYW1"
+      }
+    ],
+    "bestsellers_rank": [
+      {
+        "name": "See Top 100 in Pet Supplies",
+        "link": "https://www.amazon.com/gp/bestsellers/pet-supplies/ref=pd_zg_ts_pet-supplies"
+      },
+      {
+        "name": "Dog Beds",
+        "link": "https://www.amazon.com/gp/bestsellers/pet-supplies/2975330011/ref=pd_zg_hrsr_pet-supplies"
+      },
+      {
+        "name": "See Top 100 in Pet Supplies",
+        "link": "https://www.amazon.com/gp/bestsellers/pet-supplies/ref=pd_zg_ts_pet-supplies",
+        "rank": 65474
+      },
+      {
+        "name": "Dog Beds",
+        "link": "https://www.amazon.com/gp/bestsellers/pet-supplies/2975330011/ref=pd_zg_hrsr_pet-supplies",
+        "rank": 828
+      }
+    ],
+    "main_image": "https://m.media-amazon.com/images/I/71+6X5mSFIL.jpg",
+    "images": [
+      {
+        "link": "https://m.media-amazon.com/images/I/71+6X5mSFIL.jpg",
+        "variant": "MAIN"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/712CYBN7mhL.jpg",
+        "variant": "PT01"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/81HBU6dQnbL.jpg",
+        "variant": "PT02"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/81ncMhHtLQL.jpg",
+        "variant": "PT03"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/81tPzMsTb7L.jpg",
+        "variant": "PT04"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/81k+o81OJfL.jpg",
+        "variant": "PT05"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/81vWsAW0SAL.jpg",
+        "variant": "PT06"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/71GOn8F042L.jpg",
+        "variant": "PT07"
+      }
+    ]
+  },
+  "similar_item": {
+    "asin": "B07GPKV37B",
+    "title": "Amazon Basics Folding Portable Soft Pet Dog Crate Carrier Kennel, 26 x 18 x 18 inches, Red",
+    "link": "https://www.amazon.com/dp/B07GPKV37B/ref=vp_d_pb_TIER3_trans_lp_B0CWNXMYW1_pd?_encoding=UTF8&pf_rd_p=833279f6-3822-4089-a177-f6c02b33c169&pf_rd_r=8YV1H3N0A27TNVPW32R7&pd_rd_wg=SFLoh&pd_rd_i=B07GPKV37B&pd_rd_w=iUwTW&content-id=amzn1.sym.833279f6-3822-4089-a177-f6c02b33c169&pd_rd_r=9da45fbc-898c-4b72-b971-4b97565a16d2&psc=1",
+    "rating": 4.5,
+    "reviews": 18755,
+    "price": {
+      "raw": "$54.44",
+      "value": 54.44,
+      "symbol": "$",
+      "currency": "USD"
+    },
+    "image": "https://m.media-amazon.com/images/I/A1i8Gt3KYaL.jpg"
+  },
+  "frequently_bought_together": {
+    "total_price": {
+      "raw": "$399.97",
+      "value": 399.97,
+      "symbol": "$",
+      "currency": "USD"
+    }
+  },
+  "review_results": {
+    "local": [
+      {
+        "id": "R1PG6FC3J95D2E",
+        "asin": "R1PG6FC3J95D2E",
+        "title": "Pretty enough for my house, Kodie loves it!",
+        "link": "https://www.amazon.com/gp/customer-reviews/R1PG6FC3J95D2E/ref=cm_cr_dp_d_rvw_ttl?ie=UTF8",
+        "text": "Pros: LOOKS GREAT IN MY HOUSE, easy to set up and we're using it as a coffee table. It was fairly easy to set up and my dog jumped in right away. The door locks to the side so it doesn't get in the way. I love this feature as we use the crate more as a resting spot for Kodie most of the day. We only lock it at night. I ended up buying a second one for the bedroom and set it up as a bedstand. Cons- it is pricier than the wire crate, and doesn't have a handle. I wished it had a handle so we can collapse it and take it up and down the stairs. This is why I ended up getting a second one. Overall I am very happy with this modern look and the functionality.It was about time someone came up with something like this.",
+        "rating": 5,
+        "date": "Reviewed in the United States on November 19, 2025",
+        "extracted_date": "2025-11-19",
+        "profile": {
+          "id": "AF3TYVA6DKXE3FGVAT7JOHDPBOTQ",
+          "name": "Gar-Man Y.",
+          "link": "https://www.amazon.com/gp/profile/amzn1.account.AF3TYVA6DKXE3FGVAT7JOHDPBOTQ"
+        },
+        "images": [
+          "https://m.media-amazon.com/images/I/716PSPMt6tL.jpg",
+          "https://m.media-amazon.com/images/I/81q7-OwuzJL.jpg"
+        ],
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R2DZ4965PHRCK6",
+        "asin": "R2DZ4965PHRCK6",
+        "title": "Material concerns with recent crate",
+        "link": "https://www.amazon.com/gp/customer-reviews/R2DZ4965PHRCK6/ref=cm_cr_dp_d_rvw_ttl?ie=UTF8",
+        "text": "This is our second crate from KindTail. The first purchased two years ago has been wonderful quality and our dog loves it. The most recent one arrived in undamaged box with the following defect. One of the side panels was bent and the piece was broken. Luckily it still can be held together by the clasp. I plan to keep a close eye on this piece so a part doesn’t fall off that our dogs could ingest.",
+        "rating": 3,
+        "date": "Reviewed in the United States on January 19, 2026",
+        "extracted_date": "2026-01-19",
+        "profile": {
+          "id": "AEAWP4CBG6LA4CPUGEL4K5MNG7ZA",
+          "name": "Annika",
+          "link": "https://www.amazon.com/gp/profile/amzn1.account.AEAWP4CBG6LA4CPUGEL4K5MNG7ZA"
+        },
+        "images": [
+          "https://m.media-amazon.com/images/I/612B4zjPOSL.jpg",
+          "https://m.media-amazon.com/images/I/61JcOxdmfPL.jpg"
+        ],
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R34TT9WCX5ZPFX",
+        "asin": "R34TT9WCX5ZPFX",
+        "title": "My Dog’s Happy Place!",
+        "link": "https://www.amazon.com/gp/customer-reviews/R34TT9WCX5ZPFX/ref=cm_cr_dp_d_rvw_ttl?ie=UTF8",
+        "text": "I can’t say enough good things about our KindTail crate! It’s not just a crate it’s a beautiful piece of furniture that actually fits into my home décor. The modern design is sleek and stylish, and it folds up so easily when I need extra space. Most importantly, my dog absolutely loves it. He goes in there on his own to nap or relax. First time I set it up it took a little longer but after couple times it was easy. Would recommend!",
+        "rating": 5,
+        "date": "Reviewed in the United States on October 16, 2025",
+        "extracted_date": "2025-10-16",
+        "profile": {
+          "id": "AFRK6PWJFYY3XMQTG73ODJHETVUA",
+          "name": "sean lee",
+          "link": "https://www.amazon.com/gp/profile/amzn1.account.AFRK6PWJFYY3XMQTG73ODJHETVUA"
+        },
+        "helpful_votes": 6,
+        "images": [
+          "https://m.media-amazon.com/images/I/61J24mU6vuL.jpg",
+          "https://m.media-amazon.com/images/I/71kiux9lZyL.jpg"
+        ],
+        "is_verified_purchase": true
+      },
+      {
+        "id": "RRBG2DLQE89BO",
+        "asin": "RRBG2DLQE89BO",
+        "title": "A piece of junk for the expensive price",
+        "link": "https://www.amazon.com/gp/customer-reviews/RRBG2DLQE89BO/ref=cm_cr_dp_d_rvw_ttl?ie=UTF8",
+        "text": "Do not buy this please, $250 later. It is a piece of junk and flimsy. The bed it comes with is awful too. Way too expensive for what you are getting. I wish I never bought this crate for my dog.",
+        "rating": 1,
+        "date": "Reviewed in the United States on March 14, 2026",
+        "extracted_date": "2026-03-14",
+        "profile": {
+          "id": "AGYR53ABXY6NMEQJONLZ2FTSOUUA",
+          "name": "Michael Mastoris",
+          "link": "https://www.amazon.com/gp/profile/amzn1.account.AGYR53ABXY6NMEQJONLZ2FTSOUUA"
+        },
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R3U0WWSHTWR6UX",
+        "asin": "R3U0WWSHTWR6UX",
+        "title": "Poor materials for such an attractive design",
+        "link": "https://www.amazon.com/gp/customer-reviews/R3U0WWSHTWR6UX/ref=cm_cr_dp_d_rvw_ttl?ie=UTF8",
+        "text": "Warped panels, difficult to fit notches into slots. Not what I want if I need to travel and reassemble each time. Maybe if I could assemble it ONE time and panels were not warped. The design is very cool. The materials are not great. I would be concerned about pieces breaking off. Get a better manufacturer for this nice design.",
+        "rating": 2,
+        "date": "Reviewed in the United States on December 13, 2025",
+        "extracted_date": "2025-12-13",
+        "profile": {
+          "id": "AEOU6FVYPOHJMPXC5YLSTNBBJQRQ",
+          "name": "fleur de lys",
+          "link": "https://www.amazon.com/gp/profile/amzn1.account.AEOU6FVYPOHJMPXC5YLSTNBBJQRQ"
+        },
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R1EWPM2ON04M2J",
+        "asin": "R1EWPM2ON04M2J",
+        "title": "Great for traveling",
+        "link": "https://www.amazon.com/gp/customer-reviews/R1EWPM2ON04M2J/ref=cm_cr_dp_d_rvw_ttl?ie=UTF8",
+        "text": "This is an amazing crate, especially if you travel in an RV or tent. It’s easy to set up and to fold down and put away. Probably one of my best investments for my sweet pup.",
+        "rating": 5,
+        "date": "Reviewed in the United States on January 25, 2026",
+        "extracted_date": "2026-01-25",
+        "profile": {
+          "id": "AE5XVP5S5MRZDPABBBESKSF7TPTA",
+          "name": "Gaylia Osterlund",
+          "link": "https://www.amazon.com/gp/profile/amzn1.account.AE5XVP5S5MRZDPABBBESKSF7TPTA"
+        },
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R154IY60IBDETR",
+        "asin": "R154IY60IBDETR",
+        "title": "This crate is great if you have kids around the house!!",
+        "link": "https://www.amazon.com/gp/customer-reviews/R154IY60IBDETR/ref=cm_cr_dp_d_rvw_ttl?ie=UTF8",
+        "text": "My kids would get hurt with the wire crate as the door was always swinging out and it got in the way. My young kids are rough and they also hurt themselves running around on the wire crate so we opted for a plastic version and it’s super safe for my kids and my pup. It also folds flat quickly so it’s A+ for me",
+        "rating": 5,
+        "date": "Reviewed in the United States on December 7, 2025",
+        "extracted_date": "2025-12-07",
+        "profile": {
+          "id": "AGH655KJWRCOKYDHMUMZNVCCGV6A",
+          "name": "Kristine Boel",
+          "link": "https://www.amazon.com/gp/profile/amzn1.account.AGH655KJWRCOKYDHMUMZNVCCGV6A"
+        },
+        "images": [
+          "https://m.media-amazon.com/images/I/71h-QbZQKsL.jpg"
+        ],
+        "is_verified_purchase": true
+      },
+      {
+        "id": "R1CIL3GWVLS354",
+        "asin": "R1CIL3GWVLS354",
+        "title": "You can’t see your dog when it’s inside",
+        "link": "https://www.amazon.com/gp/customer-reviews/R1CIL3GWVLS354/ref=cm_cr_dp_d_rvw_ttl?ie=UTF8",
+        "text": "Nice crate. Lightweight and easy to collapse. I felt the door was a little wonky. We could not see the dog inside and didn’t like that. We bought a wire crate.",
+        "rating": 3,
+        "date": "Reviewed in the United States on March 28, 2026",
+        "extracted_date": "2026-03-28",
+        "profile": {
+          "id": "AFEISGJ7CRIKMZQELNT7C43JHI4A",
+          "name": "KathyF",
+          "link": "https://www.amazon.com/gp/profile/amzn1.account.AFEISGJ7CRIKMZQELNT7C43JHI4A"
+        },
+        "is_verified_purchase": true
+      }
+    ],
+    "global": [
+      {
+        "id": "R30M9YKLOX6A84",
+        "title": "Crate mat.",
+        "text": "Crate mat is great. Very happy with it.",
+        "rating": 5,
+        "date": "Reviewed in Australia on March 22, 2025",
+        "extracted_date": "2025-03-22",
+        "profile": {
+          "name": "Judy Bihary"
+        },
+        "is_verified_purchase": true
+      }
+    ]
+  }
+}

--- a/src/data/amazon-products/B0G3PBR7XS.json
+++ b/src/data/amazon-products/B0G3PBR7XS.json
@@ -1,0 +1,144 @@
+{
+  "search_metadata": {
+    "id": "search_Lpb2Z8vDqdsEl2ZRDkVgQzRy",
+    "status": "Success",
+    "created_at": "2026-04-10T03:02:58Z",
+    "request_time_taken": 4.21,
+    "parsing_time_taken": 0.04,
+    "total_time_taken": 4.25,
+    "request_url": "https://www.amazon.com/dp/B0G3PBR7XS?th=1&psc=1",
+    "html_url": "https://www.searchapi.io/api/v1/searches/search_Lpb2Z8vDqdsEl2ZRDkVgQzRy.html",
+    "json_url": "https://www.searchapi.io/api/v1/searches/search_Lpb2Z8vDqdsEl2ZRDkVgQzRy"
+  },
+  "search_parameters": {
+    "engine": "amazon_product",
+    "asin": "B0G3PBR7XS",
+    "amazon_domain": "amazon.com",
+    "delivery_country": "us"
+  },
+  "product": {
+    "asin": "B0G3PBR7XS",
+    "title": "Lesure Soft Collapsible Dog Crate with LE SURE Dog Birthday Cake Toy",
+    "brand_store": {
+      "text": "Brand: LE SURE",
+      "link": "https://www.amazon.com/s/ref=bl_dp_s_web_0?ie=UTF8&search-alias=aps&field-keywords=LE+SURE"
+    },
+    "marketplace_id": "ATVPDKIKX0DER",
+    "link": "https://www.amazon.com/Lesure-Collapsible-Crate-SURE-Birthday/dp/B0G3PBR7XS",
+    "description": "Lesure Soft Collapsible Dog Crate With LE SURE Dog Birthday Cake Toy",
+    "feature_bullets": [
+      "Designed for Traveling: This soft-sided crate features a foldable construction frame that can be easily folded into an extra compact package. It comes with a convenient storage bag, allowing you to carry it effortlessly on your outings and travels. The quick assembly in just 2 minutes and easy disassembly make it a hassle-free choice for your adventures.",
+      "Breathable & Comfortable: The four-side zippered breathable mesh walls ensure optimal ventilation, providing a comfortable environment for your furry friend. The soft plush mat inside the crate offers a cozy and comfortable space for them to relax and unwind.",
+      "Enhanced Safety: This crate features a sturdy iron frame that maintains structural integrity. Reflective strips on both sides provide visibility for your pet's safety. The self-locking zipper system prevents escapes, while the mesh offers secure containment. An integrated leash adds an additional safety measure.",
+      "Easy Assembly, Storage, & Maintenance: The convenient and simple design allows for quick assembly within 2 minutes. The crate can be folded into two different ways, catering to various indoor and outdoor settings. It features a water resistant design with waterproof fabric, making it easy to clean with just a damp cloth. The removable and machine washable mat simplifies care.",
+      "Various Sizes for All Breeds: This crate is available in four sizes to accommodate different breeds and sizes of pets. Choose from S (up to 35lbs), M (up to 50lbs), L (up to 70lbs), and XL (up to 90lbs) to find the perfect fit for your furry companion."
+    ],
+    "search_alias": {
+      "title": "Pet Supplies",
+      "value": "pets"
+    },
+    "buybox": {
+      "price": {
+        "raw": "$104.00",
+        "value": 104,
+        "symbol": "$",
+        "currency": "USD"
+      },
+      "original_price": {
+        "raw": "$111.98",
+        "value": 111.98,
+        "symbol": "$",
+        "currency": "USD"
+      },
+      "save": {
+        "percentage": 7
+      },
+      "offer_listing_id": "N3Am7fVu3frFMuHtRjaicIlirB%2BTsW%2F%2BHmQMm7ZR81RVCVkDE%2FuOKsffuxCW7HmleTsrzwctCfRLk9DaMD5iueAQYi5WlA2aBZCVH%2Be2GbsGSUyPRHf5i9i38YFb0fw0lN9%2FJl2sBIr86r258LdZGqoD7O9mPnG7gKXwwS9arTo%3D",
+      "fulfillment": {
+        "standard_delivery": {
+          "text": "Delivery April 24 - May 18",
+          "date": "April 24 - May 18"
+        },
+        "third_party_seller": {
+          "id": "A23G3BO9GSH7EX",
+          "name": "Bedsure Comfy Pet",
+          "link": "https://www.amazon.com/gp/help/seller/at-a-glance.html/ref=dp_merchant_link?ie=UTF8&seller=A23G3BO9GSH7EX&asin=B0G3PBR7XS&ref_=dp_merchant_link&isAmazonFulfilled=1"
+        },
+        "ships_from": "Amazon",
+        "sold_by": "Bedsure Comfy Pet",
+        "is_sold_by_amazon": true
+      }
+    },
+    "specifications": [
+      {
+        "name": "Brand Name",
+        "value": "LE SURE"
+      },
+      {
+        "name": "ASIN",
+        "value": "B0G3PBR7XS"
+      },
+      {
+        "name": "Product Style",
+        "value": "Lesure Soft Collapsible Dog Crate With LE SURE Dog Birt"
+      },
+      {
+        "name": "Date First Available",
+        "value": "October 7, 2025"
+      },
+      {
+        "name": "ASIN",
+        "value": "B0G3PBR7XS"
+      }
+    ],
+    "main_image": "https://m.media-amazon.com/images/I/8111DM2a0KL.jpg",
+    "images": [
+      {
+        "link": "https://m.media-amazon.com/images/I/8111DM2a0KL.jpg",
+        "variant": "MAIN"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/91NAyJvKBlL.jpg",
+        "variant": "PT01"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/71PyRVnjMKL.jpg",
+        "variant": "PT02"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/81vlrcmuoUL.jpg",
+        "variant": "PT04"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/81K3F6JBsjL.jpg",
+        "variant": "PT05"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/81NcroE7qjL.jpg",
+        "variant": "PT06"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/81QpPRhbquL.jpg",
+        "variant": "PT07"
+      },
+      {
+        "link": "https://m.media-amazon.com/images/I/81oBK9e2ZKL.jpg",
+        "variant": "PT08"
+      }
+    ]
+  },
+  "similar_item": {
+    "asin": "B0D1CDTF7L",
+    "title": "Amazon Basics Portable Folding Soft Dog Crate, 4-Doors, Collapsible Travel Kennel for Cat, Dog, and Small Animals, Quick Setup, Small 26\" x 18\" x 18\", Grey",
+    "link": "https://www.amazon.com/dp/B0D1CDTF7L/ref=vp_d_pbs_trans_lp_B0G3PBR7XS_pd?_encoding=UTF8&pf_rd_p=f6007f53-9fa1-4c0d-b499-54e844408da9&pf_rd_r=P44WNXKWDYVADD0WNNSZ&pd_rd_wg=xYRGv&pd_rd_i=B0D1CDTF7L&pd_rd_w=hmSdi&content-id=amzn1.sym.f6007f53-9fa1-4c0d-b499-54e844408da9&pd_rd_r=399f307d-c553-48d4-b4a1-3abb305d724b&psc=1",
+    "rating": 4.5,
+    "reviews": 18745,
+    "price": {
+      "raw": "$62.99",
+      "value": 62.99,
+      "symbol": "$",
+      "currency": "USD"
+    },
+    "image": "https://m.media-amazon.com/images/I/81mUSHCk2oL.jpg"
+  }
+}

--- a/src/data/collector-bodies.ts
+++ b/src/data/collector-bodies.ts
@@ -210,8 +210,8 @@ export const comfortCollectorBody: CollectorBodyConfig = {
   accent: 'terracotta',
   sections: [
     {
-      heading: 'Shop by Bed Type',
-      intro: 'Two types of beds for two different needs — calming beds for dogs who seek security and enclosure, orthopedic beds for dogs who need joint support.',
+      heading: 'Shop by Rest Setup',
+      intro: 'Beds and crates for different rest needs — calming beds for dogs who seek security, orthopedic beds for joint support, and puppy crates for training.',
       cards: [
         {
           href: ROUTES.comfortCalmingBeds,
@@ -228,6 +228,30 @@ export const comfortCollectorBody: CollectorBodyConfig = {
           linkLabel: 'See our picks ->',
           dataToPage: ROUTES.comfortOrthopedicBeds,
           dataCategory: 'orthopedic-beds',
+        },
+        {
+          href: ROUTES.comfortPuppyCrates,
+          title: 'Best Puppy Crates',
+          description: 'Divider-based wire crates for housebreaking, quiet-time practice, and a first crate-training setup.',
+          linkLabel: 'See our picks ->',
+          dataToPage: ROUTES.comfortPuppyCrates,
+          dataCategory: 'crates',
+        },
+        {
+          href: ROUTES.comfortAnxietyCrates,
+          title: 'Best Dog Crates for Anxiety',
+          description: 'Wire, enclosed, and heavy-duty crates for different anxiety and escape-risk patterns.',
+          linkLabel: 'Compare options ->',
+          dataToPage: ROUTES.comfortAnxietyCrates,
+          dataCategory: 'crates',
+        },
+        {
+          href: ROUTES.comfortTravelCrates,
+          title: 'Best Travel Crates for Road Trips',
+          description: 'Hard-sided and soft folding crates for car travel, hotels, and road trip setup.',
+          linkLabel: 'Compare travel crates ->',
+          dataToPage: ROUTES.comfortTravelCrates,
+          dataCategory: 'crates',
         },
       ],
     },

--- a/src/data/relaxation-converter-pages.ts
+++ b/src/data/relaxation-converter-pages.ts
@@ -659,7 +659,7 @@ export const relaxationConverterPages: Record<string, RelaxationConverterPageCon
     hero: {
       title: 'Best Travel Crates for Road Trips',
       subtitle:
-        'For road trips, the best dog travel crate depends less on price and more on how your dog actually travels. Some dogs do well in a lightweight folding crate that is easy to pack and set up. Others need a sturdier hard-sided kennel with more structure and fewer opportunities to claw their way out.',
+        'For road trips, the best dog travel crate depends less on price and more on how your dog actually travels. Some dogs do well in a lightweight folding crate that is easy to pack and set up. Others need a sturdier, hard-sided kennel with more structure that makes it harder for them to claw their way out.',
       disclaimer: 'As an Amazon Associate, we earn from qualifying purchases.',
       primaryCta: { label: 'See Quick Picks', href: '#quick-picks' },
       secondaryCta: { label: 'Road Trip Gear', href: ROUTES.roadTrip },
@@ -677,7 +677,7 @@ export const relaxationConverterPages: Record<string, RelaxationConverterPageCon
         id: 'quick-picks',
         heading: 'Quick Answer: Top Picks',
         intro:
-          'If you already know how your dog behaves in a crate, the choice gets simple. Prioritize structure for dogs who push boundaries. Prioritize portability only for calm, crate-trained dogs.',
+          'If you already know how your dog behaves in a crate, the choice is simple. Prioritize portability for calm, crate-trained dogs. Prioritize structure for dogs who push boundaries.',
         items: [
           {
             label: 'Best Overall for Road Trips',
@@ -699,7 +699,7 @@ export const relaxationConverterPages: Record<string, RelaxationConverterPageCon
             label: 'Best Soft Folding Crate',
             title: 'EliteField 3-Door Folding Soft Dog Crate',
             description:
-              'A strong soft-sided option for trained dogs, hotel stays, and temporary setup when the three-door layout is useful.',
+              'A strong, soft-sided option for trained dogs, hotel stays, and temporary setup when the three-door layout is useful.',
             productId: 'elitefield-three-door-soft-crate',
             position: 'quick-picks-3',
           },
@@ -718,9 +718,9 @@ export const relaxationConverterPages: Record<string, RelaxationConverterPageCon
         id: 'hard-sided-vs-soft',
         heading: 'Hard-Sided vs Soft Folding Travel Crates',
         paragraphs: [
-          'A dog travel crate for car use is not the same decision as a puppy house-training crate or an airline crate. For road trips, the tradeoff is usually structure versus portability.',
-          'Hard-sided dog crates for road trips are usually the better choice for dogs that need more containment, more enclosure, or fewer soft surfaces to scratch and chew. They take up more room and are less convenient to store, but they give you a more structured setup.',
-          'A collapsible dog crate for road trips is easier to pack, carry, and set up in hotels or temporary spaces. Soft dog crates for car travel are best for dogs that are already crate trained, calm in confinement, and not likely to chew, claw, or push hard against the walls.',
+          'Choosing a travel crate for car use is not the same as choosing a puppy house-training crate or an airline crate. For road trips, the tradeoff is usually structure versus portability.',
+          'Hard-sided dog crates are usually the better choice for dogs that need more containment, more enclosure, and fewer soft surfaces to scratch and chew. They take up more room and are less convenient to store, but they give you a more structured setup.',
+          'A collapsible dog crate is easier to pack, carry, and set up in hotels or temporary spaces. Soft dog crates are best for dogs that are already crate trained, calm in confinement, and not likely to chew, claw, or push hard against the walls.',
           '<strong>Important:</strong> Soft folding crates are convenient for road trips, hotel stays, and calm crate-trained dogs, but they are not indestructible. A determined dog can claw, chew, or push out of one much more easily than from a hard-sided crate. Do not use a soft crate for dogs with serious anxiety, destructive behavior, or strong escape tendencies.',
         ],
         alt: true,
@@ -732,7 +732,7 @@ export const relaxationConverterPages: Record<string, RelaxationConverterPageCon
         positionOffset: 0,
         columns: 2,
         intro:
-          'These are road-trip crate picks, not general indoor crates or airline-crate rankings. The goal is quick fit: car convenience, realistic containment, and easy setup when you reach the next stop.',
+          'These crate picks are for road trips, not for general indoor use or for airline travel. They prioritize car convenience, realistic containment, and easy setup when you reach the next stop.',
         productIds: [
           'petsafe-happy-ride-travel-crate',
           'petmate-sky-kennel',
@@ -752,7 +752,7 @@ export const relaxationConverterPages: Record<string, RelaxationConverterPageCon
         kind: 'prose',
         heading: 'Petmate Sky Kennel',
         paragraphs: [
-          'Choose Petmate if your dog needs a harder-sided, more secure setup. The plastic shell is more enclosed than a soft folding crate and gives dogs fewer fabric or mesh surfaces to chew, claw, or push through.',
+          'Choose Petmate if your dog needs a harder-sided, more secure setup. The plastic shell is more enclosed than a soft folding crate with no mesh surfaces to chew, claw, or push through.',
           'It is the better fit for dogs who need more structure on road trips, but it is less compact than a soft folding travel crate. That is the tradeoff: more structure, less packability.',
         ],
         alt: true,
@@ -761,8 +761,8 @@ export const relaxationConverterPages: Record<string, RelaxationConverterPageCon
         kind: 'prose',
         heading: 'EliteField 3-Door Folding Soft Dog Crate',
         paragraphs: [
-          'Choose EliteField if you want a soft folding crate for a trained dog and like the three-door setup. Top, front, and side access can make a real difference when the crate moves between a car, hotel room, campsite, or temporary sleeping area.',
-          'This is a convenience pick for dogs who already settle calmly in a crate. It is not the right choice for dogs who panic, chew, claw, or test crate walls.',
+          'Choose EliteField if you want a soft folding crate for a trained dog and like the three-door setup. Top, front, and side access is convenient when the crate moves between a car, hotel room, campsite, or temporary sleeping area.',
+          'This is good for dogs who already settle calmly in a crate. It is not the right choice for dogs who panic, chew, claw, or test crate walls.',
         ],
       },
       {
@@ -780,19 +780,19 @@ export const relaxationConverterPages: Record<string, RelaxationConverterPageCon
         left: {
           heading: 'Choose hard-sided when',
           items: [
-            'Your dog needs more structure or enclosure during car travel.',
-            'Your dog paws at doors, pushes against crate walls, or gets overstimulated by visibility.',
-            'You want a more realistic containment setup than fabric and mesh.',
-            'Packability matters less than a sturdier travel crate.',
+            'Your dog needs more structure or enclosure during car travel',
+            'Your dog paws at doors, pushes against crate walls, or gets overstimulated by visibility',
+            'Your dog needs stronger containment than fabric and mesh',
+            'Packability matters less than a sturdier travel crate',
           ],
         },
         right: {
           heading: 'Choose soft folding when',
           items: [
-            'Your dog is already crate-trained and calm in confinement.',
-            'You need a folding dog crate for travel, hotel stays, or temporary setup.',
-            'Lightweight carry and compact storage matter most.',
-            'Your dog will not chew, claw, or try hard to escape.',
+            'Your dog is already crate-trained and calm in confinement',
+            'You need a folding dog crate for travel, hotel stays, or temporary setup',
+            'You need the convenience of lightweight carry and compact storage',
+            'Your dog will not chew, claw, or try to escape',
           ],
         },
       },

--- a/src/data/relaxation-converter-pages.ts
+++ b/src/data/relaxation-converter-pages.ts
@@ -304,6 +304,569 @@ export const relaxationConverterPages: Record<string, RelaxationConverterPageCon
     },
   },
 
+  'best-puppy-crates': {
+    slug: 'best-puppy-crates',
+    title: 'Best Puppy Crates for Crate Training',
+    description:
+      'Compare puppy crates for crate training, including KindTail PAWD, Midwest iCrate, Midwest Life Stages, and Petmate Training Retreat Kennel options.',
+    pageSlug: 'best-puppy-crates',
+    hero: {
+      title: 'Best Puppy Crates',
+      subtitle:
+        'A first puppy crate needs to do one job well: make housebreaking and quiet-time practice easier without forcing you to buy another crate in a month. For most puppies, that means a wire crate with a divider panel, enough size options, and a door layout that fits the room where training actually happens.',
+      disclaimer: 'As an Amazon Associate, we earn from qualifying purchases.',
+      primaryCta: { label: 'See Quick Picks', href: '#quick-picks' },
+      secondaryCta: { label: 'Crate Training Guide', href: ROUTES.calmingCrateGuide },
+    },
+    toc: [
+      { label: 'Quick Picks', anchor: 'quick-picks' },
+      { label: 'Puppy Crate Picks', anchor: 'puppy-crates' },
+      { label: 'iCrate vs Life Stages', anchor: 'icrate-vs-life-stages' },
+      { label: 'Which Crate Fits Your Puppy', anchor: 'which-crate' },
+      { label: 'FAQ', anchor: 'faq' },
+    ],
+    blocks: [
+      {
+        kind: 'quick_picks',
+        id: 'quick-picks',
+        heading: 'Quick Picks',
+        intro:
+          'Start with the crate that matches your actual constraint: finished home setup, budget, build quality, or room layout. These picks are practical for puppy crate training, but they solve slightly different problems.',
+        items: [
+          {
+            label: 'Top Pick for Puppy Crate Training',
+            title: 'KindTail PAWD Collapsible Dog Crate',
+            description:
+              'The featured pick if you want a cleaner-looking puppy crate that collapses for storage and includes a washable bed.',
+            productId: 'kindtail-pawd-collapsible-crate',
+            position: 'quick-picks-1',
+          },
+          {
+            label: 'Best Budget First Crate',
+            title: 'MidWest iCrate Dog Crate (18-Inch)',
+            description:
+              'The simple pick for tiny-breed puppies: lighter, usually cheaper, and built around the divider-panel setup that makes puppy housebreaking easier.',
+            productId: 'midwest-icrate-puppy',
+            position: 'quick-picks-2',
+          },
+          {
+            label: 'Best Sturdier Wire Crate',
+            title: 'MidWest Life Stages Dog Crate (22-Inch)',
+            description:
+              'The one to lean toward if the price gap is small. Life Stages uses heavier-gauge steel than iCrate and feels more solid for active puppies.',
+            productId: 'midwest-life-stages-puppy-crate',
+            position: 'quick-picks-3',
+          },
+          {
+            label: 'Best Flexible Door Layout',
+            title: 'Petmate Training Retreat Kennel',
+            description:
+              'A useful alternative when side-door access matters. The two-door layout can make daily crate routines easier in tight bedrooms or living rooms.',
+            productId: 'petmate-training-retreat-kennel',
+            position: 'quick-picks-4',
+          },
+        ],
+      },
+      {
+        kind: 'product_section',
+        id: 'puppy-crates',
+        heading: 'Puppy Crate Picks',
+        positionOffset: 0,
+        columns: 3,
+        intro:
+          'For crate training, prioritize fit and daily usability over extras. A divider matters because puppies should not start with a crate that is so large they can sleep on one side and potty on the other.',
+        productIds: [
+          'kindtail-pawd-collapsible-crate',
+          'midwest-icrate-puppy',
+          'midwest-life-stages-puppy-crate',
+          'petmate-training-retreat-kennel',
+        ],
+      },
+      {
+        kind: 'prose',
+        id: 'icrate-vs-life-stages',
+        heading: 'MidWest iCrate vs Life Stages',
+        paragraphs: [
+          'The iCrate and Life Stages lines look similar because they solve the same core problem: a wire crate with multiple size options and a divider panel. The practical difference is build and handling.',
+          'iCrate is the lighter, simpler, usually more budget-friendly option. It is easier to move around and makes sense for standard puppy crate training when your dog is not especially strong or hard on gear.',
+          'Life Stages uses heavier-gauge steel and is built to feel sturdier. Some iCrate sizes are also slightly narrower and lower than comparable Life Stages models. If the price gap is small, Life Stages is the one I would lean toward for a stronger or more active puppy.',
+        ],
+        alt: true,
+      },
+      {
+        kind: 'decision_columns',
+        id: 'which-crate',
+        left: {
+          heading: 'Get iCrate when',
+          items: [
+            'You want the simpler budget-friendly option.',
+            'You plan to move the crate around the house often.',
+            'Your puppy is average-strength and you mainly need a divider-based training setup.',
+            'Lower crate weight matters more than a sturdier wire frame.',
+          ],
+        },
+        right: {
+          heading: 'Get Life Stages when',
+          items: [
+            'You want the sturdier Midwest option.',
+            'Your puppy is strong, active, or likely to push against the crate.',
+            'You do not mind extra crate weight.',
+            'The price difference is small enough that durability is worth prioritizing.',
+          ],
+        },
+      },
+      {
+        kind: 'note',
+        heading: 'Where Petmate Fits',
+        text:
+          'The Petmate Training Retreat Kennel is less about beating the Midwest crates on build and more about room fit. If a side door would make the crate easier to use every day, it can be the more practical choice.',
+        alt: true,
+      },
+    ],
+    faq: {
+      heading: 'Puppy Crate FAQ',
+      items: [
+        {
+          question: 'What type of crate is best for a puppy?',
+          answer:
+            'For most puppies, a wire crate with a divider panel is the easiest starting point. The divider lets you create a smaller sleeping area during housebreaking, then expand the space as your puppy grows.',
+        },
+        {
+          question: 'Should I get iCrate or Life Stages?',
+          answer:
+            'Get iCrate if you want the lighter, usually cheaper option for standard puppy crate training. Get Life Stages if you want the sturdier Midwest crate and do not mind extra weight. If the price gap is small, Life Stages is the stronger pick.',
+        },
+        {
+          question: 'Why does a puppy crate need a divider?',
+          answer:
+            'A divider prevents the crate from being too large at the beginning. Puppies are more likely to keep a correctly sized sleeping area clean, while an oversized crate can let them sleep in one corner and potty in another.',
+        },
+        {
+          question: 'Is a two-door crate worth it?',
+          answer:
+            'A two-door crate is useful when the crate sits beside furniture, in a bedroom corner, or anywhere a single front door would be inconvenient. If the crate will sit in an open area, one door is usually enough.',
+        },
+      ],
+    },
+    relatedGuides: {
+      heading: 'More Crate Training Help',
+      guides: [
+        {
+          href: ROUTES.calmingCrateGuide,
+          title: 'How to Crate Train Your Dog',
+          description:
+            'Step-by-step crate training guidance for puppies, anxious dogs, travel, and common mistakes to avoid.',
+        },
+        {
+          href: ROUTES.comfortCalmingBeds,
+          title: 'Best Calming Dog Beds',
+          description:
+            'If your puppy settles better with soft edges and a defined rest area, compare calming beds and bolster beds next.',
+        },
+      ],
+    },
+    disclosureShowSafety: false,
+    internalLinkStrip: {
+      heading: 'More Puppy Comfort Guides',
+      links: [
+        { label: 'Crate Training Guide', href: ROUTES.calmingCrateGuide },
+        { label: 'Calming Dog Beds', href: ROUTES.comfortCalmingBeds },
+        { label: 'Comfort & Rest', href: ROUTES.comfortHub },
+      ],
+    },
+    itemListSchema: {
+      name: 'Best Puppy Crates',
+      url: 'https://www.chill-dogs.com/comforting/best-puppy-crates/',
+      productIds: [
+        'kindtail-pawd-collapsible-crate',
+        'midwest-icrate-puppy',
+        'midwest-life-stages-puppy-crate',
+        'petmate-training-retreat-kennel',
+      ],
+    },
+  },
+
+  'best-anxiety-dog-crates': {
+    slug: 'best-anxiety-dog-crates',
+    title: 'Best Dog Crates for Anxiety Management',
+    description:
+      'Compare dog crates for anxiety management, including wire, enclosed plastic, and heavy-duty options for different dog patterns.',
+    pageSlug: 'best-anxiety-dog-crates',
+    hero: {
+      title: 'Best Dog Crates for Anxiety',
+      subtitle:
+        'An anxiety crate should match the dog, not the label. Some dogs settle in a familiar wire crate. Some do better with an enclosed kennel that blocks visual stimulation. And some escape artists need a heavy-duty crate only as part of a broader safety plan.',
+      disclaimer: 'As an Amazon Associate, we earn from qualifying purchases.',
+      primaryCta: { label: 'See Quick Picks', href: '#quick-picks' },
+      secondaryCta: { label: 'Crate Training Guide', href: ROUTES.calmingCrateGuide },
+    },
+    toc: [
+      { label: 'Quick Picks', anchor: 'quick-picks' },
+      { label: 'Safety First', anchor: 'safety-first' },
+      { label: 'Anxiety Crate Picks', anchor: 'anxiety-crates' },
+      { label: 'Which Crate Fits the Pattern', anchor: 'which-crate' },
+      { label: 'FAQ', anchor: 'faq' },
+    ],
+    blocks: [
+      {
+        kind: 'quick_picks',
+        id: 'quick-picks',
+        heading: 'Quick Picks',
+        intro:
+          'Use these as management categories, not anxiety cures. The right choice depends on whether your dog is mildly unsettled, overstimulated by visibility, or actively trying to escape.',
+        items: [
+          {
+            label: 'Best Wire Crate for Mild Anxiety',
+            title: 'MidWest Life Stages Dog Crate',
+            description:
+              'A sturdy wire option for dogs who are already crate-trained and need a familiar, ventilated place to settle during mild stress.',
+            productId: 'midwest-life-stages-crate',
+            position: 'quick-picks-1',
+          },
+          {
+            label: 'Best Enclosed Crate',
+            title: 'Petmate Sky Kennel',
+            description:
+              'The enclosed plastic shell can reduce visual stimulation for dogs who settle better when the world is partly blocked out.',
+            productId: 'petmate-sky-kennel',
+            position: 'quick-picks-2',
+          },
+          {
+            label: 'Best Heavy-Duty Crate',
+            title: 'Impact High Anxiety Dog Crate',
+            description:
+              'The heavy-duty option for dogs with a real escape history, bent wire crates, or injury risk from standard crate attempts.',
+            productId: 'impact-high-anxiety-crate',
+            position: 'quick-picks-3',
+          },
+        ],
+      },
+      {
+        kind: 'prose',
+        id: 'safety-first',
+        heading: 'Safety First: A Crate Is Not a Separation Anxiety Cure',
+        paragraphs: [
+          'A crate can be a useful management tool for some anxious dogs, but it is not a treatment for separation anxiety by itself. <a href="https://www.humaneworld.org/resources/separation-anxiety-dogs">Humane World</a> specifically advises creating a safe space instead of defaulting to a crate for separation anxiety because dogs can continue panicking inside confinement and may injure themselves trying to escape.',
+          '<a href="https://www.aspca.org/pet-care/dog-care/common-dog-behavior-issues/separation-anxiety">ASPCA separation-anxiety guidance</a> and <a href="https://www.oregonhumane.org/portland-training/crate-training-your-dog/">Oregon Humane crate-training guidance</a> make the same practical point: watch the dog’s actual pattern. If confinement makes panic worse, use a room, pen, veterinary behavior support, and gradual training rather than trying to solve the problem with a stronger crate.',
+          'So this page frames crates as management choices: wire for mild anxiety in dogs who already tolerate crates, enclosed plastic for dogs who need less visual stimulation, and heavy-duty containment only when escape risk makes standard crates unsafe.',
+        ],
+        alt: true,
+      },
+      {
+        kind: 'product_section',
+        id: 'anxiety-crates',
+        heading: 'Anxiety Crate Picks',
+        positionOffset: 0,
+        columns: 3,
+        intro:
+          'These three picks cover different anxiety patterns. Do not size down for containment. Your dog still needs room to stand, turn around, and lie down naturally.',
+        productIds: ['midwest-life-stages-crate', 'petmate-sky-kennel', 'impact-high-anxiety-crate'],
+      },
+      {
+        kind: 'decision_columns',
+        id: 'which-crate',
+        left: {
+          heading: 'Use Life Stages or Sky Kennel when',
+          items: [
+            'Your dog is already crate-trained and does not panic in confinement.',
+            'The anxiety is mild, situational, or linked to overstimulation.',
+            'Your goal is a predictable rest space, not brute-force containment.',
+            'You can monitor the dog’s response and change course if distress escalates.',
+          ],
+        },
+        right: {
+          heading: 'Consider Impact only when',
+          items: [
+            'Your dog has escaped from or damaged standard crates.',
+            'Wire bars create tooth, paw, or latch-injury risk for this specific dog.',
+            'You are also working on the underlying anxiety with training or professional support.',
+            'You need containment as harm reduction, not as the whole behavior plan.',
+          ],
+        },
+      },
+      {
+        kind: 'note',
+        heading: 'When No Crate Is the Better Choice',
+        text:
+          'If your dog drools, thrashes, screams, urinates, or injures itself when confined, a stronger crate may only make the panic more dangerous. In that case, use a safer room or pen setup and talk with a veterinarian or qualified separation-anxiety trainer.',
+        alt: true,
+      },
+    ],
+    faq: {
+      heading: 'Anxiety Crate FAQ',
+      items: [
+        {
+          question: 'Can a crate help with dog anxiety?',
+          answer:
+            'Sometimes, but only for dogs who already feel safe in a crate. For mild anxiety, a familiar crate can reduce pacing and provide predictability. For true separation anxiety or confinement panic, a crate can make distress worse.',
+        },
+        {
+          question: 'What is the best crate for mild anxiety?',
+          answer:
+            'For mild anxiety in a dog who tolerates wire crates, MidWest Life Stages is the practical pick because it is sturdier than lighter wire crates while still offering airflow, visibility, and a divider panel.',
+        },
+        {
+          question: 'Is an enclosed crate better for anxious dogs?',
+          answer:
+            'An enclosed plastic crate like the Petmate Sky Kennel can help dogs who settle better with less visual stimulation. It is not automatically better for every anxious dog, especially dogs who panic when confined.',
+        },
+        {
+          question: 'When does a heavy-duty anxiety crate make sense?',
+          answer:
+            'A heavy-duty crate makes sense when a dog has a real escape history and standard crates create injury risk. It should still be part of a broader plan that addresses the underlying anxiety.',
+        },
+      ],
+    },
+    relatedGuides: {
+      heading: 'More Anxiety & Crate Training Help',
+      guides: [
+        {
+          href: ROUTES.calmingCrateGuide,
+          title: 'How to Crate Train Your Dog',
+          description:
+            'Crate training basics, puppy setup, anxiety cautions, travel use, and common mistakes to avoid.',
+        },
+        {
+          href: ROUTES.calmingTop,
+          title: 'Best Calming Products for Anxious Dogs',
+          description:
+            'Compare wraps, chews, lick mats, and snuffle mats for dogs who need support beyond crate management.',
+        },
+      ],
+    },
+    disclosureShowSafety: true,
+    internalLinkStrip: {
+      heading: 'More Anxiety Guides',
+      links: [
+        { label: 'Crate Training Guide', href: ROUTES.calmingCrateGuide },
+        { label: 'Puppy Crates', href: ROUTES.comfortPuppyCrates },
+        { label: 'Best Calming Products', href: ROUTES.calmingTop },
+      ],
+    },
+    itemListSchema: {
+      name: 'Best Dog Crates for Anxiety',
+      url: 'https://www.chill-dogs.com/comforting/best-anxiety-dog-crates/',
+      productIds: ['midwest-life-stages-crate', 'petmate-sky-kennel', 'impact-high-anxiety-crate'],
+    },
+  },
+
+  'best-travel-crates-for-road-trips': {
+    slug: 'best-travel-crates-for-road-trips',
+    title: 'Best Travel Crates for Road Trips',
+    description:
+      'Compare the best travel crates for road trips, including collapsible dog crates, hard-sided kennels, and soft folding crates for car travel.',
+    pageSlug: 'best-travel-crates-for-road-trips',
+    hero: {
+      title: 'Best Travel Crates for Road Trips',
+      subtitle:
+        'For road trips, the best dog travel crate depends less on price and more on how your dog actually travels. Some dogs do well in a lightweight folding crate that is easy to pack and set up. Others need a sturdier hard-sided kennel with more structure and fewer opportunities to claw their way out.',
+      disclaimer: 'As an Amazon Associate, we earn from qualifying purchases.',
+      primaryCta: { label: 'See Quick Picks', href: '#quick-picks' },
+      secondaryCta: { label: 'Road Trip Gear', href: ROUTES.roadTrip },
+    },
+    toc: [
+      { label: 'Quick Picks', anchor: 'quick-picks' },
+      { label: 'Hard-Sided vs Soft Folding', anchor: 'hard-sided-vs-soft' },
+      { label: 'Travel Crate Comparison', anchor: 'travel-crates' },
+      { label: 'Which One Should You Buy', anchor: 'which-one' },
+      { label: 'Bottom Line', anchor: 'bottom-line' },
+    ],
+    blocks: [
+      {
+        kind: 'quick_picks',
+        id: 'quick-picks',
+        heading: 'Quick Answer: Top Picks',
+        intro:
+          'If you already know how your dog behaves in a crate, the choice gets simple. Prioritize structure for dogs who push boundaries. Prioritize portability only for calm, crate-trained dogs.',
+        items: [
+          {
+            label: 'Best Overall for Road Trips',
+            title: 'PetSafe Happy Ride Collapsible Travel Crate',
+            description:
+              'The best all-around road trip pick because it is specifically built around travel use, car setup, and collapsible storage.',
+            productId: 'petsafe-happy-ride-travel-crate',
+            position: 'quick-picks-1',
+          },
+          {
+            label: 'Best Hard-Sided Travel Crate',
+            title: 'Petmate Sky Kennel',
+            description:
+              'The better hard-sided choice when your dog needs more structure, more enclosure, or a sturdier alternative to soft folding travel crates.',
+            productId: 'petmate-sky-kennel',
+            position: 'quick-picks-2',
+          },
+          {
+            label: 'Best Soft Folding Crate',
+            title: 'EliteField 3-Door Folding Soft Dog Crate',
+            description:
+              'A strong soft-sided option for trained dogs, hotel stays, and temporary setup when the three-door layout is useful.',
+            productId: 'elitefield-three-door-soft-crate',
+            position: 'quick-picks-3',
+          },
+          {
+            label: 'Best Lightweight Soft Crate',
+            title: 'Lesure Soft Collapsible Dog Crate',
+            description:
+              'The lightweight convenience pick for calm, trained dogs when easy carry, quick setup, and compact storage matter most.',
+            productId: 'lesure-soft-collapsible-crate',
+            position: 'quick-picks-4',
+          },
+        ],
+      },
+      {
+        kind: 'prose',
+        id: 'hard-sided-vs-soft',
+        heading: 'Hard-Sided vs Soft Folding Travel Crates',
+        paragraphs: [
+          'A dog travel crate for car use is not the same decision as a puppy house-training crate or an airline crate. For road trips, the tradeoff is usually structure versus portability.',
+          'Hard-sided dog crates for road trips are usually the better choice for dogs that need more containment, more enclosure, or fewer soft surfaces to scratch and chew. They take up more room and are less convenient to store, but they give you a more structured setup.',
+          'A collapsible dog crate for road trips is easier to pack, carry, and set up in hotels or temporary spaces. Soft dog crates for car travel are best for dogs that are already crate trained, calm in confinement, and not likely to chew, claw, or push hard against the walls.',
+          '<strong>Important:</strong> Soft folding crates are convenient for road trips, hotel stays, and calm crate-trained dogs, but they are not indestructible. A determined dog can claw, chew, or push out of one much more easily than from a hard-sided crate. Do not use a soft crate for dogs with serious anxiety, destructive behavior, or strong escape tendencies.',
+        ],
+        alt: true,
+      },
+      {
+        kind: 'product_section',
+        id: 'travel-crates',
+        heading: 'Product Comparison',
+        positionOffset: 0,
+        columns: 2,
+        intro:
+          'These are road-trip crate picks, not general indoor crates or airline-crate rankings. The goal is quick fit: car convenience, realistic containment, and easy setup when you reach the next stop.',
+        productIds: [
+          'petsafe-happy-ride-travel-crate',
+          'petmate-sky-kennel',
+          'elitefield-three-door-soft-crate',
+          'lesure-soft-collapsible-crate',
+        ],
+      },
+      {
+        kind: 'prose',
+        heading: 'PetSafe Happy Ride Collapsible Travel Crate',
+        paragraphs: [
+          'Choose PetSafe Happy Ride if you want the best all-around road trip travel crate. It is framed around car travel rather than indoor crate training, with a collapsible format, mesh visibility, dual side access, storage pockets, and back-seat setup details.',
+          'This is the pick for owners who want a travel-specific crate that packs down between trips and feels more purpose-built for long drives than a standard indoor wire crate.',
+        ],
+      },
+      {
+        kind: 'prose',
+        heading: 'Petmate Sky Kennel',
+        paragraphs: [
+          'Choose Petmate if your dog needs a harder-sided, more secure setup. The plastic shell is more enclosed than a soft folding crate and gives dogs fewer fabric or mesh surfaces to chew, claw, or push through.',
+          'It is the better fit for dogs who need more structure on road trips, but it is less compact than a soft folding travel crate. That is the tradeoff: more structure, less packability.',
+        ],
+        alt: true,
+      },
+      {
+        kind: 'prose',
+        heading: 'EliteField 3-Door Folding Soft Dog Crate',
+        paragraphs: [
+          'Choose EliteField if you want a soft folding crate for a trained dog and like the three-door setup. Top, front, and side access can make a real difference when the crate moves between a car, hotel room, campsite, or temporary sleeping area.',
+          'This is a convenience pick for dogs who already settle calmly in a crate. It is not the right choice for dogs who panic, chew, claw, or test crate walls.',
+        ],
+      },
+      {
+        kind: 'prose',
+        heading: 'Lesure Soft Collapsible Dog Crate',
+        paragraphs: [
+          'Choose Lesure if you want the lightest, most portable soft-sided option. Its appeal is fast setup, compact storage, breathable mesh, and easy carry for road trip stops or temporary rooms.',
+          'Like any soft-sided folding dog crate for travel, it is best for calm, trained dogs. If containment strength matters more than portability, choose Petmate instead.',
+        ],
+        alt: true,
+      },
+      {
+        kind: 'decision_columns',
+        id: 'which-one',
+        left: {
+          heading: 'Choose hard-sided when',
+          items: [
+            'Your dog needs more structure or enclosure during car travel.',
+            'Your dog paws at doors, pushes against crate walls, or gets overstimulated by visibility.',
+            'You want a more realistic containment setup than fabric and mesh.',
+            'Packability matters less than a sturdier travel crate.',
+          ],
+        },
+        right: {
+          heading: 'Choose soft folding when',
+          items: [
+            'Your dog is already crate-trained and calm in confinement.',
+            'You need a folding dog crate for travel, hotel stays, or temporary setup.',
+            'Lightweight carry and compact storage matter most.',
+            'Your dog will not chew, claw, or try hard to escape.',
+          ],
+        },
+      },
+      {
+        kind: 'note',
+        heading: 'Bottom Line',
+        text:
+          'PetSafe Happy Ride is the best overall road trip pick because it is built around travel use. Petmate is the better hard-sided choice for dogs that need more structure. EliteField and Lesure are strong soft-sided options for calm, crate-trained dogs, with EliteField winning on access and Lesure winning on lightweight portability.',
+        alt: true,
+      },
+    ],
+    faq: {
+      heading: 'Travel Crate FAQ',
+      items: [
+        {
+          question: 'What is the best travel crate for road trips?',
+          answer:
+            'PetSafe Happy Ride is the best overall road trip pick because it is designed around travel use and collapses for storage. If your dog needs more structure, choose a hard-sided kennel like Petmate.',
+        },
+        {
+          question: 'Are soft dog crates good for car travel?',
+          answer:
+            'Soft dog crates can work well for car travel with calm, crate-trained dogs. They are convenient and portable, but they are not escape-proof and should not be used for dogs that panic, chew, or try hard to escape.',
+        },
+        {
+          question: 'Is a travel crate the same as crash-tested vehicle safety gear?',
+          answer:
+            'No. This page focuses on road trip containment, portability, and temporary travel setup. Road trip convenience is different from crash-tested vehicle safety. If crash protection is the priority, look specifically for products tested for that purpose.',
+        },
+        {
+          question: 'Should I use a hard-sided or soft folding travel crate?',
+          answer:
+            'Use a hard-sided crate if your dog needs more structure or containment. Use a soft folding crate if your dog is already calm in a crate and you care most about portability, hotel setup, and easy storage.',
+        },
+      ],
+    },
+    relatedGuides: {
+      heading: 'More Road Trip & Crate Help',
+      guides: [
+        {
+          href: ROUTES.roadTrip,
+          title: "Rhys's Road Trip Chill Kit",
+          description:
+            'A road trip setup that combines cooling, calming, hydration, and rest gear for long drives with dogs.',
+        },
+        {
+          href: ROUTES.calmingCrateGuide,
+          title: 'How to Crate Train Your Dog',
+          description:
+            'Crate training guidance for puppies, anxious dogs, travel, and common crate mistakes.',
+        },
+      ],
+    },
+    disclosureShowSafety: false,
+    internalLinkStrip: {
+      heading: 'More Travel & Crate Guides',
+      links: [
+        { label: 'Road Trip Gear', href: ROUTES.roadTrip },
+        { label: 'Crate Training Guide', href: ROUTES.calmingCrateGuide },
+        { label: 'Anxiety Crates', href: ROUTES.comfortAnxietyCrates },
+      ],
+    },
+    itemListSchema: {
+      name: 'Best Travel Crates for Road Trips',
+      url: 'https://www.chill-dogs.com/comforting/best-travel-crates-for-road-trips/',
+      productIds: [
+        'petsafe-happy-ride-travel-crate',
+        'petmate-sky-kennel',
+        'elitefield-three-door-soft-crate',
+        'lesure-soft-collapsible-crate',
+      ],
+    },
+  },
+
   'best-orthopedic-dog-beds': {
     slug: 'best-orthopedic-dog-beds',
     title: 'Best Orthopedic Dog Beds for Large & Older Dogs',

--- a/src/data/relaxation-converter-pages.ts
+++ b/src/data/relaxation-converter-pages.ts
@@ -313,7 +313,7 @@ export const relaxationConverterPages: Record<string, RelaxationConverterPageCon
     hero: {
       title: 'Best Puppy Crates',
       subtitle:
-        'A first puppy crate needs to do one job well: make housebreaking and quiet-time practice easier without forcing you to buy another crate in a month. For most puppies, that means a wire crate with a divider panel, enough size options, and a door layout that fits the room where training actually happens.',
+        'A puppy\'s first crate should make housebreaking and quiet-time practice easier without forcing you to buy another crate in a month. For most puppies, that means a wire crate with a divider panel and a door layout that fits the room where training actually happens.',
       disclaimer: 'As an Amazon Associate, we earn from qualifying purchases.',
       primaryCta: { label: 'See Quick Picks', href: '#quick-picks' },
       secondaryCta: { label: 'Crate Training Guide', href: ROUTES.calmingCrateGuide },
@@ -331,7 +331,7 @@ export const relaxationConverterPages: Record<string, RelaxationConverterPageCon
         id: 'quick-picks',
         heading: 'Quick Picks',
         intro:
-          'Start with the crate that matches your actual constraint: finished home setup, budget, build quality, or room layout. These picks are practical for puppy crate training, but they solve slightly different problems.',
+          'Start with the crate that best fits your budget and best matches your room layout. All three picks are practical for puppy crate training, but they solve different problems.',
         items: [
           {
             label: 'Top Pick for Puppy Crate Training',
@@ -353,7 +353,7 @@ export const relaxationConverterPages: Record<string, RelaxationConverterPageCon
             label: 'Best Sturdier Wire Crate',
             title: 'MidWest Life Stages Dog Crate (22-Inch)',
             description:
-              'The one to lean toward if the price gap is small. Life Stages uses heavier-gauge steel than iCrate and feels more solid for active puppies.',
+              'Life Stages uses heavier-gauge steel than iCrate and feels more solid for active puppies.',
             productId: 'midwest-life-stages-puppy-crate',
             position: 'quick-picks-3',
           },
@@ -361,7 +361,7 @@ export const relaxationConverterPages: Record<string, RelaxationConverterPageCon
             label: 'Best Flexible Door Layout',
             title: 'Petmate Training Retreat Kennel',
             description:
-              'A useful alternative when side-door access matters. The two-door layout can make daily crate routines easier in tight bedrooms or living rooms.',
+              'A useful alternative when side-door access is needed. The two-door layout can make daily crate routines easier in tight bedrooms or living rooms.',
             productId: 'petmate-training-retreat-kennel',
             position: 'quick-picks-4',
           },
@@ -374,7 +374,7 @@ export const relaxationConverterPages: Record<string, RelaxationConverterPageCon
         positionOffset: 0,
         columns: 3,
         intro:
-          'For crate training, prioritize fit and daily usability over extras. A divider matters because puppies should not start with a crate that is so large they can sleep on one side and potty on the other.',
+          'For crate training, prioritize fit and daily usability. A divider is useful because puppies should not start with a crate so large that they can sleep on one side and potty on the other.',
         productIds: [
           'kindtail-pawd-collapsible-crate',
           'midwest-icrate-puppy',
@@ -387,9 +387,9 @@ export const relaxationConverterPages: Record<string, RelaxationConverterPageCon
         id: 'icrate-vs-life-stages',
         heading: 'MidWest iCrate vs Life Stages',
         paragraphs: [
-          'The iCrate and Life Stages lines look similar because they solve the same core problem: a wire crate with multiple size options and a divider panel. The practical difference is build and handling.',
+          'The iCrate and Life Stages lines are both wire crates with multiple size options and a divider panel. The difference is build and handling.',
           'iCrate is the lighter, simpler, usually more budget-friendly option. It is easier to move around and makes sense for standard puppy crate training when your dog is not especially strong or hard on gear.',
-          'Life Stages uses heavier-gauge steel and is built to feel sturdier. Some iCrate sizes are also slightly narrower and lower than comparable Life Stages models. If the price gap is small, Life Stages is the one I would lean toward for a stronger or more active puppy.',
+          'Life Stages uses heavier-gauge steel and is built to feel more sturdy. Some Life Stages crates are wider and higher than comparable iCrate models. Life Stages are appropriate for stronger, more active puppies.',
         ],
         alt: true,
       },
@@ -397,29 +397,29 @@ export const relaxationConverterPages: Record<string, RelaxationConverterPageCon
         kind: 'decision_columns',
         id: 'which-crate',
         left: {
-          heading: 'Get iCrate when',
+          heading: 'Get iCrate When',
           items: [
-            'You want the simpler budget-friendly option.',
-            'You plan to move the crate around the house often.',
-            'Your puppy is average-strength and you mainly need a divider-based training setup.',
-            'Lower crate weight matters more than a sturdier wire frame.',
+            'You want the simpler, more budget-friendly option',
+            'You plan to move the crate around the house often',
+            'Your puppy is of average strength and you need a divider-based training setup',
+            'A lighter crate matters more than a sturdier wire frame',
           ],
         },
         right: {
-          heading: 'Get Life Stages when',
+          heading: 'Get Life Stages When',
           items: [
-            'You want the sturdier Midwest option.',
-            'Your puppy is strong, active, or likely to push against the crate.',
-            'You do not mind extra crate weight.',
-            'The price difference is small enough that durability is worth prioritizing.',
+            'You want the sturdier Midwest option',
+            'Your puppy is strong, active, or likely to push against the crate',
+            'You do not mind a heavier crate',
+            'Durability is your first priority',
           ],
         },
       },
       {
         kind: 'note',
-        heading: 'Where Petmate Fits',
+        heading: 'Get Petmate Training Retreat Kennel When',
         text:
-          'The Petmate Training Retreat Kennel is less about beating the Midwest crates on build and more about room fit. If a side door would make the crate easier to use every day, it can be the more practical choice.',
+          'A side door makes the crate easier to use in a specific room',
         alt: true,
       },
     ],
@@ -439,7 +439,7 @@ export const relaxationConverterPages: Record<string, RelaxationConverterPageCon
         {
           question: 'Why does a puppy crate need a divider?',
           answer:
-            'A divider prevents the crate from being too large at the beginning. Puppies are more likely to keep a correctly sized sleeping area clean, while an oversized crate can let them sleep in one corner and potty in another.',
+            'A divider prevents the crate from being too large at the start of training. Puppies are more likely to keep a smaller sleeping area clean, while an oversized crate can allow them sleep in one corner and potty in another.',
         },
         {
           question: 'Is a two-door crate worth it?',
@@ -461,7 +461,7 @@ export const relaxationConverterPages: Record<string, RelaxationConverterPageCon
           href: ROUTES.comfortCalmingBeds,
           title: 'Best Calming Dog Beds',
           description:
-            'If your puppy settles better with soft edges and a defined rest area, compare calming beds and bolster beds next.',
+            'If your puppy settles better with soft edges and a defined rest area, compare calming beds and bolster beds.',
         },
       ],
     },

--- a/src/data/relaxation-converter-pages.ts
+++ b/src/data/relaxation-converter-pages.ts
@@ -495,7 +495,7 @@ export const relaxationConverterPages: Record<string, RelaxationConverterPageCon
     hero: {
       title: 'Best Dog Crates for Anxiety',
       subtitle:
-        'An anxiety crate should match the dog, not the label. Some dogs settle in a familiar wire crate. Some do better with an enclosed kennel that blocks visual stimulation. And some escape artists need a heavy-duty crate only as part of a broader safety plan.',
+        'Some dogs settle in a familiar wire crate. Others do better with an enclosed kennel that blocks visual stimulation. And some escape artists need a heavy-duty crate to help keep them safe.',
       disclaimer: 'As an Amazon Associate, we earn from qualifying purchases.',
       primaryCta: { label: 'See Quick Picks', href: '#quick-picks' },
       secondaryCta: { label: 'Crate Training Guide', href: ROUTES.calmingCrateGuide },
@@ -535,7 +535,7 @@ export const relaxationConverterPages: Record<string, RelaxationConverterPageCon
             label: 'Best Heavy-Duty Crate',
             title: 'Impact High Anxiety Dog Crate',
             description:
-              'The heavy-duty option for dogs with a real escape history, bent wire crates, or injury risk from standard crate attempts.',
+              'The heavy-duty option for dogs with a real escape history, who have bent wire crates, or who risk injury from standard crate escape attempts.',
             productId: 'impact-high-anxiety-crate',
             position: 'quick-picks-3',
           },
@@ -546,9 +546,9 @@ export const relaxationConverterPages: Record<string, RelaxationConverterPageCon
         id: 'safety-first',
         heading: 'Safety First: A Crate Is Not a Separation Anxiety Cure',
         paragraphs: [
-          'A crate can be a useful management tool for some anxious dogs, but it is not a treatment for separation anxiety by itself. <a href="https://www.humaneworld.org/resources/separation-anxiety-dogs">Humane World</a> specifically advises creating a safe space instead of defaulting to a crate for separation anxiety because dogs can continue panicking inside confinement and may injure themselves trying to escape.',
+          'A crate can be a useful management tool for some anxious dogs, but it is not a treatment for separation anxiety by itself. <a href="https://www.humaneworld.org/resources/separation-anxiety-dogs">Humane World</a> specifically advises creating a safe space instead of defaulting to a crate for separation anxiety. Dogs can continue panicking inside a confined space and may injure themselves trying to escape.',
           '<a href="https://www.aspca.org/pet-care/dog-care/common-dog-behavior-issues/separation-anxiety">ASPCA separation-anxiety guidance</a> and <a href="https://www.oregonhumane.org/portland-training/crate-training-your-dog/">Oregon Humane crate-training guidance</a> make the same practical point: watch the dog’s actual pattern. If confinement makes panic worse, use a room, pen, veterinary behavior support, and gradual training rather than trying to solve the problem with a stronger crate.',
-          'So this page frames crates as management choices: wire for mild anxiety in dogs who already tolerate crates, enclosed plastic for dogs who need less visual stimulation, and heavy-duty containment only when escape risk makes standard crates unsafe.',
+          'Choose wire for dogs with mild anxiety who already tolerate crates, enclosed plastic for dogs who need less visual stimulation, and heavy-duty containment only when escape risk makes standard crates unsafe.',
         ],
         alt: true,
       },
@@ -559,28 +559,28 @@ export const relaxationConverterPages: Record<string, RelaxationConverterPageCon
         positionOffset: 0,
         columns: 3,
         intro:
-          'These three picks cover different anxiety patterns. Do not size down for containment. Your dog still needs room to stand, turn around, and lie down naturally.',
+          'These three picks address different anxiety issues. Do not size down for containment. Your dog still needs room to stand, turn around, and lie down naturally.',
         productIds: ['midwest-life-stages-crate', 'petmate-sky-kennel', 'impact-high-anxiety-crate'],
       },
       {
         kind: 'decision_columns',
         id: 'which-crate',
         left: {
-          heading: 'Use Life Stages or Sky Kennel when',
+          heading: 'Use Life Stages or Sky Kennel When',
           items: [
-            'Your dog is already crate-trained and does not panic in confinement.',
-            'The anxiety is mild, situational, or linked to overstimulation.',
-            'Your goal is a predictable rest space, not brute-force containment.',
-            'You can monitor the dog’s response and change course if distress escalates.',
+            'Your dog is already crate-trained and does not panic in confined spaces',
+            'The anxiety is mild, situational, or linked to overstimulation',
+            'Your goal is a predictable rest space',
+            'You can monitor the dog’s response and change course if distress escalates',
           ],
         },
         right: {
-          heading: 'Consider Impact only when',
+          heading: 'Consider Impact When',
           items: [
-            'Your dog has escaped from or damaged standard crates.',
-            'Wire bars create tooth, paw, or latch-injury risk for this specific dog.',
-            'You are also working on the underlying anxiety with training or professional support.',
-            'You need containment as harm reduction, not as the whole behavior plan.',
+            'Your dog has escaped from or damaged standard crates',
+            'Wire bars create tooth, paw, or latch-injury risk',
+            'You are also working on underlying anxiety issues with training or professional support',
+            'You need containment as harm reduction',
           ],
         },
       },

--- a/src/data/relaxation-products.ts
+++ b/src/data/relaxation-products.ts
@@ -225,7 +225,206 @@ export const relaxationProducts: RelaxationProduct[] = [
     image: { src: 'https://m.media-amazon.com/images/I/71riy3hJGtL._SL500_.jpg', alt: 'OneTigris Travel Dog Bed' },
   },
 
-  // ── Crates (future page) ─────────────────────────────────────────────────
+  // ── Crates ───────────────────────────────────────────────────────────────
+
+  {
+    id: 'kindtail-pawd-collapsible-crate',
+    asin: 'B0CWNXMYW1',
+    name: 'KindTail PAWD Collapsible Dog Crate',
+    category: 'crates',
+    amazonUrl: 'https://www.amazon.com/dp/B0CWNXMYW1/?tag=chill-dogs-20',
+    bullets: [
+      'Collapsible panel design folds flat for storage or moving around the house',
+      'Includes a washable padded bed for a more finished puppy rest setup',
+      'Medium size is listed for small-to-medium pets between 15 and 25 pounds',
+    ],
+    bestFor: 'Puppy owners who want a cleaner-looking, portable indoor crate instead of a standard wire crate',
+    whyItWorks:
+      'The collapsible hard-panel format gives puppies a defined resting space while feeling more like home furniture than a basic wire crate',
+    considerIf:
+      'You want the featured puppy-crate pick and your puppy fits the listed medium size range',
+    image: { src: 'https://m.media-amazon.com/images/I/71+6X5mSFIL.jpg', alt: 'KindTail PAWD Collapsible Dog Crate' },
+  },
+  {
+    id: 'midwest-icrate-puppy',
+    asin: 'B000TZ59ES',
+    name: 'MidWest iCrate Dog Crate (18-Inch)',
+    category: 'crates',
+    amazonUrl: 'https://www.amazon.com/dp/B000TZ59ES/?tag=chill-dogs-20',
+    bullets: [
+      '18-inch iCrate size is listed for tiny breeds up to 10 pounds',
+      'Includes a divider panel so the usable crate space can grow with a small puppy',
+      'Folding wire design is easy to move, store, or reposition around the house',
+    ],
+    bestFor: 'Tiny-breed puppies who need a small, straightforward first wire crate with a divider',
+    whyItWorks:
+      'The smaller puppy-specific size keeps the crate from starting too large while preserving the divider-based housebreaking setup',
+    considerIf:
+      'You want the simpler, lighter Midwest option for a tiny puppy and do not need the heavier-gauge Life Stages build',
+    image: { src: 'https://m.media-amazon.com/images/I/81Cpkz5lEPL.jpg', alt: 'MidWest iCrate 18-Inch Dog Crate' },
+  },
+  {
+    id: 'midwest-life-stages-puppy-crate',
+    asin: 'B0002TKBU8',
+    name: 'MidWest Life Stages Dog Crate (22-Inch)',
+    category: 'crates',
+    amazonUrl: 'https://www.amazon.com/dp/B0002TKBU8/?tag=chill-dogs-20',
+    bullets: [
+      '22-inch Life Stages size is listed for extra-small breeds up to 15 pounds',
+      'Includes a divider panel for puppy-to-adult crate setup in a smaller footprint',
+      'Heavier-gauge steel than the iCrate line for a sturdier wire-crate feel',
+    ],
+    bestFor: 'Extra-small puppies when you want the sturdier Midwest wire crate in a puppy-sized model',
+    whyItWorks:
+      'It keeps the same divider-based training logic as iCrate but uses a heavier build for extra durability',
+    considerIf:
+      'You do not mind extra weight and want the sturdier Midwest option for a small puppy',
+    image: { src: 'https://m.media-amazon.com/images/I/91Xxqc6WtBL.jpg', alt: 'MidWest Life Stages 22-Inch Dog Crate' },
+  },
+  {
+    id: 'midwest-icrate',
+    asin: 'B000QFT1RC',
+    name: 'MidWest iCrate Dog Crate',
+    category: 'crates',
+    amazonUrl: 'https://www.amazon.com/dp/B000QFT1RC/?tag=chill-dogs-20',
+    bullets: [
+      'Includes a divider panel so the usable crate space can grow with a puppy',
+      'Folding wire design is easy to move, store, or reposition around the house',
+      'A practical budget-friendly starting point for standard puppy crate training',
+    ],
+    bestFor: 'Most puppies who need a straightforward first wire crate with a divider',
+    whyItWorks:
+      'The divider lets you size the sleeping area smaller during housebreaking, then open up more room as the puppy grows',
+    considerIf:
+      'You want the simpler, lighter Midwest option and do not need the heavier-gauge Life Stages build',
+    image: { src: 'https://m.media-amazon.com/images/I/916OE0sVPqL.jpg', alt: 'MidWest iCrate Dog Crate' },
+  },
+  {
+    id: 'midwest-life-stages-crate',
+    asin: 'B0002AT3ME',
+    name: 'MidWest Life Stages Dog Crate',
+    category: 'crates',
+    amazonUrl: 'https://www.amazon.com/dp/B0002AT3ME/?tag=chill-dogs-20',
+    bullets: [
+      'Includes multiple sizes and a divider panel for puppy-to-adult crate setup',
+      'Heavier-gauge steel than the iCrate line for a sturdier wire-crate feel',
+      'A stronger choice when the price gap is small or the puppy is especially active',
+    ],
+    bestFor: 'Owners who want a sturdier wire crate for a strong or active puppy',
+    whyItWorks:
+      'It keeps the same divider-based training logic as iCrate but uses a heavier build for extra durability',
+    considerIf:
+      'You do not mind extra weight and want the crate that feels more solid between the two Midwest options',
+    image: { src: 'https://m.media-amazon.com/images/I/91NBxSDchXL.jpg', alt: 'MidWest Life Stages Dog Crate' },
+  },
+  {
+    id: 'petmate-training-retreat-kennel',
+    asin: 'B005U6UOEQ',
+    name: 'Petmate Training Retreat Kennel',
+    category: 'crates',
+    amazonUrl: 'https://www.amazon.com/dp/B005U6UOEQ/?tag=chill-dogs-20',
+    bullets: [
+      'Two-door layout gives you more placement options in bedrooms, kitchens, or living rooms',
+      'Wire construction keeps airflow and visibility high during early crate introduction',
+      'Useful alternative if the room layout makes a single front door awkward',
+    ],
+    bestFor: 'Puppy owners who want flexible door access for different room setups',
+    whyItWorks:
+      'A second access point can make daily crate routines easier when the crate sits beside furniture or against a wall',
+    considerIf:
+      'You want a wire training crate but need side-door access more than the sturdier Life Stages build',
+    image: { src: 'https://m.media-amazon.com/images/I/81abUgMp5uL.jpg', alt: 'Petmate Training Retreat Kennel' },
+  },
+  {
+    id: 'impact-high-anxiety-crate',
+    asin: 'B0CV4KXTPR',
+    name: 'Impact High Anxiety Dog Crate',
+    category: 'crates',
+    amazonUrl: 'https://www.amazon.com/dp/B0CV4KXTPR/?tag=chill-dogs-20',
+    bullets: [
+      'Powder-coated aluminum crate built for dogs who damage standard wire crates',
+      'Zinc steel paddle latch plus four butterfly latches add multiple security points',
+      'Small circular ventilation holes are designed to limit tooth access while preserving airflow',
+    ],
+    bestFor: 'Escape artists who have already bent wire crates or injured themselves trying to get out',
+    whyItWorks:
+      'The heavier enclosure, reinforced latching, and smaller ventilation openings are aimed at containment when standard crates are not enough',
+    considerIf:
+      'Your dog has a proven escape history and you are using the crate as part of a broader safety and behavior plan',
+    image: { src: 'https://m.media-amazon.com/images/I/71PqD1QxTFL.jpg', alt: 'Impact High Anxiety Dog Crate' },
+  },
+  {
+    id: 'petmate-sky-kennel',
+    asin: 'B003E6YYYK',
+    name: 'Petmate Sky Kennel',
+    category: 'crates',
+    amazonUrl: 'https://www.amazon.com/dp/B003E6YYYK/?tag=chill-dogs-20',
+    bullets: [
+      'Enclosed plastic shell reduces visual stimulation compared with open wire crates',
+      '360-degree ventilation and tie-down holes support travel use',
+      'Includes travel-prep accessories such as live-animal stickers, cup, ID stickers, and absorbent pad',
+    ],
+    bestFor: 'Anxious dogs who settle better with a more enclosed den-like crate',
+    whyItWorks:
+      'The plastic shell creates a quieter, more contained environment while still allowing ventilation from all sides',
+    considerIf:
+      'Your dog is crate-trained but gets overstimulated by open wire visibility or needs a travel-ready kennel',
+    image: { src: 'https://m.media-amazon.com/images/I/71HTfabbQ3L.jpg', alt: 'Petmate Sky Kennel' },
+  },
+  {
+    id: 'petsafe-happy-ride-travel-crate',
+    asin: 'B09T1P2B7J',
+    name: 'PetSafe Happy Ride Collapsible Travel Crate',
+    category: 'crates',
+    amazonUrl: 'https://www.amazon.com/dp/B09T1P2B7J/?tag=chill-dogs-20',
+    bullets: [
+      'Designed around car travel with seat belt straps and a headrest loop for back-seat setup',
+      'Collapsible soft-sided format folds flat for storage between road trips',
+      'Mesh windows, dual side doors, storage pockets, and waterproof fleece pad support long-drive convenience',
+    ],
+    bestFor: 'Road trips where you want a travel-specific crate that is easier to pack than a standard indoor crate',
+    whyItWorks:
+      'It is built around car-use details rather than house-training, making it the cleanest all-around road trip pick',
+    considerIf:
+      'Your dog is calm enough for a soft travel crate and you want a crate that packs down between drives',
+    image: { src: 'https://m.media-amazon.com/images/I/81LvTZeUnwL.jpg', alt: 'PetSafe Happy Ride Collapsible Travel Crate' },
+  },
+  {
+    id: 'elitefield-three-door-soft-crate',
+    asin: 'B01HKF4AQW',
+    name: 'EliteField 3-Door Folding Soft Dog Crate',
+    category: 'crates',
+    amazonUrl: 'https://www.amazon.com/dp/B01HKF4AQW/?tag=chill-dogs-20',
+    bullets: [
+      'Three mesh doors on top, front, and side make access easier in cars, hotels, and temporary setups',
+      'Folds down to a low profile and includes a carrying bag and fleece bed',
+      'Steel-tube frame with fabric and mesh cover is convenient for trained dogs who settle calmly',
+    ],
+    bestFor: 'Crate-trained dogs who travel well and benefit from multiple access points',
+    whyItWorks:
+      'The three-door layout makes placement more flexible when a crate is moving between the car, hotel room, and campsite',
+    considerIf:
+      'Your dog is already calm in a crate and you want a soft folding crate with more door options than most',
+    image: { src: 'https://m.media-amazon.com/images/I/81eoHEQHU3L.jpg', alt: 'EliteField 3-Door Folding Soft Dog Crate' },
+  },
+  {
+    id: 'lesure-soft-collapsible-crate',
+    asin: 'B0G3PBR7XS',
+    name: 'Lesure Soft Collapsible Dog Crate',
+    category: 'crates',
+    amazonUrl: 'https://www.amazon.com/dp/B0G3PBR7XS/?tag=chill-dogs-20',
+    bullets: [
+      'Soft collapsible frame folds into a compact package with included storage bag',
+      'Quick setup and disassembly make it practical for travel stops and temporary rooms',
+      'Four-sided breathable mesh and removable mat keep the setup light and easy to maintain',
+    ],
+    bestFor: 'Calm, trained dogs whose owners prioritize the lightest, most portable soft crate setup',
+    whyItWorks:
+      'The compact folding design favors convenience and fast setup over hard-sided structure',
+    considerIf:
+      'You want easy carry-and-store travel convenience and your dog will not chew, claw, or push at soft crate walls',
+    image: { src: 'https://m.media-amazon.com/images/I/8111DM2a0KL.jpg', alt: 'Lesure Soft Collapsible Dog Crate' },
+  },
 
   {
     id: 'kindtail-collapsible-crate',

--- a/src/data/relaxation-products.ts
+++ b/src/data/relaxation-products.ts
@@ -378,13 +378,13 @@ export const relaxationProducts: RelaxationProduct[] = [
     category: 'crates',
     amazonUrl: 'https://www.amazon.com/dp/B09T1P2B7J/?tag=chill-dogs-20',
     bullets: [
-      'Designed around car travel with seat belt straps and a headrest loop for back-seat setup',
+      'Designed for car travel with seat belt straps and a headrest loop for back-seat setup',
       'Collapsible soft-sided format folds flat for storage between road trips',
-      'Mesh windows, dual side doors, storage pockets, and waterproof fleece pad support long-drive convenience',
+      'Mesh windows, dual side doors, storage pockets, and waterproof fleece pad for long-drive convenience',
     ],
     bestFor: 'Road trips where you want a travel-specific crate that is easier to pack than a standard indoor crate',
     whyItWorks:
-      'It is built around car-use details rather than house-training, making it the cleanest all-around road trip pick',
+      'It is built around for car use rather than house-training, making it great for road trips',
     considerIf:
       'Your dog is calm enough for a soft travel crate and you want a crate that packs down between drives',
     image: { src: 'https://m.media-amazon.com/images/I/81LvTZeUnwL.jpg', alt: 'PetSafe Happy Ride Collapsible Travel Crate' },
@@ -400,7 +400,7 @@ export const relaxationProducts: RelaxationProduct[] = [
       'Folds down to a low profile and includes a carrying bag and fleece bed',
       'Steel-tube frame with fabric and mesh cover is convenient for trained dogs who settle calmly',
     ],
-    bestFor: 'Crate-trained dogs who travel well and benefit from multiple access points',
+    bestFor: 'Crate-trained dogs who travel well',
     whyItWorks:
       'The three-door layout makes placement more flexible when a crate is moving between the car, hotel room, and campsite',
     considerIf:

--- a/src/data/relaxation-products.ts
+++ b/src/data/relaxation-products.ts
@@ -309,6 +309,8 @@ export const relaxationProducts: RelaxationProduct[] = [
       'Includes multiple sizes and a divider panel for puppy-to-adult crate setup',
       'Heavier-gauge steel than the iCrate line for a sturdier wire-crate feel',
       'A stronger choice for an especially active puppy',
+    ],
+    bestFor: 'Owners who want a sturdier wire crate for a strong or active puppy',
     whyItWorks:
       'It keeps the same divider-based training logic as iCrate but uses a heavier build for extra durability',
     considerIf:

--- a/src/data/relaxation-products.ts
+++ b/src/data/relaxation-products.ts
@@ -290,7 +290,7 @@ export const relaxationProducts: RelaxationProduct[] = [
     bullets: [
       'Includes a divider panel so the usable crate space can grow with a puppy',
       'Folding wire design is easy to move, store, or reposition around the house',
-      'A practical budget-friendly starting point for standard puppy crate training',
+      'A practical, budget-friendly starting point for standard puppy crate training',
     ],
     bestFor: 'Most puppies who need a straightforward first wire crate with a divider',
     whyItWorks:
@@ -308,7 +308,7 @@ export const relaxationProducts: RelaxationProduct[] = [
     bullets: [
       'Includes multiple sizes and a divider panel for puppy-to-adult crate setup',
       'Heavier-gauge steel than the iCrate line for a sturdier wire-crate feel',
-      'A stronger choice when the price gap is small or the puppy is especially active',
+      'A stronger choice for an active puppy',
     ],
     bestFor: 'Owners who want a sturdier wire crate for a strong or active puppy',
     whyItWorks:

--- a/src/data/relaxation-products.ts
+++ b/src/data/relaxation-products.ts
@@ -308,13 +308,11 @@ export const relaxationProducts: RelaxationProduct[] = [
     bullets: [
       'Includes multiple sizes and a divider panel for puppy-to-adult crate setup',
       'Heavier-gauge steel than the iCrate line for a sturdier wire-crate feel',
-      'A stronger choice for an active puppy',
-    ],
-    bestFor: 'Owners who want a sturdier wire crate for a strong or active puppy',
+      'A stronger choice for an especially active puppy',
     whyItWorks:
       'It keeps the same divider-based training logic as iCrate but uses a heavier build for extra durability',
     considerIf:
-      'You do not mind extra weight and want the crate that feels more solid between the two Midwest options',
+      'You do not mind a heavier crate that feels more solid',
     image: { src: 'https://m.media-amazon.com/images/I/91NBxSDchXL.jpg', alt: 'MidWest Life Stages Dog Crate' },
   },
   {
@@ -360,7 +358,7 @@ export const relaxationProducts: RelaxationProduct[] = [
     category: 'crates',
     amazonUrl: 'https://www.amazon.com/dp/B003E6YYYK/?tag=chill-dogs-20',
     bullets: [
-      'Enclosed plastic shell reduces visual stimulation compared with open wire crates',
+      'Enclosed plastic shell reduces visual stimulation compared to open wire crates',
       '360-degree ventilation and tie-down holes support travel use',
       'Includes travel-prep accessories such as live-animal stickers, cup, ID stickers, and absorbent pad',
     ],

--- a/src/data/routes.ts
+++ b/src/data/routes.ts
@@ -15,6 +15,7 @@ export const ROUTES = {
   calmingTop: '/calming/best-calming-products-for-anxious-dogs/',
   calmingAlternatives: '/calming/best-thundershirt-alternatives/',
   calmingCar: '/calming/car-anxiety-for-dogs/',
+  calmingCrateGuide: '/calming/crate-training-for-dogs/',
   roadTrip: '/travel/dog-road-trip-gear/',
   rhysRanAway: '/travel/rhys-ran-away-cerro-san-luis-obispo/',
   // Tracking cluster
@@ -26,6 +27,9 @@ export const ROUTES = {
   comfortHub: '/comforting/',
   comfortCalmingBeds: '/comforting/best-calming-dog-beds/',
   comfortOrthopedicBeds: '/comforting/best-orthopedic-dog-beds/',
+  comfortPuppyCrates: '/comforting/best-puppy-crates/',
+  comfortAnxietyCrates: '/comforting/best-anxiety-dog-crates/',
+  comfortTravelCrates: '/comforting/best-travel-crates-for-road-trips/',
   comfortSleepArticle: '/comforting/how-much-do-dogs-sleep/',
   affiliateDisclosure: '/affiliate-disclosure/',
   privacyPolicy: '/privacy-policy/',

--- a/src/pages/calming/[slug].astro
+++ b/src/pages/calming/[slug].astro
@@ -1,0 +1,26 @@
+---
+import { getCollection, render } from 'astro:content';
+import ArticleLayout from '@layouts/ArticleLayout.astro';
+
+export async function getStaticPaths() {
+  const articles = await getCollection('articles', (e) =>
+    e.data.canonicalPath.startsWith('/calming/')
+  );
+  return articles.map((entry) => ({
+    params: { slug: entry.data.canonicalPath.split('/').filter(Boolean).pop() },
+    props: { entry },
+  }));
+}
+
+const { entry } = Astro.props;
+const { Content } = await render(entry);
+---
+<ArticleLayout
+  title={entry.data.title}
+  description={entry.data.description}
+  ogTitle={entry.data.ogTitle}
+  canonicalPath={entry.data.canonicalPath}
+  ogImage={entry.data.ogImage}
+>
+  <Content />
+</ArticleLayout>

--- a/src/pages/comforting/best-anxiety-dog-crates.astro
+++ b/src/pages/comforting/best-anxiety-dog-crates.astro
@@ -1,0 +1,8 @@
+---
+import RelaxationConverterPage from '@components/modules/RelaxationConverterPage.astro';
+import { getRelaxationConverterPageConfig } from '@data/relaxation-converter-pages';
+
+const config = getRelaxationConverterPageConfig('best-anxiety-dog-crates');
+---
+
+<RelaxationConverterPage config={config} />

--- a/src/pages/comforting/best-puppy-crates.astro
+++ b/src/pages/comforting/best-puppy-crates.astro
@@ -1,0 +1,8 @@
+---
+import RelaxationConverterPage from '@components/modules/RelaxationConverterPage.astro';
+import { getRelaxationConverterPageConfig } from '@data/relaxation-converter-pages';
+
+const config = getRelaxationConverterPageConfig('best-puppy-crates');
+---
+
+<RelaxationConverterPage config={config} />

--- a/src/pages/comforting/best-travel-crates-for-road-trips.astro
+++ b/src/pages/comforting/best-travel-crates-for-road-trips.astro
@@ -1,0 +1,8 @@
+---
+import RelaxationConverterPage from '@components/modules/RelaxationConverterPage.astro';
+import { getRelaxationConverterPageConfig } from '@data/relaxation-converter-pages';
+
+const config = getRelaxationConverterPageConfig('best-travel-crates-for-road-trips');
+---
+
+<RelaxationConverterPage config={config} />

--- a/src/pages/content-sitemap.astro
+++ b/src/pages/content-sitemap.astro
@@ -71,10 +71,13 @@ const staticSections: SitemapSection[] = [
   },
   {
     title: 'Comfort',
-    description: 'Rest, Recovery, Relaxation pillar — collector path, dog bed converter pages, and sleep guides.',
+    description: 'Rest, Recovery, Relaxation pillar — collector path, dog bed converter pages, crate converter pages, and sleep guides.',
     pages: [
       { title: 'Best Calming Dog Beds', href: '/comforting/best-calming-dog-beds/', pageType: 'converter' },
       { title: 'Best Orthopedic Dog Beds', href: '/comforting/best-orthopedic-dog-beds/', pageType: 'converter' },
+      { title: 'Best Puppy Crates', href: '/comforting/best-puppy-crates/', pageType: 'converter' },
+      { title: 'Best Dog Crates for Anxiety', href: '/comforting/best-anxiety-dog-crates/', pageType: 'converter' },
+      { title: 'Best Travel Crates for Road Trips', href: '/comforting/best-travel-crates-for-road-trips/', pageType: 'converter' },
     ],
   },
   {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -51,4 +51,3 @@ const orgSchema = {
     <HomepageBody variant="v6" />
   </BaseLayout>
 )}
-

--- a/src/scripts/analytics.ts
+++ b/src/scripts/analytics.ts
@@ -1,7 +1,7 @@
 /**
  * Lightweight analytics utility for chill-dogs.
  * Uses event delegation on [data-track] attributes.
- * Sends events to PostHog when available, falls back to console logging in dev.
+ * Sends events to PostHog when available.
  */
 
 declare global {
@@ -18,8 +18,6 @@ export function track(eventName: string, props: Record<string, any>): void {
 
   if (window.posthog && typeof window.posthog.capture === 'function') {
     window.posthog.capture(eventName, props);
-  } else if (import.meta.env.DEV) {
-    console.log(`[analytics] ${eventName}`, props);
   }
 }
 

--- a/src/styles/article-components.css
+++ b/src/styles/article-components.css
@@ -17,10 +17,6 @@
 .prose a {
   color: var(--color-link);
   font-weight: var(--weight-semibold);
-  text-decoration: none;
-}
-
-.prose a:hover {
   text-decoration: underline;
 }
 

--- a/src/styles/article-components.css
+++ b/src/styles/article-components.css
@@ -15,7 +15,7 @@
 }
 
 .prose a {
-  color: var(--color-primary);
+  color: var(--color-link);
   font-weight: var(--weight-semibold);
   text-decoration: none;
 }

--- a/src/styles/collector-article.css
+++ b/src/styles/collector-article.css
@@ -55,7 +55,7 @@
 }
 
 .prose a {
-  color: var(--color-primary);
+  color: var(--color-link);
   text-decoration: underline;
 }
 

--- a/src/styles/reset.css
+++ b/src/styles/reset.css
@@ -35,13 +35,13 @@ img, picture, video, svg {
 }
 
 a {
-  color: var(--color-primary);
+  color: var(--color-link);
   text-decoration: none;
   transition: color var(--transition-fast);
 }
 
 a:hover {
-  color: var(--color-primary-hover);
+  color: var(--color-link-hover);
 }
 
 ul, ol {

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -14,6 +14,8 @@
   --color-text: var(--color-charcoal);
   --color-text-muted: #595959;
   --color-text-inverse: #f0f4f6;
+  --color-link: #345765;
+  --color-link-hover: #284650;
   --color-primary: var(--color-sky);
   --color-primary-hover: var(--color-sky-hover);
   --color-accent: var(--color-sage);

--- a/src/utils/third-party.ts
+++ b/src/utils/third-party.ts
@@ -1,0 +1,13 @@
+export interface PinterestTagOptions {
+  tagId?: string;
+  noindex?: boolean;
+  vercelEnv?: string;
+}
+
+export function shouldLoadPinterestTag({
+  tagId,
+  noindex = false,
+  vercelEnv,
+}: PinterestTagOptions): boolean {
+  return Boolean(tagId?.trim()) && !noindex && vercelEnv === 'production';
+}


### PR DESCRIPTION
Reopens the crate-training and crate-converter work from PR #71 after it was reverted from main for copy review.\n\nIncludes:\n- How to Crate Train Your Dog collector article\n- Puppy, anxiety, and road-trip crate converter pages\n- Product data and Amazon API cache entries for crate products\n- Homepage/content sitemap/system docs updates\n- Tests covering routes, RSS, sitemap, product catalog, and OG image generation\n\nVerification:\n- bun run test\n- bun run build\n\nLeaving as draft until copy review is complete.