### PR TITLE
Make homepage article feed recency-driven

### DIFF
--- a/docs/system-definition.yaml
+++ b/docs/system-definition.yaml
@@ -8,7 +8,7 @@
 
 site_system:
   status: "active"
-  as_of: "2026-04-14"
+  as_of: "2026-04-27"
   owner: "chill-dogs"
   purpose: "Define the website as a modular conversion system and keep implementation aligned."
 
@@ -37,8 +37,10 @@ site_system:
       notes: >
         Home page includes a dusty rose color block introducing the Comfort & Rest collector
         with tagline "Settle in." — positioned between HomepageHero and the start-prompt section.
-        The latest/guide lists include How to Crate Train Your Dog and Best Travel Crates for Road Trips
-        to connect informational crate intent with the new crate converter path.
+        The homepage guide section now auto-discovers entries from the MDX articles collection,
+        sorts them by pubDate descending, features the three newest posts with images, and renders
+        the remaining articles in a compact recency list so newly published articles land on the
+        home page automatically.
         A homepage-inline email signup block sits below HomepageBody as a secondary capture path.
 
     - name: "Cooling"

--- a/src/__tests__/homepage-articles.test.ts
+++ b/src/__tests__/homepage-articles.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import type { CollectionEntry } from 'astro:content';
+import type { ImageMetadata } from 'astro';
+
+import {
+  buildHomepageArticleFeed,
+  mapHomepageArticle,
+  resolveHomepageArticleTheme,
+} from '../utils/homepage-articles';
+
+function createArticle(
+  canonicalPath: string,
+  pubDate: string,
+  ogImage?: ImageMetadata
+): CollectionEntry<'articles'> {
+  return {
+    id: canonicalPath,
+    slug: canonicalPath,
+    body: '',
+    collection: 'articles',
+    data: {
+      title: canonicalPath,
+      description: `${canonicalPath} description`,
+      pubDate: new Date(pubDate),
+      canonicalPath,
+      ogImage,
+    },
+  } as CollectionEntry<'articles'>;
+}
+
+describe('homepage article feed', () => {
+  it('derives homepage themes from article route prefixes', () => {
+    expect(resolveHomepageArticleTheme('/cooling/how-hot-is-too-hot-for-dogs/')).toEqual({
+      label: 'Cooling',
+      color: 'cool',
+    });
+    expect(resolveHomepageArticleTheme('/travel/how-to-fly-with-a-dog/')).toEqual({
+      label: 'Travel',
+      color: 'gear',
+    });
+    expect(resolveHomepageArticleTheme('/something-else/')).toEqual({
+      label: 'Guide',
+      color: 'gear',
+    });
+  });
+
+  it('maps images and sorts newest articles to the top', () => {
+    const explicitImage = {
+      src: '/_assets/custom-og.jpg',
+      width: 1200,
+      height: 630,
+      format: 'jpg',
+    } as ImageMetadata;
+
+    const feed = buildHomepageArticleFeed([
+      createArticle('/cooling/how-hot-is-too-hot-for-dogs/', '2026-03-10'),
+      createArticle('/travel/how-to-fly-with-a-dog/', '2026-04-10', explicitImage),
+      createArticle('/calming/crate-training-for-dogs/', '2026-04-09'),
+      createArticle('/safety/what-to-do-if-your-dog-runs-away/', '2026-04-03'),
+    ]);
+
+    expect(feed.featuredArticles.map((article) => article.href)).toEqual([
+      '/travel/how-to-fly-with-a-dog/',
+      '/calming/crate-training-for-dogs/',
+      '/safety/what-to-do-if-your-dog-runs-away/',
+    ]);
+    expect(feed.moreArticles.map((article) => article.href)).toEqual([
+      '/cooling/how-hot-is-too-hot-for-dogs/',
+    ]);
+    expect(feed.latestGuides.map((article) => article.href)).toEqual([
+      '/travel/how-to-fly-with-a-dog/',
+      '/calming/crate-training-for-dogs/',
+      '/safety/what-to-do-if-your-dog-runs-away/',
+      '/cooling/how-hot-is-too-hot-for-dogs/',
+    ]);
+
+    expect(feed.featuredArticles[0]?.image).toBe('/_assets/custom-og.jpg');
+    expect(feed.moreArticles[0]?.image).toBe('/og/cooling-how-hot-is-too-hot-for-dogs.jpg');
+  });
+
+  it('maps a single article into homepage card data', () => {
+    const article = mapHomepageArticle(
+      createArticle('/comforting/how-much-do-dogs-sleep/', '2026-03-24')
+    );
+
+    expect(article).toMatchObject({
+      title: '/comforting/how-much-do-dogs-sleep/',
+      href: '/comforting/how-much-do-dogs-sleep/',
+      label: 'Comfort',
+      color: 'comfort',
+      image: '/og/comforting-how-much-do-dogs-sleep.jpg',
+    });
+  });
+});

