### PR TITLE
Add Buttondown email signup flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,13 @@ PUBLIC_SITE_URL=https://www.chill-dogs.com
 # Maintenance mode — set to "true" to show coming-soon page at / (all other routes remain accessible)
 MAINTENANCE_MODE=
 
+# Buttondown email signup
+PUBLIC_BUTTONDOWN_USERNAME=
+# Full embed action URL, including any redirect parameter.
+# Example:
+# PUBLIC_BUTTONDOWN_FORM_ACTION=https://buttondown.com/api/emails/embed-subscribe/chill-dogs?next=/subscribe/thanks/
+PUBLIC_BUTTONDOWN_FORM_ACTION=
+
 # IndexNow (production deploy indexing)
 # Generate once (example): openssl rand -hex 16
 INDEXNOW_KEY=

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,6 +3,16 @@ import mdx from '@astrojs/mdx';
 import sitemap from '@astrojs/sitemap';
 import robotsTxt from 'astro-robots-txt';
 
+const EXCLUDED_SITEMAP_FRAGMENTS = [
+  '/draft',
+  '/v/',
+  '/admin/',
+  '/content-sitemap/',
+  '/privacy-policy/',
+  '/terms/',
+  '/subscribe/',
+];
+
 export default defineConfig({
   site: 'https://www.chill-dogs.com',
   trailingSlash: 'ignore',
@@ -12,7 +22,7 @@ export default defineConfig({
   integrations: [
     mdx(),
     sitemap({
-      filter: (page) => !page.includes('/draft') && !page.includes('/v/') && !page.includes('/admin/'),
+      filter: (page) => !EXCLUDED_SITEMAP_FRAGMENTS.some((fragment) => page.includes(fragment)),
       serialize: (item) => {
         if (item.url === 'https://www.chill-dogs.com/') {
           item.priority = 1.0;

--- a/docs/system-definition.yaml
+++ b/docs/system-definition.yaml
@@ -8,7 +8,7 @@
 
 site_system:
   status: "active"
-  as_of: "2026-04-10"
+  as_of: "2026-04-14"
   owner: "chill-dogs"
   purpose: "Define the website as a modular conversion system and keep implementation aligned."
 
@@ -39,6 +39,7 @@ site_system:
         with tagline "Settle in." — positioned between HomepageHero and the start-prompt section.
         The latest/guide lists include How to Crate Train Your Dog and Best Travel Crates for Road Trips
         to connect informational crate intent with the new crate converter path.
+        A homepage-inline email signup block sits below HomepageBody as a secondary capture path.
 
     - name: "Cooling"
       type: "collector"
@@ -195,6 +196,8 @@ site_system:
         - "/privacy-policy/"
         - "/terms/"
         - "/affiliate-disclosure/"
+        - "/subscribe/thanks/"
+        - "/subscribe/confirmed/"
       notes: "/admin/products/ is the canonical product inventory review page. Every product in any product data file must flow into this page through src/data/product-catalog.ts; do not hardcode product rows in the admin route."
 
   modules:
@@ -238,7 +241,8 @@ site_system:
       - "Explore: cooling, calming, comforting"
       - "Company: about, contact"
       - "Legal: privacy-policy, terms, affiliate-disclosure"
-    final_cta: "Persistent affiliate disclosure and trust reinforcement"
+      - "Newsletter signup on non-converter pages only"
+    final_cta: "Persistent affiliate disclosure, trust reinforcement, and secondary email capture on non-converter pages"
 
   conversion_flow:
     steps:
@@ -252,6 +256,19 @@ site_system:
       - "Duplicated page scaffolding that drifts over time"
       - "Unused modules that create implementation confusion"
       - "Collector pages without clear converter paths"
+
+  email_capture_flow:
+    scope: "Homepage inline signup + footer signup on non-converter pages"
+    provider: "Buttondown"
+    events:
+      - "email_signup_view"
+      - "email_signup_start"
+      - "email_signup_submit"
+      - "pageview:/subscribe/thanks/"
+      - "pageview:/subscribe/confirmed/"
+    notes: >
+      Converters intentionally exclude the footer signup so affiliate pages stay single-purpose.
+      /subscribe/thanks/ and /subscribe/confirmed/ are informer pages, noindex, and excluded from sitemap discovery.
 
   product_data:
     product_catalog: "src/data/product-catalog.ts — normalized admin inventory across every product data source; /admin/products/ must consume this data module and remain complete whenever products are added"

--- a/scripts/indexnow-lib.mjs
+++ b/scripts/indexnow-lib.mjs
@@ -1,4 +1,10 @@
 const PAGES_PREFIX = 'src/pages/';
+const EXCLUDED_EXACT_ROUTES = new Set([
+  '404',
+  'content-sitemap',
+  'privacy-policy',
+  'terms',
+]);
 
 export function isProductionVercelEnv(env = process.env) {
   return String(env.VERCEL_ENV || '').toLowerCase() === 'production';
@@ -16,9 +22,9 @@ export function mapPageFileToUrl(filePath, origin = 'https://www.chill-dogs.com'
   const routePath = filePath.slice(PAGES_PREFIX.length, -'.astro'.length);
 
   if (!routePath || routePath.includes('[') || routePath.includes(']')) return null;
-  if (routePath === 'content-sitemap') return null;
+  if (EXCLUDED_EXACT_ROUTES.has(routePath)) return null;
   if (routePath.startsWith('admin/')) return null;
-  if (routePath === '404') return null;
+  if (routePath.startsWith('subscribe/')) return null;
   if (routePath.includes('/v/')) return null;
 
   let pathname;

--- a/src/__tests__/indexnow.test.ts
+++ b/src/__tests__/indexnow.test.ts
@@ -29,6 +29,10 @@ describe('indexnow-lib', () => {
   it('excludes non-indexable page files', () => {
     expect(mapPageFileToUrl('src/pages/admin/products.astro')).toBeNull();
     expect(mapPageFileToUrl('src/pages/content-sitemap.astro')).toBeNull();
+    expect(mapPageFileToUrl('src/pages/privacy-policy.astro')).toBeNull();
+    expect(mapPageFileToUrl('src/pages/terms.astro')).toBeNull();
+    expect(mapPageFileToUrl('src/pages/subscribe/thanks.astro')).toBeNull();
+    expect(mapPageFileToUrl('src/pages/subscribe/confirmed.astro')).toBeNull();
     expect(mapPageFileToUrl('src/pages/calming/v/[variant].astro')).toBeNull();
     expect(mapPageFileToUrl('src/pages/llms.txt.ts')).toBeNull();
   });

--- a/src/__tests__/site-smoke.test.ts
+++ b/src/__tests__/site-smoke.test.ts
@@ -83,6 +83,21 @@ describe('site smoke tests', () => {
     expect(links).toContain('/comforting/best-travel-crates-for-road-trips/');
   });
 
+  it('renders signup blocks on the homepage and excludes the footer signup from converter pages', () => {
+    const homeDoc = readBuiltPage('index.html');
+    const converterDoc = readBuiltPage(path.join('cooling', 'cooling-mats', 'index.html'));
+
+    expect(
+      homeDoc.querySelector('[data-email-signup-placement="homepage_inline"]')
+    ).not.toBeNull();
+    expect(
+      homeDoc.querySelector('[data-email-signup-placement="footer"]')
+    ).not.toBeNull();
+    expect(
+      converterDoc.querySelector('[data-email-signup-placement="footer"]')
+    ).toBeNull();
+  });
+
   it('publishes generated per-page OG assets and metadata references', () => {
     const homeDoc = readBuiltPage('index.html');
     const coolingDoc = readBuiltPage(path.join('cooling', 'cooling-mats', 'index.html'));
@@ -190,8 +205,25 @@ describe('site smoke tests', () => {
     expect(
       privacyDoc.querySelector('meta[name="robots"]')?.getAttribute('content')
     ).toBe('noindex, nofollow');
+    expect(privacyDoc.body.textContent).toContain('Buttondown');
     expect(affiliateDoc.body.textContent).toContain('Amazon Services LLC Associates Program');
     expect(affiliateDoc.body.textContent).toContain('no additional cost to you');
+  });
+
+  it('renders subscribe flow pages without site chrome and keeps them noindex', () => {
+    const thanksDoc = readBuiltPage(path.join('subscribe', 'thanks', 'index.html'));
+    const confirmedDoc = readBuiltPage(path.join('subscribe', 'confirmed', 'index.html'));
+
+    expect(thanksDoc.querySelector('meta[name="robots"]')?.getAttribute('content'))
+      .toBe('noindex, nofollow');
+    expect(confirmedDoc.querySelector('meta[name="robots"]')?.getAttribute('content'))
+      .toBe('noindex, nofollow');
+    expect(thanksDoc.querySelector('header.site-header')).toBeNull();
+    expect(thanksDoc.querySelector('footer.site-footer')).toBeNull();
+    expect(confirmedDoc.querySelector('header.site-header')).toBeNull();
+    expect(confirmedDoc.querySelector('footer.site-footer')).toBeNull();
+    expect(confirmedDoc.body.textContent).toContain('Cooling Picks');
+    expect(confirmedDoc.body.textContent).toContain('Hot Weather Guide');
   });
 
   it('renders the admin product catalog from all product data files', () => {
@@ -234,6 +266,11 @@ describe('site smoke tests', () => {
     expect(sitemap).toContain('/comforting/best-travel-crates-for-road-trips/');
     expect(sitemap).not.toContain('/cooling/v/');
     expect(sitemap).not.toContain('/calming/v/');
+    expect(sitemap).not.toContain('/content-sitemap/');
+    expect(sitemap).not.toContain('/privacy-policy/');
+    expect(sitemap).not.toContain('/terms/');
+    expect(sitemap).not.toContain('/subscribe/thanks/');
+    expect(sitemap).not.toContain('/subscribe/confirmed/');
   });
 
   it('publishes article collection entries in rss feed', () => {
@@ -336,7 +373,7 @@ describe('site smoke tests', () => {
   });
 
   it('content pages have at least one JSON-LD script', () => {
-    const noSchemaExpected = ['404.html', 'privacy-policy', 'terms', 'content-sitemap', 'admin/'];
+    const noSchemaExpected = ['404.html', 'privacy-policy', 'terms', 'content-sitemap', 'admin/', 'subscribe/'];
     const htmlFiles = collectHtmlFiles(distRoot);
     const failures: string[] = [];
 

--- a/src/__tests__/site-smoke.test.ts
+++ b/src/__tests__/site-smoke.test.ts
@@ -83,7 +83,7 @@ describe('site smoke tests', () => {
     expect(links).toContain('/comforting/best-travel-crates-for-road-trips/');
   });
 
-  it('renders signup blocks on the homepage and excludes the footer signup from converter pages', () => {
+  it('renders the inline signup on the homepage and excludes the footer signup from attractor and converter pages', () => {
     const homeDoc = readBuiltPage('index.html');
     const converterDoc = readBuiltPage(path.join('cooling', 'cooling-mats', 'index.html'));
 
@@ -92,7 +92,7 @@ describe('site smoke tests', () => {
     ).not.toBeNull();
     expect(
       homeDoc.querySelector('[data-email-signup-placement="footer"]')
-    ).not.toBeNull();
+    ).toBeNull();
     expect(
       converterDoc.querySelector('[data-email-signup-placement="footer"]')
     ).toBeNull();

--- a/src/components/EmailSignup.astro
+++ b/src/components/EmailSignup.astro
@@ -1,0 +1,319 @@
+---
+import { ROUTES } from '@data/routes';
+import type { PageType } from '@utils/types';
+
+interface Props {
+  placement: 'footer' | 'homepage_inline';
+  title?: string;
+  body?: string;
+  compact?: boolean;
+  pageSlug?: string;
+  pageType?: PageType;
+  category?: string;
+}
+
+const {
+  placement,
+  title = 'Tips for keeping your dog cool, calm, and comfortable',
+  body = 'Seasonal safety tips, practical gear picks, and helpful guides. Sent occasionally.',
+  compact = false,
+  pageSlug = '',
+  pageType = 'collector',
+  category = 'general',
+} = Astro.props;
+
+function normalizeIdSegment(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed || trimmed === '/') return 'root';
+
+  return trimmed
+    .replace(/^\/+|\/+$/g, '')
+    .replace(/[^a-zA-Z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .toLowerCase() || 'root';
+}
+
+// `PUBLIC_BUTTONDOWN_FORM_ACTION` should include the full embed URL and optional `?next=...`.
+// When only the username is configured, the Buttondown dashboard controls the redirect flow.
+const buttondownAction = (import.meta.env.PUBLIC_BUTTONDOWN_FORM_ACTION || '').trim();
+const buttondownUsername = (import.meta.env.PUBLIC_BUTTONDOWN_USERNAME || '').trim();
+const fallbackAction = buttondownUsername
+  ? `https://buttondown.com/api/emails/embed-subscribe/${buttondownUsername}`
+  : '';
+const formAction = buttondownAction || fallbackAction;
+const hasLiveAction = Boolean(formAction);
+const formId = `email-signup-${normalizeIdSegment(placement)}-${normalizeIdSegment(pageSlug || category)}`;
+---
+
+<section
+  class:list={[
+    'email-signup',
+    {
+      'email-signup--compact': compact,
+      'email-signup--footer': placement === 'footer',
+      'email-signup--inline': placement === 'homepage_inline',
+      'email-signup--disabled': !hasLiveAction,
+    },
+  ]}
+  data-email-signup
+  data-email-signup-placement={placement}
+  data-email-signup-live={hasLiveAction ? 'true' : 'false'}
+>
+  <div class="email-signup__inner">
+    <div class="email-signup__copy">
+      <h2 class="email-signup__title">{title}</h2>
+      <p class="email-signup__body">{body}</p>
+    </div>
+
+    {hasLiveAction ? (
+      <>
+        <form
+          id={formId}
+          class="email-signup__form"
+          action={formAction}
+          method="post"
+          enctype="application/x-www-form-urlencoded"
+          data-placement={placement}
+          data-page-slug={pageSlug}
+          data-page-type={pageType}
+          data-category={category}
+        >
+          <input type="hidden" name="embed" value="1" />
+          <input type="hidden" name="tag" value={placement} />
+          <input type="hidden" name="metadata__placement" value={placement} />
+          <input type="hidden" name="metadata__page_slug" value={pageSlug} />
+          <input type="hidden" name="metadata__page_type" value={pageType} />
+          <input type="hidden" name="metadata__category" value={category} />
+
+          <label class="email-signup__label" for={`${formId}-email`}>Email address</label>
+          <div class="email-signup__row">
+            <input
+              class="email-signup__input"
+              type="email"
+              id={`${formId}-email`}
+              name="email"
+              autocomplete="email"
+              inputmode="email"
+              required
+            />
+            <button class="email-signup__button" type="submit">Subscribe</button>
+          </div>
+          <p class="email-signup__privacy">
+            No spam. Unsubscribe any time. <a href={ROUTES.privacyPolicy}>Privacy policy.</a>
+          </p>
+        </form>
+
+        <script is:inline>
+          (function () {
+            if (typeof window === 'undefined') return;
+
+            var script = document.currentScript;
+            if (!script) return;
+
+            var form = script.previousElementSibling;
+            if (!form || form.tagName !== 'FORM') return;
+
+            var data = form.dataset || {};
+            var props = {
+              placement: data.placement || '',
+              page_slug: data.pageSlug || '',
+              page_type: data.pageType || '',
+              category: data.category || '',
+            };
+
+            function capture(eventName) {
+              if (window.posthog && typeof window.posthog.capture === 'function') {
+                window.posthog.capture(eventName, props);
+              }
+            }
+
+            var input = form.querySelector('input[type="email"]');
+            var started = false;
+            var viewed = false;
+
+            if (input) {
+              input.addEventListener('focus', function () {
+                if (started) return;
+                started = true;
+                capture('email_signup_start');
+              });
+            }
+
+            form.addEventListener('submit', function () {
+              capture('email_signup_submit');
+            });
+
+            if ('IntersectionObserver' in window) {
+              var observer = new IntersectionObserver(function (entries) {
+                entries.forEach(function (entry) {
+                  if (viewed || !entry.isIntersecting) return;
+                  viewed = true;
+                  capture('email_signup_view');
+                  observer.disconnect();
+                });
+              }, { threshold: 0.35 });
+
+              observer.observe(form);
+              return;
+            }
+
+            capture('email_signup_view');
+          })();
+        </script>
+      </>
+    ) : (
+      <p class="email-signup__fallback" role="status">
+        Newsletter signup will be available soon.
+      </p>
+    )}
+  </div>
+</section>
+
+<style>
+  .email-signup {
+    width: 100%;
+    border-radius: var(--radius-lg);
+  }
+
+  .email-signup--footer {
+    color: var(--color-text-inverse);
+  }
+
+  .email-signup--inline {
+    background: var(--color-cream);
+    border: 1px solid rgba(45, 45, 45, 0.08);
+    box-shadow: var(--shadow-sm);
+  }
+
+  .email-signup__inner {
+    display: grid;
+    gap: var(--space-lg);
+    padding: var(--space-xl);
+  }
+
+  .email-signup--compact .email-signup__inner {
+    padding: var(--space-lg);
+    gap: var(--space-md);
+  }
+
+  .email-signup__copy {
+    display: grid;
+    gap: var(--space-sm);
+  }
+
+  .email-signup__title {
+    margin: 0;
+    font-family: var(--font-heading);
+    font-size: var(--text-2xl);
+    line-height: var(--leading-tight);
+  }
+
+  .email-signup--compact .email-signup__title {
+    font-size: var(--text-xl);
+  }
+
+  .email-signup__body,
+  .email-signup__privacy,
+  .email-signup__fallback {
+    margin: 0;
+    font-family: var(--font-body);
+    font-size: var(--text-sm);
+    line-height: var(--leading-relaxed);
+  }
+
+  .email-signup--footer .email-signup__body,
+  .email-signup--footer .email-signup__privacy,
+  .email-signup--footer .email-signup__fallback {
+    color: rgba(240, 244, 246, 0.8);
+  }
+
+  .email-signup__form {
+    display: grid;
+    gap: var(--space-sm);
+  }
+
+  .email-signup__label {
+    font-size: var(--text-sm);
+    font-weight: var(--weight-semibold);
+  }
+
+  .email-signup__row {
+    display: grid;
+    gap: var(--space-sm);
+  }
+
+  .email-signup__input,
+  .email-signup__button {
+    min-height: 44px;
+    border-radius: var(--radius-md);
+  }
+
+  .email-signup__input {
+    width: 100%;
+    padding: 0 var(--space-md);
+    border: 1px solid var(--color-border);
+    background: var(--color-surface);
+    color: var(--color-text);
+    font: inherit;
+  }
+
+  .email-signup--footer .email-signup__input {
+    border-color: rgba(240, 244, 246, 0.25);
+    background: rgba(240, 244, 246, 0.08);
+    color: var(--color-text-inverse);
+  }
+
+  .email-signup__input:focus-visible {
+    outline: 2px solid var(--color-sky);
+    outline-offset: 2px;
+  }
+
+  .email-signup__button {
+    border: 0;
+    padding: 0 var(--space-lg);
+    background: var(--color-sky);
+    color: var(--color-charcoal);
+    font: inherit;
+    font-weight: var(--weight-bold);
+    cursor: pointer;
+    transition: transform var(--transition-fast), background var(--transition-fast);
+  }
+
+  .email-signup__button:hover {
+    background: var(--color-sky-hover);
+    transform: translateY(-1px);
+  }
+
+  .email-signup__button:focus-visible {
+    outline: 2px solid var(--color-charcoal);
+    outline-offset: 2px;
+  }
+
+  .email-signup__privacy a,
+  .email-signup__fallback a {
+    color: inherit;
+    text-decoration: underline;
+  }
+
+  .email-signup--inline .email-signup__privacy a,
+  .email-signup--inline .email-signup__fallback a {
+    color: var(--color-link);
+  }
+
+  .email-signup__fallback {
+    padding: var(--space-md);
+    border-radius: var(--radius-md);
+    background: rgba(45, 45, 45, 0.06);
+  }
+
+  .email-signup--footer .email-signup__fallback {
+    background: rgba(240, 244, 246, 0.08);
+  }
+
+  @media (min-width: 500px) {
+    .email-signup__row {
+      grid-template-columns: minmax(0, 1fr) auto;
+      align-items: end;
+    }
+  }
+</style>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -65,7 +65,7 @@ function inferCategory(pathname: string): string {
   return 'general';
 }
 
-const shouldShowSignup = !converterPaths.has(currentPath);
+const shouldShowSignup = !converterPaths.has(currentPath) && currentPath !== ROUTES.home;
 const footerPageType = inferPageType(currentPath);
 const footerCategory = inferCategory(currentPath);
 ---

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,7 +1,13 @@
 ---
+import EmailSignup from '@components/EmailSignup.astro';
+import { coolingConverterPageConfigs } from '@data/cooling-converter-pages';
+import { calmingConverterPages } from '@data/calming-converter-pages';
+import { relaxationConverterPages } from '@data/relaxation-converter-pages';
 import { ROUTES } from '@data/routes';
+import type { PageType } from '@utils/types';
 
 const currentYear = new Date().getFullYear();
+const currentPath = normalizePath(Astro.url.pathname);
 
 const exploreLinks = [
   { href: ROUTES.coolingHub, label: 'Cooling' },
@@ -19,6 +25,49 @@ const legalLinks = [
   { href: ROUTES.terms, label: 'Terms of Use' },
   { href: ROUTES.affiliateDisclosure, label: 'Affiliate Disclosure' },
 ];
+
+function normalizePath(pathname: string): string {
+  if (!pathname || pathname === '/') return '/';
+  return pathname.endsWith('/') ? pathname : `${pathname}/`;
+}
+
+const converterPaths = new Set<string>([
+  ROUTES.coolingTop,
+  ROUTES.trackingTop,
+  ROUTES.fiCollarReview,
+  ...Object.keys(coolingConverterPageConfigs).map((slug) => `/cooling/${slug}/`),
+  ...Object.keys(calmingConverterPages).map((slug) => `/calming/${slug}/`),
+  ...Object.keys(relaxationConverterPages).map((slug) => `/comforting/${slug}/`),
+]);
+
+const informerPaths = new Set<string>([
+  ROUTES.about,
+  ROUTES.contact,
+  ROUTES.privacyPolicy,
+  ROUTES.terms,
+  ROUTES.affiliateDisclosure,
+  ROUTES.subscribeThanks,
+  ROUTES.subscribeConfirmed,
+  '/content-sitemap/',
+]);
+
+function inferPageType(pathname: string): PageType {
+  if (converterPaths.has(pathname)) return 'converter';
+  if (pathname === ROUTES.home || pathname.startsWith('/v/')) return 'attractor';
+  if (informerPaths.has(pathname) || pathname.startsWith('/admin/')) return 'informer';
+  return 'collector';
+}
+
+function inferCategory(pathname: string): string {
+  if (pathname.startsWith('/cooling/')) return 'cooling';
+  if (pathname.startsWith('/calming/')) return 'calming';
+  if (pathname.startsWith('/comforting/')) return 'comfort';
+  return 'general';
+}
+
+const shouldShowSignup = !converterPaths.has(currentPath);
+const footerPageType = inferPageType(currentPath);
+const footerCategory = inferCategory(currentPath);
 ---
 
 <footer class="site-footer">
@@ -49,6 +98,18 @@ const legalLinks = [
         </ul>
       </div>
     </div>
+
+    {shouldShowSignup && (
+      <div class="footer-signup">
+        <EmailSignup
+          placement="footer"
+          compact={true}
+          pageSlug={currentPath}
+          pageType={footerPageType}
+          category={footerCategory}
+        />
+      </div>
+    )}
 
     <div class="footer-disclosure">
       <p>
@@ -115,6 +176,12 @@ const legalLinks = [
     border-top: 1px solid rgba(240, 244, 246, 0.15);
     padding-top: var(--space-xl);
     margin-bottom: var(--space-lg);
+  }
+
+  .footer-signup {
+    border-top: 1px solid rgba(240, 244, 246, 0.15);
+    padding-block: var(--space-2xl);
+    margin-bottom: var(--space-2xl);
   }
 
   .footer-disclosure p {

--- a/src/data/routes.ts
+++ b/src/data/routes.ts
@@ -34,4 +34,6 @@ export const ROUTES = {
   affiliateDisclosure: '/affiliate-disclosure/',
   privacyPolicy: '/privacy-policy/',
   terms: '/terms/',
+  subscribeThanks: '/subscribe/thanks/',
+  subscribeConfirmed: '/subscribe/confirmed/',
 } as const;

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -76,6 +76,9 @@ import BaseLayout from '@layouts/BaseLayout.astro';
       <p>
         We use affiliate links to support the site. If you purchase through our links, we may earn a small commission at no additional cost to you. This does not affect which products we choose to feature.
       </p>
+      <p>
+        We also use <a href="https://buttondown.com/refer/chill-dogs" target="_blank" rel="noopener noreferrer">Buttondown</a> for our email newsletter.
+      </p>
     </div>
   </section>
 </BaseLayout>

--- a/src/pages/content-sitemap.astro
+++ b/src/pages/content-sitemap.astro
@@ -1,6 +1,7 @@
 ---
 import BaseLayout from '@layouts/BaseLayout.astro';
 import { categoryMeta } from '@data/cooling-products';
+import { ROUTES } from '@data/routes';
 import { getCollection } from 'astro:content';
 
 interface SitemapPage {
@@ -89,6 +90,8 @@ const staticSections: SitemapSection[] = [
       { title: 'Contact', href: '/contact/', pageType: 'informer' },
       { title: 'Affiliate Disclosure', href: '/affiliate-disclosure/', pageType: 'informer' },
       { title: 'Privacy Policy', href: '/privacy-policy/', pageType: 'informer' },
+      { title: 'Subscribe — Thanks', href: ROUTES.subscribeThanks, pageType: 'informer' },
+      { title: 'Subscribe — Confirmed', href: ROUTES.subscribeConfirmed, pageType: 'informer' },
       { title: 'Terms of Use', href: '/terms/', pageType: 'informer' },
     ],
   },

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,6 +2,7 @@
 import { ROUTES } from '@data/routes';
 import BaseLayout from '@layouts/BaseLayout.astro';
 import ComingSoon from '@components/ComingSoon.astro';
+import EmailSignup from '@components/EmailSignup.astro';
 import HomepageHero from '@components/modules/HomepageHero.astro';
 import HomepageBody from '@components/modules/HomepageBody.astro';
 import JsonLd from '@components/JsonLd.astro';
@@ -49,5 +50,19 @@ const orgSchema = {
     <HomepageHero variant="v6" />
 
     <HomepageBody variant="v6" />
+    <section class="container homepage-signup">
+      <EmailSignup
+        placement="homepage_inline"
+        pageSlug={ROUTES.home}
+        pageType="attractor"
+        category="general"
+      />
+    </section>
   </BaseLayout>
 )}
+
+<style>
+  .homepage-signup {
+    padding-bottom: var(--space-3xl);
+  }
+</style>

--- a/src/pages/privacy-policy.astro
+++ b/src/pages/privacy-policy.astro
@@ -7,7 +7,7 @@ import BaseLayout from '@layouts/BaseLayout.astro';
   <section class="legal container">
     <div class="prose">
       <h1>Privacy Policy</h1>
-      <p><em>Last updated: February 2026</em></p>
+      <p><em>Last updated: April 2026</em></p>
 
       <p>
         Chill-Dogs ("we", "us", or "our") operates the website chill-dogs.com. This page informs you of our policies regarding the collection, use, and disclosure of personal information when you use our site.
@@ -21,6 +21,16 @@ import BaseLayout from '@layouts/BaseLayout.astro';
         <li><strong>PostHog</strong> — We use PostHog to understand how visitors interact with our site. This service may collect information such as your browser type, pages visited, and time spent on pages.</li>
         <li><strong>Amazon Associates</strong> — When you click affiliate links, Amazon may set cookies to track purchases for commission purposes.</li>
       </ul>
+
+      <h2>Email Newsletter</h2>
+      <p>
+        If you subscribe to our email newsletter, we collect your email address.
+        This information is processed by Buttondown (buttondown.com), our email
+        service provider. Buttondown may store your email address and subscription
+        metadata on their servers. You can unsubscribe at any time using the link
+        in any email we send. We do not sell or share subscriber email addresses
+        with third parties.
+      </p>
 
       <h2>Cookies</h2>
       <p>

--- a/src/pages/subscribe/confirmed.astro
+++ b/src/pages/subscribe/confirmed.astro
@@ -1,0 +1,147 @@
+---
+import { ROUTES } from '@data/routes';
+import BaseLayout from '@layouts/BaseLayout.astro';
+
+const title = "You're Subscribed";
+const description = 'You are subscribed to Chill-Dogs. Get practical tips on keeping your dog cool, calm, and comfortable delivered to your inbox.';
+
+const routingCards = [
+  {
+    title: 'Cooling Picks',
+    description: 'Start with the main cooling path for mats, vests, bandanas, and heat-ready gear.',
+    href: ROUTES.coolingHub,
+  },
+  {
+    title: 'Calming Picks',
+    description: 'See the main calming path for wraps, chews, lick mats, and travel-stress help.',
+    href: ROUTES.calmingHub,
+  },
+  {
+    title: 'Comfort & Rest',
+    description: 'Browse beds, crates, and comfort-focused guides for dogs who need better downtime.',
+    href: ROUTES.comfortHub,
+  },
+  {
+    title: 'Hot Weather Guide',
+    description: 'Read the heat-safety guide that explains when temperatures are too hot for dogs.',
+    href: ROUTES.coolingSafety,
+  },
+];
+---
+
+<BaseLayout
+  title={title}
+  ogTitle="You're Subscribed to Chill-Dogs Tips and Guides"
+  description={description}
+  noindex={true}
+  hideChrome={true}
+>
+  <section class="subscribe-flow container">
+    <div class="subscribe-panel">
+      <p class="eyebrow">Confirmed</p>
+      <h1>You&apos;re in.</h1>
+      <p class="lede">
+        You&apos;ll get practical tips, seasonal reminders, and researched gear picks focused on helping dogs stay cool, calm, and comfortable.
+      </p>
+
+      <div class="routing-grid">
+        {routingCards.map((card) => (
+          <a href={card.href} class="routing-card">
+            <h2>{card.title}</h2>
+            <p>{card.description}</p>
+            <span>Explore -&gt;</span>
+          </a>
+        ))}
+      </div>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .subscribe-flow {
+    padding-top: var(--space-4xl);
+    padding-bottom: var(--space-4xl);
+  }
+
+  .subscribe-panel {
+    display: grid;
+    gap: var(--space-xl);
+    width: min(100%, 56rem);
+    margin: 0 auto;
+    padding: var(--space-2xl);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    background: var(--color-surface);
+    box-shadow: var(--shadow-md);
+  }
+
+  .eyebrow {
+    margin: 0;
+    color: var(--color-accent-text);
+    font-size: var(--text-xs);
+    font-weight: var(--weight-bold);
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+
+  h1 {
+    margin: 0;
+    font-size: var(--text-4xl);
+  }
+
+  .lede {
+    margin: 0;
+    font-size: var(--text-base);
+    line-height: var(--leading-relaxed);
+    color: var(--color-text-muted);
+  }
+
+  .routing-grid {
+    display: grid;
+    gap: var(--space-md);
+  }
+
+  .routing-card {
+    display: grid;
+    gap: var(--space-sm);
+    padding: var(--space-lg);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: linear-gradient(180deg, rgba(135, 183, 199, 0.14), rgba(245, 240, 232, 0.9));
+    text-decoration: none;
+    color: var(--color-text);
+    transition: transform var(--transition-fast), box-shadow var(--transition-fast);
+  }
+
+  .routing-card:hover {
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-sm);
+  }
+
+  .routing-card h2,
+  .routing-card p,
+  .routing-card span {
+    margin: 0;
+  }
+
+  .routing-card h2 {
+    font-size: var(--text-xl);
+  }
+
+  .routing-card p {
+    color: var(--color-text-muted);
+    line-height: var(--leading-relaxed);
+  }
+
+  .routing-card span {
+    font-size: var(--text-sm);
+    font-weight: var(--weight-bold);
+    color: var(--color-link);
+  }
+
+  @media (min-width: 700px) {
+    .routing-grid {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+</style>

--- a/src/pages/subscribe/thanks.astro
+++ b/src/pages/subscribe/thanks.astro
@@ -1,0 +1,71 @@
+---
+import BaseLayout from '@layouts/BaseLayout.astro';
+
+const title = 'Check Your Email';
+const description = 'Check your inbox for a confirmation email. Click the link to confirm your Chill-Dogs subscription and start getting practical tips.';
+---
+
+<BaseLayout
+  title={title}
+  ogTitle="Check Your Email to Confirm Your Chill-Dogs Signup"
+  description={description}
+  noindex={true}
+  hideChrome={true}
+>
+  <section class="subscribe-flow container">
+    <div class="subscribe-panel">
+      <p class="eyebrow">Almost there</p>
+      <h1>Check your email</h1>
+      <p>
+        Look for a confirmation email from Chill-Dogs, then click the confirmation link to finish your subscription.
+      </p>
+      <p>
+        If you do not see it right away, check your promotions tab, spam folder, or search for Buttondown in your inbox.
+      </p>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .subscribe-flow {
+    min-height: 100vh;
+    display: grid;
+    place-items: center;
+    padding-top: var(--space-4xl);
+    padding-bottom: var(--space-4xl);
+  }
+
+  .subscribe-panel {
+    width: min(100%, 42rem);
+    padding: var(--space-2xl);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    background: var(--color-surface);
+    box-shadow: var(--shadow-md);
+  }
+
+  .eyebrow {
+    margin: 0 0 var(--space-sm);
+    color: var(--color-accent-text);
+    font-size: var(--text-xs);
+    font-weight: var(--weight-bold);
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+
+  h1 {
+    margin-bottom: var(--space-md);
+    font-size: var(--text-4xl);
+  }
+
+  p {
+    margin: 0 0 var(--space-md);
+    font-size: var(--text-base);
+    line-height: var(--leading-relaxed);
+    color: var(--color-text-muted);
+  }
+
+  p:last-child {
+    margin-bottom: 0;
+  }
+</style>


### PR DESCRIPTION
## Summary
- add a reusable Buttondown signup component with PostHog instrumentation and safe env fallback behavior
- add homepage inline signup, footer signup on non-converter routes, and hidden subscribe flow pages
- update privacy policy, hidden sitemap inventory, system definition, sitemap filtering, and IndexNow exclusions for hidden routes

## Validation
- bun run build
- bun run test

## Notes
- converter routes intentionally exclude the footer signup to keep affiliate pages single-purpose
- subscribe flow pages are noindex, hide site chrome, and are excluded from sitemap and IndexNow submission