--- a/src/__tests__/site-smoke.test.ts
+++ b/src/__tests__/site-smoke.test.ts
@@ -37,6 +37,29 @@ function readBuiltAsset(relativePath: string): string {
   return readFileSync(path.join(distRoot, relativePath), 'utf8');
 }
 
+function readArticlePublishOrder(): string[] {
+  const articlesRoot = path.join(projectRoot, 'src', 'content', 'articles');
+
+  return readdirSync(articlesRoot)
+    .filter((entry) => entry.endsWith('.mdx'))
+    .map((entry) => {
+      const contents = readFileSync(path.join(articlesRoot, entry), 'utf8');
+      const pubDate = contents.match(/^pubDate:\s*([0-9-]+)/m)?.[1];
+      const canonicalPath = contents.match(/^canonicalPath:\s*'([^']+)'/m)?.[1];
+
+      if (!pubDate || !canonicalPath) {
+        throw new Error(`Missing pubDate or canonicalPath in ${entry}`);
+      }
+
+      return {
+        canonicalPath,
+        pubDate: new Date(pubDate),
+      };
+    })
+    .sort((a, b) => b.pubDate.valueOf() - a.pubDate.valueOf())
+    .map((article) => article.canonicalPath);
+}
+
 function firstMainImageAbsolute(doc: Document): string | null {
   const image = doc.querySelector<HTMLImageElement>('main img');
   const src = image?.getAttribute('src');
@@ -90,6 +113,16 @@ describe('site smoke tests', () => {
 
     expect(links).toContain('/calming/crate-training-for-dogs/');
     expect(links).toContain('/comforting/best-travel-crates-for-road-trips/');
+  });
+
+  it('orders homepage article cards by article publish date', () => {
+    const doc = readBuiltPage('index.html');
+    const renderedArticleLinks = [
+      ...Array.from(doc.querySelectorAll<HTMLAnchorElement>('.featured-grid [data-home-article="true"]')),
+      ...Array.from(doc.querySelectorAll<HTMLAnchorElement>('.more-grid [data-home-article="true"]')),
+    ].map((link) => link.getAttribute('href'));
+
+    expect(renderedArticleLinks).toEqual(readArticlePublishOrder());
   });
 
   it('renders the inline signup on the homepage and excludes the footer signup from attractor and converter pages', () => {

--- a/src/components/modules/HomepageBody.astro
+++ b/src/components/modules/HomepageBody.astro
@@ -1,16 +1,14 @@
 ---
-import { Image } from 'astro:assets';
 import { ROUTES } from '@data/routes';
 import type { HomepageVariant } from '@components/modules/HomepageHero.astro';
-import coolingSafetyOg from '/public/og/cooling-how-hot-is-too-hot-for-dogs.jpg';
-import calmingCarOg from '/public/og/calming-car-anxiety-for-dogs.jpg';
-import comfortSleepOg from '/public/og/comforting-how-much-do-dogs-sleep.jpg';
+import type { HomepageArticleFeed } from '@utils/homepage-articles';
 
 interface Props {
   variant?: HomepageVariant;
+  articleFeed: HomepageArticleFeed;
 }
 
-const { variant } = Astro.props;
+const { variant, articleFeed } = Astro.props;
 const isV6 = variant === 'v6';
 
 const shopCards = [
@@ -44,45 +42,6 @@ const shopCards = [
   },
 ];
 
-const featuredArticles = [
-  {
-    title: 'How Hot Is Too Hot for Dogs?',
-    description: 'Heat threshold guidance with routes to cooling product pages.',
-    href: ROUTES.coolingSafety,
-    image: coolingSafetyOg,
-    label: 'Cooling',
-    color: 'cool',
-  },
-  {
-    title: 'Car Anxiety for Dogs',
-    description: 'Practical calming tools for travel stress and restless rides.',
-    href: ROUTES.calmingCar,
-    image: calmingCarOg,
-    label: 'Calming',
-    color: 'calm',
-  },
-  {
-    title: 'How Much Do Dogs Sleep?',
-    description: 'Sleep norms by age and breed, REM research, and what disruptions might mean.',
-    href: ROUTES.comfortSleepArticle,
-    image: comfortSleepOg,
-    label: 'Comfort',
-    color: 'comfort',
-  },
-];
-
-const moreArticles = [
-  { title: 'Car Cooling for Dogs', description: 'In-car cooling gear and heat-risk reduction essentials.', href: ROUTES.coolingCar, color: 'cool' },
-  { title: 'Cooling Mats', description: 'Compare pressure-activated and water-based cooling mats.', href: ROUTES.coolingMats, color: 'cool' },
-  { title: 'Cooling Vests', description: 'Evaporative cooling vests for active outdoor dogs.', href: ROUTES.coolingVests, color: 'cool' },
-  { title: 'Anxiety Vest Alternatives', description: 'When to choose wraps, chews, lick mats, or snuffle mats instead.', href: ROUTES.calmingAlternatives, color: 'calm' },
-  { title: 'How to Crate Train Your Dog', description: 'Crate training for puppies, anxious dogs, and travel routines.', href: ROUTES.calmingCrateGuide, color: 'calm' },
-  { title: "Rhys's Road Trip Chill Kit", description: 'Cooling and calming picks for long drives with dogs.', href: ROUTES.roadTrip, color: 'calm' },
-  { title: 'Travel Crates for Road Trips', description: 'Hard-sided and soft folding crates for dogs who travel by car.', href: ROUTES.comfortTravelCrates, color: 'comfort' },
-  { title: 'The Day Rhys Ran Off on Cerro San Luis Obispo', description: 'What a foggy summit and a 30-minute search taught us about GPS trackers.', href: ROUTES.rhysRanAway, color: 'gear' },
-  { title: 'What To Do If Your Dog Runs Away', description: 'A step-by-step action guide for the first hour and beyond.', href: ROUTES.dogRanAwaySafety, color: 'gear' },
-];
-
 const topGuides = [
   { title: 'Best Cooling Products for Dogs', description: 'Mats, vests, bandanas, and frozen enrichment', href: ROUTES.coolingTop },
   { title: 'Best Calming Products for Anxious Dogs', description: 'Wraps, chews, lick mats, and snuffle mats', href: ROUTES.calmingTop },
@@ -90,19 +49,13 @@ const topGuides = [
   { title: 'Dog GPS Trackers & Safety', description: 'Cellular, off-grid, and Bluetooth tracking — know which type fits your terrain.', href: ROUTES.trackingTop },
 ];
 
-const latestGuides = [
-  { title: 'How Much Do Dogs Sleep?', description: 'Sleep norms by age and breed, REM research, and what disruptions might mean.', href: ROUTES.comfortSleepArticle },
-  { title: 'Car Cooling for Dogs', description: 'In-car cooling gear and heat-risk reduction essentials.', href: ROUTES.coolingCar },
-  { title: 'Car Anxiety for Dogs', description: 'Practical calming tools for travel stress and restless rides.', href: ROUTES.calmingCar },
-  { title: 'How Hot Is Too Hot for Dogs?', description: 'Heat threshold guidance with routes to cooling product pages.', href: ROUTES.coolingSafety },
-  { title: 'Cooling Mats', description: 'Compare pressure-activated and water-based cooling mats.', href: ROUTES.coolingMats },
-  { title: 'Cooling Vests', description: 'Evaporative cooling vests for active outdoor dogs.', href: ROUTES.coolingVests },
-  { title: 'Anxiety Vest Alternatives', description: 'When to choose wraps, chews, lick mats, or snuffle mats instead.', href: ROUTES.calmingAlternatives },
-  { title: 'How to Crate Train Your Dog', description: 'Crate training for puppies, anxious dogs, and travel routines.', href: ROUTES.calmingCrateGuide },
-  { title: "Rhys's Road Trip Chill Kit", description: 'Cooling and calming picks for long drives with dogs.', href: ROUTES.roadTrip },
-  { title: 'Travel Crates for Road Trips', description: 'Hard-sided and soft folding crates for dogs who travel by car.', href: ROUTES.comfortTravelCrates },
-  { title: 'The Day Rhys Ran Off on Cerro San Luis Obispo', description: 'What a foggy summit and a 30-minute search taught us about GPS trackers.', href: ROUTES.rhysRanAway },
-  { title: 'What To Do If Your Dog Runs Away', description: 'A step-by-step action guide for the first hour and beyond.', href: ROUTES.dogRanAwaySafety },
+const pinnedGuideRoutes = [
+  {
+    title: 'Travel Crates for Road Trips',
+    description: 'Hard-sided and soft folding crates for dogs who travel by car.',
+    href: ROUTES.comfortTravelCrates,
+    color: 'comfort',
+  },
 ];
 ---
 
@@ -133,21 +86,22 @@ const latestGuides = [
     <section class="guide-section container">
       <h2 class="section-title">From the Guide</h2>
       <div class="featured-grid">
-        {featuredArticles.map((article) => (
+        {articleFeed.featuredArticles.map((article) => (
           <a
             href={article.href}
             class="article-card"
+            data-home-article="true"
             data-track="collector_to_converter_click"
             data-to-page={article.href}
             data-link-position="homepage-featured-articles"
           >
             <div class="article-img-wrap">
-              <Image
-                src={article.image}
+              <img
+                src={typeof article.image === 'string' ? article.image : article.image.src}
                 alt=""
                 class="article-img"
-                width={400}
-                height={210}
+                width="400"
+                height="210"
                 loading="lazy"
               />
             </div>
@@ -162,10 +116,11 @@ const latestGuides = [
       </div>
 
       <div class="more-grid">
-        {moreArticles.map((article) => (
+        {[...articleFeed.moreArticles, ...pinnedGuideRoutes].map((article) => (
           <a
             href={article.href}
             class={`more-card more-card--${article.color}`}
+            data-home-article={articleFeed.moreArticles.includes(article) ? 'true' : undefined}
             data-track="collector_to_converter_click"
             data-to-page={article.href}
             data-link-position="homepage-more-articles"
@@ -194,7 +149,7 @@ const latestGuides = [
     <section class="latest container">
       <h2 class="section-title">Latest Guides</h2>
       <div class="cards-grid">
-        {latestGuides.map((guide) => (
+        {articleFeed.latestGuides.map((guide) => (
           <a href={guide.href} class="guide-card" data-track="collector_to_converter_click" data-to-page={guide.href} data-link-position="homepage-latest-guides">
             <h3 class="guide-title">{guide.title}</h3>
             <p class="guide-description">{guide.description}</p>
@@ -357,6 +312,7 @@ const latestGuides = [
   .article-label--cool    { color: hsl(200, 80%, 28%); }
   .article-label--calm    { color: hsl(155, 50%, 26%); }
   .article-label--comfort { color: hsl(345, 38%, 38%); }
+  .article-label--gear    { color: hsl(220, 20%, 35%); }
 
   .article-title {
     font-family: var(--font-heading);

--- a/src/components/modules/HomepageBody.astro
+++ b/src/components/modules/HomepageBody.astro
@@ -27,9 +27,9 @@ const shopCards = [
     color: 'calm',
   },
   {
-    title: 'Comfort & Rest for Dogs',
-    description: 'Supportive beds, cozy blankets, and comforting toys for every age.',
-    href: ROUTES.comfortHub,
+    title: 'Best Calming Dog Beds',
+    description: 'Supportive beds for rest, recovery, and relaxation — curated for anxious dogs.',
+    href: ROUTES.comfortCalmingBeds,
     label: 'Comfort',
     color: 'comfort',
   },
@@ -61,27 +61,6 @@ const pinnedGuideRoutes = [
 
 {isV6 ? (
   <>
-    {/* ── Shop by Need ── */}
-    <section class="shop container">
-      <h2 class="section-title">Shop by Need</h2>
-      <div class="shop-grid">
-        {shopCards.map((card) => (
-          <a
-            href={card.href}
-            class={`shop-card shop-card--${card.color}`}
-            data-track="collector_to_converter_click"
-            data-to-page={card.href}
-            data-link-position="homepage-shop"
-          >
-            <span class={`shop-label shop-label--${card.color}`}>{card.label}</span>
-            <h3 class="shop-title">{card.title}</h3>
-            <p class="shop-desc">{card.description}</p>
-            <span class="shop-cta">Explore picks →</span>
-          </a>
-        ))}
-      </div>
-    </section>
-
     {/* ── From the Guide ── */}
     <section class="guide-section container">
       <h2 class="section-title">From the Guide</h2>
@@ -127,6 +106,30 @@ const pinnedGuideRoutes = [
           >
             <h3 class="more-title">{article.title}</h3>
             <p class="more-desc">{article.description}</p>
+          </a>
+        ))}
+      </div>
+    </section>
+
+    {/* ── Newsletter (injected from parent) ── */}
+    <slot name="newsletter" />
+
+    {/* ── Shop by Need ── */}
+    <section class="shop container">
+      <h2 class="section-title">Shop by Need</h2>
+      <div class="shop-grid">
+        {shopCards.map((card) => (
+          <a
+            href={card.href}
+            class={`shop-card shop-card--${card.color}`}
+            data-track="collector_to_converter_click"
+            data-to-page={card.href}
+            data-link-position="homepage-shop"
+          >
+            <span class={`shop-label shop-label--${card.color}`}>{card.label}</span>
+            <h3 class="shop-title">{card.title}</h3>
+            <p class="shop-desc">{card.description}</p>
+            <span class="shop-cta">Explore picks →</span>
           </a>
         ))}
       </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -52,15 +52,16 @@ const orgSchema = {
     <JsonLd slot="head" schema={orgSchema} />
     <HomepageHero variant="v6" />
 
-    <HomepageBody variant="v6" articleFeed={articleFeed} />
-    <section class="container homepage-signup">
-      <EmailSignup
-        placement="homepage_inline"
-        pageSlug={ROUTES.home}
-        pageType="attractor"
-        category="general"
-      />
-    </section>
+    <HomepageBody variant="v6" articleFeed={articleFeed}>
+      <section slot="newsletter" class="container homepage-signup">
+        <EmailSignup
+          placement="homepage_inline"
+          pageSlug={ROUTES.home}
+          pageType="attractor"
+          category="general"
+        />
+      </section>
+    </HomepageBody>
   </BaseLayout>
 )}
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,13 +1,16 @@
 ---
 import { ROUTES } from '@data/routes';
+import { getCollection } from 'astro:content';
 import BaseLayout from '@layouts/BaseLayout.astro';
 import ComingSoon from '@components/ComingSoon.astro';
 import EmailSignup from '@components/EmailSignup.astro';
 import HomepageHero from '@components/modules/HomepageHero.astro';
 import HomepageBody from '@components/modules/HomepageBody.astro';
 import JsonLd from '@components/JsonLd.astro';
+import { buildHomepageArticleFeed } from '@utils/homepage-articles';
 
 const maintenanceMode = !!import.meta.env.MAINTENANCE_MODE;
+const articleFeed = buildHomepageArticleFeed(await getCollection('articles'));
 
 const websiteSchema = {
   '@context': 'https://schema.org',
@@ -49,7 +52,7 @@ const orgSchema = {
     <JsonLd slot="head" schema={orgSchema} />
     <HomepageHero variant="v6" />
 
-    <HomepageBody variant="v6" />
+    <HomepageBody variant="v6" articleFeed={articleFeed} />
     <section class="container homepage-signup">
       <EmailSignup
         placement="homepage_inline"

--- a/src/pages/v/[variant].astro
+++ b/src/pages/v/[variant].astro
@@ -1,8 +1,10 @@
 ---
+import { getCollection } from 'astro:content';
 import BaseLayout from '@layouts/BaseLayout.astro';
 import HomepageHero from '@components/modules/HomepageHero.astro';
 import HomepageBody from '@components/modules/HomepageBody.astro';
 import type { HomepageVariant } from '@components/modules/HomepageHero.astro';
+import { buildHomepageArticleFeed } from '@utils/homepage-articles';
 
 export function getStaticPaths() {
   const variants: HomepageVariant[] = ['v1', 'v2', 'v3', 'v4', 'v5', 'v6', 'v7', 'v8'];
@@ -10,6 +12,7 @@ export function getStaticPaths() {
 }
 
 const { variant } = Astro.params as { variant: HomepageVariant };
+const articleFeed = buildHomepageArticleFeed(await getCollection('articles'));
 
 /**
  * Variant pages are experiment copies of /.
@@ -27,5 +30,5 @@ const canonicalUrl = new URL('/', Astro.site).href;
   <meta slot="head" name="robots" content="noindex, follow" />
 
   <HomepageHero variant={variant} />
-  <HomepageBody variant={variant} />
+  <HomepageBody variant={variant} articleFeed={articleFeed} />
 </BaseLayout>

--- a/src/utils/homepage-articles.ts
+++ b/src/utils/homepage-articles.ts
@@ -1,0 +1,76 @@
+import type { CollectionEntry } from 'astro:content';
+import type { ImageMetadata } from 'astro';
+import { resolveAutoOgImagePath, resolveProvidedOgImagePath } from './og';
+
+export type HomepageArticleColor = 'cool' | 'calm' | 'comfort' | 'gear';
+
+export interface HomepageArticleCard {
+  title: string;
+  description: string;
+  href: string;
+  image: string | ImageMetadata;
+  label: string;
+  color: HomepageArticleColor;
+  pubDate: Date;
+}
+
+export interface HomepageArticleFeed {
+  featuredArticles: HomepageArticleCard[];
+  moreArticles: HomepageArticleCard[];
+  latestGuides: HomepageArticleCard[];
+}
+
+const ARTICLE_THEME_BY_PREFIX: Array<{
+  prefix: string;
+  label: string;
+  color: HomepageArticleColor;
+}> = [
+  { prefix: '/cooling/', label: 'Cooling', color: 'cool' },
+  { prefix: '/calming/', label: 'Calming', color: 'calm' },
+  { prefix: '/comforting/', label: 'Comfort', color: 'comfort' },
+  { prefix: '/travel/', label: 'Travel', color: 'gear' },
+  { prefix: '/safety/', label: 'Safety', color: 'gear' },
+  { prefix: '/gear/', label: 'Gear', color: 'gear' },
+];
+
+export function resolveHomepageArticleTheme(canonicalPath: string): Pick<HomepageArticleCard, 'label' | 'color'> {
+  const match = ARTICLE_THEME_BY_PREFIX.find(({ prefix }) => canonicalPath.startsWith(prefix));
+
+  if (!match) {
+    return { label: 'Guide', color: 'gear' };
+  }
+
+  return { label: match.label, color: match.color };
+}
+
+export function mapHomepageArticle(entry: CollectionEntry<'articles'>): HomepageArticleCard {
+  const theme = resolveHomepageArticleTheme(entry.data.canonicalPath);
+
+  return {
+    title: entry.data.title,
+    description: entry.data.description,
+    href: entry.data.canonicalPath,
+    image: resolveProvidedOgImagePath(entry.data.ogImage)
+      ?? resolveAutoOgImagePath({ pathname: entry.data.canonicalPath })
+      ?? '/og-default.jpg',
+    label: theme.label,
+    color: theme.color,
+    pubDate: entry.data.pubDate,
+  };
+}
+
+export function buildHomepageArticleFeed(
+  entries: CollectionEntry<'articles'>[],
+  featuredCount = 3
+): HomepageArticleFeed {
+  const sortedArticles = entries
+    .slice()
+    .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf())
+    .map(mapHomepageArticle);
+
+  return {
+    featuredArticles: sortedArticles.slice(0, featuredCount),
+    moreArticles: sortedArticles.slice(featuredCount),
+    latestGuides: sortedArticles,
+  };
+}


### PR DESCRIPTION
## Summary
- build the homepage guide cards from the MDX articles collection
- sort homepage article cards by pubDate so new posts surface automatically
- keep a pinned travel-crates route and add tests for recency ordering

## Testing
- bun run test
- bun run build