### PR TITLE
Add dog-friendly airlines travel collector article

### DIFF
--- a/docs/system-definition.yaml
+++ b/docs/system-definition.yaml
@@ -194,6 +194,15 @@ site_system:
         - "/travel/how-to-fly-with-a-dog/"
       notes: "Informational air-travel guide; attributes facts to TSA, USDA APHIS, AVMA, DOT, CDC, and AAHA. No product roundup. Internal links to calming and comfort converters."
 
+    - name: "Best Dog-Friendly Airlines"
+      type: "collector"
+      collector_subtype: "article"
+      target_action: "Route dog-friendly flight service intent to travel, calming, and comfort converters/collectors"
+      metric: "collector_to_converter_click to travel, calming, and comfort pages"
+      routes:
+        - "/travel/dog-friendly-airlines/"
+      notes: "Article collector focused on dog-forward onboard flight options beyond standard under-seat commercial airline pet policies; routes to flying-with-dogs, carrier, travel bag, car anxiety, and road trip pages."
+
     - name: "How Much Do Dogs Sleep"
       type: "collector"
       collector_subtype: "article"

--- a/src/content/articles/travel-dog-friendly-airlines.mdx
+++ b/src/content/articles/travel-dog-friendly-airlines.mdx
@@ -33,11 +33,11 @@ export const tocHeadings = [
 export const dogFriendlyAirlineFaqs = [
   {
     question: 'What airline lets large dogs fly in the cabin?',
-    answer: 'For non-service dogs, the most relevant options are dog-forward or semi-private services rather than normal commercial airlines. JSX has recently allowed larger dogs up to about 79 pounds in the cabin with an additional seat arrangement. BARK Air, K9 JETS, RetrievAir, and private charters also focus on in-cabin pet travel, though routes, aircraft, pricing, and acceptance rules change often.',
+    answer: 'For non-service dogs, the most relevant options are dog-forward or semi-private services rather than normal commercial airlines. JSX has recently allowed larger dogs up to about 79 pounds in the cabin with an additional seat arrangement. BARK Air, K9 JETS, RetrievAir, and private charters also focus on in-cabin pet travel, though routes, aircraft, pricing, and acceptance rules differ.',
   },
   {
     question: 'Is BARK Air a real airline?',
-    answer: 'BARK Air is a real bookable dog-first travel service, but it operates more like a premium public charter and hospitality service than a normal commercial airline. Its own site frames the experience around no cargo holds or crates, concierge support, and dog-first flights, with listed routes and prices that vary by date.',
+    answer: 'BARK Air is a bookable dog-first travel service. It operates more like a premium public charter and hospitality service than a normal commercial airline. There are no cargo holds or crates. It offers concierge support and dog-first flights. Listed routes and prices vary by date.',
   },
   {
     question: 'Can my dog sit next to me on JSX?',
@@ -45,11 +45,11 @@ export const dogFriendlyAirlineFaqs = [
   },
   {
     question: 'Are K9 JETS flights private?',
-    answer: 'K9 JETS sells seats on shared private-jet-style pet flights, so the experience is private-charter-like but not the same as chartering the whole aircraft yourself. K9 JETS states that it is a public charter operator, not a scheduled airline or direct air carrier, and that flights are operated by licensed air carriers.',
+    answer: 'K9 JETS sells seats on shared private-jet-style pet flights. The experience is private-charter-like, but not the same as chartering an entire aircraft yourself. K9 JETS is a public charter operator, not a scheduled airline or direct air carrier. Flights are operated by licensed air carriers.',
   },
   {
-    question: 'Are normal airlines included in this list?',
-    answer: 'Not as the focus. Delta, Alaska, United, American, JetBlue, and similar carriers mostly use the standard small-dog-in-an-under-seat-carrier model. This guide is about the rarer options where dogs can stay meaningfully closer to their humans in the cabin, including larger-dog possibilities.',
+    question: 'How do these companies differ from traditional airlines?',
+    answer: 'Airlines like Delta, Alaska, United, American, JetBlue, and similar carriers generally allow small dogs to fly in a carrier stowed under the seat in front of you. These companies differ in that they allow dogs of most if not all sizes to fly in the cabin with you.',
   },
 ];
 
@@ -66,10 +66,10 @@ export const dogFriendlyAirlineFaqs = [
 
   <div class="prose">
     <p>
-      "Pet-friendly airline" usually means one thing: a small dog in a zippered carrier under the seat in front of you. That will work if your dog is small, but if you have a larger dog you may still be wondering: can my dog be onboard with me without being treated like cargo or carry-on luggage?
+      "Pet-friendly airline" usually means one thing: a small dog in a zippered carrier under the seat in front of you. That will work if your dog is small. But if you have a larger dog, you may still be wondering, can my dog be onboard with me without being treated like cargo or carry-on luggage?
     </p>
     <p>
-      This guide focuses on the burgeoning industry of dog-friendly air travel. These airlines provide an onboard experience that is more conducive to flying with a large dog.
+      This guide focuses on the burgeoning industry of dog-friendly air travel. These airlines provide an onboard experience that is more conducive to flying with a large dog. This convenience comes at a cost. Travel on these routes is expensive, prohibitively expensive for many if not most people. But if you have the financial means, these options provide the most comfortable flying experience for you and your pet.
     </p>
     <p>
       For carrier rules, TSA screening, cargo, paperwork, and anxiety prep, start with our <a href="/travel/how-to-fly-with-a-dog/" data-track="collector_to_converter_click" data-from-page="dog-friendly-airlines" data-to-page="/travel/how-to-fly-with-a-dog/" data-link-position="intro">full flying-with-dogs guide</a>.
@@ -88,16 +88,16 @@ export const dogFriendlyAirlineFaqs = [
 
     <h2 id="meaning">What "dog-friendly airline" actually means</h2>
     <p>
-      The useful distinction is not simply whether pets are allowed on the plane; it is how close your dog can actually stay to you.
+      The useful distinction is not simply whether pets are allowed on the plane; it is how close your dog can actually stay to you during the flight.
     </p>
     <p>
-      On normal commercial airlines, in-cabin pet travel is usually limited to a small dog or cat that fits under the seat in an airline-approved carrier. The dog stays in the carrier, and the carrier counts against your space. Larger pets generally cannot travel in the cabin unless they are trained service dogs.
+      On most commercial airlines, in-cabin pet travel is usually limited to a small dog or cat that fits under the seat in front of you in an airline-approved carrier. The dog stays in the carrier, and the carrier counts against your space. Larger pets generally cannot travel in the cabin unless they are trained service dogs.
     </p>
     <p>
-      These airlines are different. They are dog-first travel services, semi-private public charters, shared private flights, or full private charter arrangements. The trade-off is obvious: the closer your large dog stays to you, the more limited and expensive the options become.
+      These companies are different. They are dog-first travel services, semi-private public charters, shared private flights, or full private charter arrangements. The trade-off is obvious: the closer your large dog stays to you, the more limited and expensive the options become.
     </p>
     <p>
-      This list is weighted around cabin access, dog comfort, larger-dog possibility, route practicality, and cost. "Best" here means best fit for a particular travel problem, not a permanent ranking.
+      This list is weighted around cabin access, dog comfort, larger-dog possibility, route practicality, and cost. "Best" here means best fit for a particular travel need, not a permanent ranking.
     </p>
 
     <h2 id="bark-air">BARK Air: The closest thing to a real airline for dogs</h2>
@@ -108,10 +108,10 @@ export const dogFriendlyAirlineFaqs = [
       Current BARK Air booking pages list one ticket as covering one dog and one human. Recent regular scheduled service routes include New York to and from Los Angeles, London, Lisbon, Madrid, Paris, and San Francisco. Shared charter routes include more destinations.
     </p>
     <p>
-      The cost is luxury/private flight pricing. Recently listed BARK Air fares were about $7,075 for a one way ticket from New York-Los Angeles; about $7,450 for San Francisco-New York; about $9,900 for New York-London, and about $10,225 for New York-Paris. One ticket flies one dog and one human. Prices can change by route, date, aircraft, and whether a flight is scheduled or a shared charter.
+      The cost is luxury/private flight pricing. Recently listed BARK Air fares were about $7,000 -$11,000 for a one way ticket, depending on the route. One ticket flies one dog and one human. Prices can change by route, date, aircraft, and whether a flight is scheduled or a shared charter.
     </p>
     <p>
-      The appeal is the experience: no standard under-seat carriers, limited passenger count, a dog-focused traveling experience, and a calmer cabin than a major airline. The limitation is just as clear: BARK Air is expensive (prohibitively expensive for most people) and route-limited. But if your question is "what is the closest thing to a true dog airline?" this is probably it.
+      The appeal is the experience: no standard under-seat carriers, limited passenger count, a dog-focused traveling experience, and a calmer cabin than a major airline. The limitation is just as clear: BARK Air is expensive and route-limited. But if your question is "what is the closest thing to a true dog airline?" this is probably it.
     </p>
 
     <h2 id="jsx">JSX: The semi-private option that may work for larger dogs</h2>
@@ -131,7 +131,7 @@ export const dogFriendlyAirlineFaqs = [
       Because seat maps, aircraft, route rules, and pet capacity can change, call JSX or consult the Pet Policy page of their website before purchasing a ticket.
     </p>
     <p>
-      JSX is not the most luxurious option, but it may be the most practical. If your dog is too large for an under-seat carrier and your route lines up with JSX's network, this is one of the first options worth considering.
+      JSX is not the most luxurious option, but it may be the most practical option. If your dog is too large for an under-seat carrier and your route lines up with JSX's network, this is one of the first options worth considering.
     </p>
 
     <h2 id="k9-jets">K9 JETS: Shared private flights for dogs and their people</h2>
@@ -139,10 +139,10 @@ export const dogFriendlyAirlineFaqs = [
       <a href="https://www.k9jets.com/" rel="nofollow noopener" target="_blank">K9 JETS</a> is a shared private-jet option for people traveling with pets, especially across the Atlantic. Dogs fly in the cabin with their humans. K9 JETS emphasizes no queues, no cages, and no muzzles, with the option to buy a seat for a pet if needed.
     </p>
     <p>
-      The company is careful about its model: it states that it is a public charter operator, not a scheduled airline or direct air carrier, and that flights are operated by licensed U.S. and EU air carriers. That means you are not booking it like a daily airline route. You are booking a seat on a route-based shared charter schedule.
+      The company is careful about its model: it states that it is a public charter operator, not a scheduled airline or direct air carrier, and that flights are operated by licensed U.S. and EU air carriers. That means you are not booking it like a daily airline route; you are booking a seat on a route-based shared charter schedule.
     </p>
     <p>
-      Current K9 JETS route pages show flights such as Teterboro/New Jersey to London for $9000-$11,000, Toronto to London for about $10,000, London to Dubai for about $13,000, and London to Van Nuys/Los Angeles for about $14,000.
+      K9 JETS operates out of more than 15 cities domestically and internationally. One-way tickets are around $9,000 to more than $15,000, depending on the route.
     </p>
     <p>
       This is especially relevant for relocation, transatlantic moves, and owners who will not put a dog in cargo. The limitation is schedule and cost. K9 JETS is not a normal airline with daily route choice; it is a high-end shared charter calendar that you plan around.
@@ -150,7 +150,7 @@ export const dogFriendlyAirlineFaqs = [
 
     <h2 id="retrievair">RetrievAir: Public charter planes operating like semi-private flights for dogs of all sizes</h2>
     <p>
-      <a href="https://retrievair.com/" rel="nofollow noopener" target="_blank">RetrievAir</a> operates out of pet-friendly private terminals, ensuring a peaceful experience for you and your pet. They allow dogs to fly in the cabin with their humans, and they accommodate dogs of all sizes. On longer itineraries, they make regular stops at pet-friendly terminals to give your pet a chance to stretch their legs and take a break from flying.
+      <a href="https://retrievair.com/" rel="nofollow noopener" target="_blank">RetrievAir</a> operates out of pet-friendly private terminals, ensuring a peaceful experience for you and your pet. They allow dogs to fly in the cabin with their humans, and they accommodate dogs of all sizes. On longer itineraries, they make regular stops at pet-friendly terminals to give your pet a break from flying.
     </p>
     <p>
       RetrievAir flies pets and their families between major U.S. destinations. Each adult passenger may fly with one pet. Its current booking rules say pets up to 40 pounds may sit on your lap, pets from 41 to 74 pounds may use legroom space in some two-adult arrangements, and pets over 75 pounds require a separate seat.
@@ -189,7 +189,7 @@ export const dogFriendlyAirlineFaqs = [
           <tr>
             <th scope="col">Option</th>
             <th scope="col">Best for</th>
-            <th scope="col">Big dogs?</th>
+            <th scope="col">Big dogs allowed?</th>
             <th scope="col">Typical route type</th>
             <th scope="col">Typical cost level</th>
             <th scope="col">Main limitation</th>
@@ -209,7 +209,7 @@ export const dogFriendlyAirlineFaqs = [
             <td>Smoother U.S. semi-private experience</td>
             <td>Sometimes, with extra-seat arrangement</td>
             <td>U.S. regional routes plus select Mexico service</td>
-            <td>Often far below full charter, but more than basic economy</td>
+            <td>Often below full charter, but more than economy or business class</td>
             <td>Large-dog rules and seats must be confirmed</td>
           </tr>
           <tr>
@@ -217,12 +217,12 @@ export const dogFriendlyAirlineFaqs = [
             <td>Relocation and transatlantic pet travel</td>
             <td>Yes, subject to seat and operator rules</td>
             <td>Route-based shared private charter schedule</td>
-            <td>High-end charter, often many thousands one way</td>
+            <td>High-end charter, often several thousand dollars one way</td>
             <td>Limited schedules and city pairs</td>
           </tr>
           <tr>
             <td>RetrievAir</td>
-            <td>U.S. in-cabin travel for dogs of many sizes</td>
+            <td>U.S. in-cabin travel for dogs of all sizes</td>
             <td>Yes, current rules include 75+ pound pets with separate seat</td>
             <td>Growing U.S. city network</td>
             <td>Varies by route and seat needs; verify before booking</td>
@@ -242,11 +242,11 @@ export const dogFriendlyAirlineFaqs = [
 
     <h2 id="before-booking">What to check before booking</h2>
     <p>
-      Because these services change routes, aircraft, and policies often, confirm the service-specific details before you build the rest of the trip.
+      These services differ in terms of routes, aircraft, and policies. Confirm the service-specific details before you book your trip.
     </p>
     <ul>
-      <li>Will your dog be in a carrier, on the floor, in legroom space, in a secured seat, or beside you?</li>
-      <li>Is an extra seat required for your dog's size or weight?</li>
+      <li>Will your dog be in a carrier, on the floor, in legroom space, or in a secured seat beside you?</li>
+      <li>Is an extra seat required for your dog's size and weight?</li>
       <li>Are there weight limits, breed limits, behavior requirements, or temperament screening steps?</li>
       <li>How many pets are allowed per flight, per adult, and per row?</li>
       <li>Which routes are actually operating on your travel dates?</li>
@@ -254,7 +254,7 @@ export const dogFriendlyAirlineFaqs = [
       <li>What happens if the flight is delayed, rerouted, underbooked, or moved to a different aircraft?</li>
     </ul>
     <p>
-      If you are still comparing whether flying is worth it at all, our <a href="/travel/dog-road-trip-gear/" data-track="collector_to_converter_click" data-from-page="dog-friendly-airlines" data-to-page="/travel/dog-road-trip-gear/" data-link-position="section">dog road trip gear guide</a> is the calmer fallback. Some dogs are better served by a long drive than a forced flight.
+      If you are still comparing whether flying is worth it at all, and you are considering driving, check out our <a href="/travel/dog-road-trip-gear/" data-track="collector_to_converter_click" data-from-page="dog-friendly-airlines" data-to-page="/travel/dog-road-trip-gear/" data-link-position="section">dog road trip gear guide</a>. Some dogs are better served by a long drive than a flight.
     </p>
   </div>
 

--- a/src/content/articles/travel-dog-friendly-airlines.mdx
+++ b/src/content/articles/travel-dog-friendly-airlines.mdx
@@ -1,0 +1,252 @@
+---
+title: 'Best Dog-Friendly Airlines Where Your Dog Can Fly With You'
+description: 'Most airlines only allow small dogs under the seat, but these dog-forward airlines, semi-private carriers, and charters keep dogs closer in the cabin.'
+ogTitle: 'Best Dog-Friendly Airlines Where Dogs Fly With You'
+pubDate: 2026-05-01
+canonicalPath: '/travel/dog-friendly-airlines/'
+---
+
+import Toc from '@components/modules/Toc.astro';
+import FAQ from '@components/modules/FAQ.astro';
+import Disclosure from '@components/modules/Disclosure.astro';
+import InternalLinkStrip from '@components/modules/InternalLinkStrip.astro';
+
+export const tocHeadings = [
+  { label: 'What dog-friendly airline means', anchor: 'meaning' },
+  { label: 'BARK Air', anchor: 'bark-air' },
+  { label: 'JSX', anchor: 'jsx' },
+  { label: 'K9 JETS', anchor: 'k9-jets' },
+  { label: 'RetrievAir', anchor: 'retrievair' },
+  { label: 'Private charters', anchor: 'private-charters' },
+  { label: 'Quick comparison', anchor: 'comparison' },
+  { label: 'Before booking', anchor: 'before-booking' },
+];
+
+export const dogFriendlyAirlineFaqs = [
+  {
+    question: 'What airline lets large dogs fly in the cabin?',
+    answer: 'For non-service dogs, the most relevant options are dog-forward or semi-private services rather than normal commercial airlines. JSX has recently allowed larger dogs up to about 79 pounds in the cabin with an additional seat arrangement. BARK Air, K9 JETS, RetrievAir, and private charters also focus on in-cabin pet travel, though routes, aircraft, pricing, and acceptance rules change often.',
+  },
+  {
+    question: 'Is BARK Air a real airline?',
+    answer: 'BARK Air is a real bookable dog-first travel service, but it operates more like a premium public charter and hospitality service than a normal commercial airline. Its own site frames the experience around no cargo holds or crates, concierge support, and dog-first flights, with listed routes and prices that vary by date.',
+  },
+  {
+    question: 'Can my dog sit next to me on JSX?',
+    answer: 'JSX is one of the more practical U.S. upgrades for in-cabin dog travel, but your dog does not simply get to sit freely in a passenger seat. Small dogs and cats generally travel in an approved carrier. Larger dogs may require an additional seat arrangement and must stay leashed on the floor space, subject to JSX approval and current rules.',
+  },
+  {
+    question: 'Are K9 JETS flights private?',
+    answer: 'K9 JETS sells seats on shared private-jet-style pet flights, so the experience is private-charter-like but not the same as chartering the whole aircraft yourself. K9 JETS states that it is a public charter operator, not a scheduled airline or direct air carrier, and that flights are operated by licensed air carriers.',
+  },
+  {
+    question: 'Are normal airlines included in this list?',
+    answer: 'Not as the focus. Delta, Alaska, United, American, JetBlue, and similar carriers mostly use the standard small-dog-in-an-under-seat-carrier model. This guide is about the rarer options where dogs can stay meaningfully closer to their humans in the cabin, including larger-dog possibilities.',
+  },
+];
+
+export const relatedLinks = [
+  { label: 'How to Fly With a Dog', href: '/travel/how-to-fly-with-a-dog/' },
+  { label: 'Best Airline-Approved Dog Carriers', href: '/comforting/best-airline-approved-dog-carriers/' },
+  { label: 'Best Dog Travel Bags for Flying', href: '/comforting/best-dog-travel-bags-for-flying/' },
+  { label: 'Calming Help for Travel Anxiety', href: '/calming/car-anxiety-for-dogs/' },
+  { label: 'Dog Road Trip Gear', href: '/travel/dog-road-trip-gear/' },
+];
+
+<article class="collector-article container">
+  <header class="article-header">
+    <span class="eyebrow">Dog Travel</span>
+    <h1>Best Dog-Friendly Airlines Where Your Dog Can Fly With You</h1>
+    <p class="lede">
+      Most airlines only allow small dogs under the seat, but a small group of dog-forward airlines, semi-private carriers, and charter services let dogs stay much closer to their humans in the cabin.
+    </p>
+  </header>
+
+  <Toc headings={tocHeadings} pageSlug="dog-friendly-airlines" />
+
+  <div class="prose">
+    <p>
+      "Pet-friendly airline" usually means one thing: a small dog in a zippered carrier under the seat in front of you. That is useful for some dogs, but it does not answer the harder question many owners are actually asking: can my dog be onboard with me without being treated like carry-on luggage?
+    </p>
+    <p>
+      This guide focuses on the rarer options where the onboard experience is more dog-friendly, including larger-dog possibilities. It is not a general flying-with-dogs checklist. For carrier rules, TSA screening, cargo, paperwork, and anxiety prep, start with our <a href="/travel/how-to-fly-with-a-dog/" data-track="collector_to_converter_click" data-from-page="dog-friendly-airlines" data-to-page="/travel/how-to-fly-with-a-dog/" data-link-position="intro">full flying-with-dogs guide</a>.
+    </p>
+
+    <div class="callout">
+      <p class="callout-heading">Quick picks</p>
+      <ul class="summary-list">
+        <li><strong>Best luxury dog-first option:</strong> BARK Air</li>
+        <li><strong>Best semi-private U.S. option:</strong> JSX</li>
+        <li><strong>Best transatlantic/shared charter option:</strong> K9 JETS</li>
+        <li><strong>Best flexible private option:</strong> evoJets and similar private charter brokers</li>
+        <li><strong>Best one to verify/watch:</strong> RetrievAir, now showing active U.S. route and booking information</li>
+      </ul>
+    </div>
+
+    <h2 id="meaning">What "dog-friendly airline" actually means</h2>
+    <p>
+      The useful distinction is not simply whether pets are allowed. It is how close your dog can actually stay to you.
+    </p>
+    <p>
+      On normal commercial airlines, in-cabin pet travel is usually limited to a small dog or cat that fits inside an airline-approved carrier under the seat. The dog stays in the carrier, the carrier counts against your space, and larger pets generally cannot travel in the cabin unless they are trained service dogs.
+    </p>
+    <p>
+      The options below sit in a different category. They are dog-first travel services, semi-private public charters, shared private flights, or full private charter arrangements. The trade-off is obvious: the closer your dog stays to you, the more limited and expensive the options become.
+    </p>
+    <p>
+      I weighted the list around cabin access, dog comfort, larger-dog possibility, route practicality, and cost. "Best" here means best fit for a particular travel problem, not a permanent ranking.
+    </p>
+
+    <h2 id="bark-air">BARK Air: the closest thing to a real airline for dogs</h2>
+    <p>
+      <a href="https://air.bark.co/" rel="nofollow noopener" target="_blank">BARK Air</a> is the most literal answer to this search. It is designed around dogs first, not around humans asking a conventional airline to tolerate pets. BARK Air describes its flight experience as having spacious cabins, no crates, and no cargo, with the broader service wrapped in concierge, charter, and relocation support.
+    </p>
+    <p>
+      Current BARK Air booking pages list one ticket as covering one dog and one human, and recently listed routes included New York to and from Los Angeles, London, Lisbon, Madrid, Paris, and San Francisco. The route filters also showed routes involving places such as Kailua-Kona, Ota City, Dublin, and Seattle. Treat that as a current menu to verify, not a permanent network.
+    </p>
+    <p>
+      Pricing is luxury/private-style pricing. Recently listed BARK Air fares included about $7,075 one way for New York-Los Angeles, about $7,450 for San Francisco-New York, about $9,850 to $9,900 for New York-London, and about $10,225 for New York-Paris, generally listed per dog-and-human ticket. Those prices can change by route, date, aircraft, and whether a flight is scheduled or shared-charter-style.
+    </p>
+    <p>
+      The appeal is the experience: no standard under-seat carrier model, limited passenger count, dog-focused boarding, treats and comfort touches, and a calmer cabin than a major airport itinerary. The limitation is just as clear. BARK Air is expensive and route-limited, but if your question is "what is the closest thing to a true dog airline?" this is probably it.
+    </p>
+
+    <h2 id="jsx">JSX: the semi-private option that may work for larger dogs</h2>
+    <p>
+      <a href="https://www.jsx.com/petpolicy" rel="nofollow noopener" target="_blank">JSX</a> is not a dog airline, which is exactly why it matters. For many U.S. travelers, it is the most realistic upgrade from a crowded commercial terminal without jumping all the way to BARK Air or a private charter.
+    </p>
+    <p>
+      JSX operates a semi-private public-charter-style model using smaller aircraft and private or dedicated terminals. The practical difference is the airport experience: shorter arrival windows, smaller passenger counts, and less of the giant-terminal chaos that can set anxious dogs off before the flight even starts. JSX's current route page lists U.S. destinations across California, Nevada, Texas, Arizona, Colorado, Florida, New York-area airports, and more, plus Cabo San Lucas.
+    </p>
+    <p>
+      The pet policy is the part to verify before booking. JSX's official site links to a dedicated pet policy and Pet Acceptance Form, but the page content is not always easy to extract from the public site. Recent travel-policy summaries and JSX-linked booking resources describe the current model this way: small dogs and cats generally travel in a carrier, while larger dogs may fly in the cabin by purchasing the required adjacent seat arrangement. The commonly reported larger-dog ceiling is around 79 pounds, with the dog leashed and kept on the floor space rather than on the seat.
+    </p>
+    <p>
+      Recently reported JSX details include a carrier size around 13 by 11 by 17 inches for small pets, a $100 fee each way or per segment for small in-carrier pets, and a cap of about five pets per flight. Because seat maps, aircraft, route rules, and pet capacity can change, call JSX or use its official pet form before buying around a large dog.
+    </p>
+    <p>
+      In plain terms: JSX is not the most dog-luxury option, but it may be the practical standout. If your dog is too large for an under-seat carrier and your route lines up with JSX's network, this is one of the first options worth checking.
+    </p>
+
+    <h2 id="k9-jets">K9 JETS: shared private flights for dogs and their people</h2>
+    <p>
+      <a href="https://www.k9jets.com/" rel="nofollow noopener" target="_blank">K9 JETS</a> is a shared private-jet-style option for people traveling with pets, especially across the Atlantic. Dogs fly in the cabin with their humans, and K9 JETS emphasizes no queues, no cages, and no muzzles, with the option to buy a seat for a pet if needed.
+    </p>
+    <p>
+      The company is careful about its model: it states that it is a public charter operator, not a scheduled airline or direct air carrier, and that flights are operated by licensed U.S. and EU air carriers. That means you are not booking it like a daily airline route. You are booking a seat on a route-based shared charter schedule.
+    </p>
+    <p>
+      Current K9 JETS route pages showed flights such as Teterboro/New Jersey to London, Toronto to London, London to Dubai, London to Toronto, routes between Europe and Van Nuys/Los Angeles, and higher-priced routes involving Dubai. Recently listed one-way fares commonly sat in the many-thousands range: examples included roughly $9,845 to $10,850 for New Jersey-London dates, $9,950 for Toronto-London, about $12,975 for London-Dubai, and $13,850 or more for some London-Los Angeles/Van Nuys routes.
+    </p>
+    <p>
+      This is especially relevant for relocation, transatlantic moves, and owners who will not put a dog in cargo. The limitation is schedule and cost. K9 JETS is not a normal airline with daily route choice; it is a high-end shared charter calendar that you plan around.
+    </p>
+
+    <h2 id="retrievair">RetrievAir: promising, but verify availability before planning around it</h2>
+    <p>
+      <a href="https://retrievair.com/" rel="nofollow noopener" target="_blank">RetrievAir</a> now appears active enough to include, with current pages showing booking widgets, city pages, flight rules, and customer service contact details. The name is a dog-themed play on "retriever," and the service is aimed squarely at the pain point this article is about: in-cabin travel for larger dogs, not just small pets under the seat.
+    </p>
+    <p>
+      RetrievAir says it flies pets and their families between major U.S. destinations and that dogs and cats of any size can travel together in the aircraft cabin. Its current booking rules say one adult equals one pet or one infant, pets up to 40 pounds may sit on your lap, pets from 41 to 74 pounds may use legroom space in some two-adult arrangements, and pets over 75 pounds require a separate seat.
+    </p>
+    <p>
+      The service also says flights operate out of pet-friendly private terminals, with a 45-minute arrival window, complimentary treats and fresh water for pets, and regular stops at pet-friendly terminals on longer itineraries. Current destination pages listed Los Angeles, New York City, Chicago, Scottsdale, Washington DC, Seattle, San Francisco, Atlanta, Dallas-Fort Worth, Denver, and Fort Lauderdale, though some were marked as new in 2026.
+    </p>
+    <p>
+      Details are still more fluid than with a mature airline network. RetrievAir states that it is not a direct air carrier and that flights are operated by RVR Aviation, a licensed U.S. air carrier. I would treat it as a promising, active service to verify directly before planning a trip around a specific date, city pair, or large-dog seating setup.
+    </p>
+
+    <h2 id="private-charters">Private charters: the flexible but expensive fallback</h2>
+    <p>
+      Private charter is not an airline category. It is the option you consider when route, dog size, number of pets, timing, or cargo avoidance matters more than price.
+    </p>
+    <p>
+      <a href="https://www.evojets.com/pets-on-private-jets/" rel="nofollow noopener" target="_blank">evoJets</a> is a useful example of the category, not a dog airline. Its pet page says pets can fly in the passenger area, dogs and cats can be loose in the cabin, there are no dog size restrictions, and larger dogs may call for a larger aircraft for comfort. evoJets also notes that it is an indirect air carrier and does not own or operate aircraft.
+    </p>
+    <p>
+      That operator-approval caveat matters. A broker can source pet-friendly aircraft and operators, but the final experience depends on aircraft size, cabin layout, route, timing, repositioning costs, and operator rules. Pricing varies too heavily to summarize honestly in one number.
+    </p>
+    <p>
+      Private charter makes the most sense for multiple pets, very large dogs, unusual routes, urgent relocation, or owners who want to avoid cargo completely and have the budget to solve the trip privately.
+    </p>
+
+    <h2 id="comparison">Quick comparison: which dog-friendly flight option fits your situation?</h2>
+    <div class="decision-table-wrap">
+      <table class="decision-table">
+        <thead>
+          <tr>
+            <th scope="col">Option</th>
+            <th scope="col">Best for</th>
+            <th scope="col">Big dogs?</th>
+            <th scope="col">Typical route type</th>
+            <th scope="col">Typical cost level</th>
+            <th scope="col">Main limitation</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>BARK Air</td>
+            <td>Dog-first luxury travel</td>
+            <td>Yes, subject to booking rules</td>
+            <td>Limited U.S. and international city pairs</td>
+            <td>Luxury/private-style, often several thousand dollars one way</td>
+            <td>Price and route availability</td>
+          </tr>
+          <tr>
+            <td>JSX</td>
+            <td>Smoother U.S. semi-private experience</td>
+            <td>Sometimes, with extra-seat arrangement</td>
+            <td>U.S. regional routes plus select Mexico service</td>
+            <td>Often far below full charter, but more than basic economy</td>
+            <td>Large-dog rules and seats must be confirmed</td>
+          </tr>
+          <tr>
+            <td>K9 JETS</td>
+            <td>Relocation and transatlantic pet travel</td>
+            <td>Yes, subject to seat and operator rules</td>
+            <td>Route-based shared private charter schedule</td>
+            <td>High-end charter, often many thousands one way</td>
+            <td>Limited schedules and city pairs</td>
+          </tr>
+          <tr>
+            <td>RetrievAir</td>
+            <td>U.S. in-cabin travel for dogs of many sizes</td>
+            <td>Yes, current rules include 75+ pound pets with separate seat</td>
+            <td>Growing U.S. city network</td>
+            <td>Varies by route and seat needs; verify before booking</td>
+            <td>Newer service with changing availability</td>
+          </tr>
+          <tr>
+            <td>evoJets/private charter</td>
+            <td>Maximum flexibility</td>
+            <td>Usually, subject to aircraft/operator approval</td>
+            <td>Custom route</td>
+            <td>Usually the most expensive option</td>
+            <td>Cost, aircraft availability, operator approval</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <h2 id="before-booking">What to check before booking</h2>
+    <p>
+      Because these services change routes, aircraft, and policies often, confirm the service-specific details before you build the rest of the trip.
+    </p>
+    <ul>
+      <li>Will your dog be in a carrier, on the floor, in legroom space, in a secured seat, or beside you?</li>
+      <li>Is an extra seat required for your dog's size or weight?</li>
+      <li>Are there weight limits, breed limits, behavior requirements, or temperament screening steps?</li>
+      <li>How many pets are allowed per flight, per adult, and per row?</li>
+      <li>Which routes are actually operating on your travel dates?</li>
+      <li>What documents are required for your destination and return trip?</li>
+      <li>What happens if the flight is delayed, rerouted, underbooked, or moved to a different aircraft?</li>
+    </ul>
+    <p>
+      If you are still comparing whether flying is worth it at all, our <a href="/travel/dog-road-trip-gear/" data-track="collector_to_converter_click" data-from-page="dog-friendly-airlines" data-to-page="/travel/dog-road-trip-gear/" data-link-position="section">dog road trip gear guide</a> is the calmer fallback. Some dogs are better served by a long drive than a forced flight.
+    </p>
+  </div>
+
+  <FAQ faqs={dogFriendlyAirlineFaqs} />
+  <Disclosure />
+  <InternalLinkStrip heading="More Dog Travel Guides" links={relatedLinks} fromPage="dog-friendly-airlines" />
+</article>

--- a/src/content/articles/travel-dog-friendly-airlines.mdx
+++ b/src/content/articles/travel-dog-friendly-airlines.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Best Dog-Friendly Airlines Where Your Dog Can Fly With You'
-description: 'Most airlines only allow small dogs under the seat, but these dog-forward airlines, semi-private carriers, and charters keep dogs closer in the cabin.'
+title: 'Best Dog-Friendly Airlines Where Your Dog Can Fly With You In the Cabin'
+description: 'Most airlines only allow small dogs in under-seat carriers, but dog-forward, semi-private, and charter options can let dogs fly in the cabin with their humans.'
 ogTitle: 'Best Dog-Friendly Airlines Where Dogs Fly With You'
 pubDate: 2026-05-01
 canonicalPath: '/travel/dog-friendly-airlines/'
@@ -27,7 +27,7 @@ export const tocHeadings = [
   { label: 'RetrievAir', anchor: 'retrievair' },
   { label: 'Private charters', anchor: 'private-charters' },
   { label: 'Quick comparison', anchor: 'comparison' },
-  { label: 'Before booking', anchor: 'before-booking' },
+  { label: 'What to Check Before Booking', anchor: 'before-booking' },
 ];
 
 export const dogFriendlyAirlineFaqs = [
@@ -56,9 +56,9 @@ export const dogFriendlyAirlineFaqs = [
 <article class="collector-article container">
   <header class="article-header">
     <span class="eyebrow">Dog Travel</span>
-    <h1>Best Dog-Friendly Airlines Where Your Dog Can Fly With You</h1>
+    <h1>Best Dog-Friendly Airlines Where Your Dog Can Fly With You In the Cabin</h1>
     <p class="lede">
-      Most airlines only allow small dogs under the seat, but a small group of dog-forward airlines, semi-private carriers, and charter services let dogs stay much closer to their humans in the cabin.
+      Most airlines only allow small dogs kept in carriers under the seat, but a small group of dog-forward airlines, semi-private carriers, and charter services allow dogs to fly in the cabin with their humans.
     </p>
   </header>
 
@@ -66,10 +66,13 @@ export const dogFriendlyAirlineFaqs = [
 
   <div class="prose">
     <p>
-      "Pet-friendly airline" usually means one thing: a small dog in a zippered carrier under the seat in front of you. That is useful for some dogs, but it does not answer the harder question many owners are actually asking: can my dog be onboard with me without being treated like carry-on luggage?
+      "Pet-friendly airline" usually means one thing: a small dog in a zippered carrier under the seat in front of you. That will work if your dog is small, but if you have a larger dog you may still be wondering: can my dog be onboard with me without being treated like cargo or carry-on luggage?
     </p>
     <p>
-      This guide focuses on the rarer options where the onboard experience is more dog-friendly, including larger-dog possibilities. It is not a general flying-with-dogs checklist. For carrier rules, TSA screening, cargo, paperwork, and anxiety prep, start with our <a href="/travel/how-to-fly-with-a-dog/" data-track="collector_to_converter_click" data-from-page="dog-friendly-airlines" data-to-page="/travel/how-to-fly-with-a-dog/" data-link-position="intro">full flying-with-dogs guide</a>.
+      This guide focuses on the burgeoning industry of dog-friendly air travel. These airlines provide an onboard experience that is more conducive to flying with a large dog.
+    </p>
+    <p>
+      For carrier rules, TSA screening, cargo, paperwork, and anxiety prep, start with our <a href="/travel/how-to-fly-with-a-dog/" data-track="collector_to_converter_click" data-from-page="dog-friendly-airlines" data-to-page="/travel/how-to-fly-with-a-dog/" data-link-position="intro">full flying-with-dogs guide</a>.
     </p>
 
     <div class="callout">
@@ -85,89 +88,98 @@ export const dogFriendlyAirlineFaqs = [
 
     <h2 id="meaning">What "dog-friendly airline" actually means</h2>
     <p>
-      The useful distinction is not simply whether pets are allowed. It is how close your dog can actually stay to you.
+      The useful distinction is not simply whether pets are allowed on the plane; it is how close your dog can actually stay to you.
     </p>
     <p>
-      On normal commercial airlines, in-cabin pet travel is usually limited to a small dog or cat that fits inside an airline-approved carrier under the seat. The dog stays in the carrier, the carrier counts against your space, and larger pets generally cannot travel in the cabin unless they are trained service dogs.
+      On normal commercial airlines, in-cabin pet travel is usually limited to a small dog or cat that fits under the seat in an airline-approved carrier. The dog stays in the carrier, and the carrier counts against your space. Larger pets generally cannot travel in the cabin unless they are trained service dogs.
     </p>
     <p>
-      The options below sit in a different category. They are dog-first travel services, semi-private public charters, shared private flights, or full private charter arrangements. The trade-off is obvious: the closer your dog stays to you, the more limited and expensive the options become.
+      These airlines are different. They are dog-first travel services, semi-private public charters, shared private flights, or full private charter arrangements. The trade-off is obvious: the closer your large dog stays to you, the more limited and expensive the options become.
     </p>
     <p>
-      I weighted the list around cabin access, dog comfort, larger-dog possibility, route practicality, and cost. "Best" here means best fit for a particular travel problem, not a permanent ranking.
-    </p>
-
-    <h2 id="bark-air">BARK Air: the closest thing to a real airline for dogs</h2>
-    <p>
-      <a href="https://air.bark.co/" rel="nofollow noopener" target="_blank">BARK Air</a> is the most literal answer to this search. It is designed around dogs first, not around humans asking a conventional airline to tolerate pets. BARK Air describes its flight experience as having spacious cabins, no crates, and no cargo, with the broader service wrapped in concierge, charter, and relocation support.
-    </p>
-    <p>
-      Current BARK Air booking pages list one ticket as covering one dog and one human, and recently listed routes included New York to and from Los Angeles, London, Lisbon, Madrid, Paris, and San Francisco. The route filters also showed routes involving places such as Kailua-Kona, Ota City, Dublin, and Seattle. Treat that as a current menu to verify, not a permanent network.
-    </p>
-    <p>
-      Pricing is luxury/private-style pricing. Recently listed BARK Air fares included about $7,075 one way for New York-Los Angeles, about $7,450 for San Francisco-New York, about $9,850 to $9,900 for New York-London, and about $10,225 for New York-Paris, generally listed per dog-and-human ticket. Those prices can change by route, date, aircraft, and whether a flight is scheduled or shared-charter-style.
-    </p>
-    <p>
-      The appeal is the experience: no standard under-seat carrier model, limited passenger count, dog-focused boarding, treats and comfort touches, and a calmer cabin than a major airport itinerary. The limitation is just as clear. BARK Air is expensive and route-limited, but if your question is "what is the closest thing to a true dog airline?" this is probably it.
+      This list is weighted around cabin access, dog comfort, larger-dog possibility, route practicality, and cost. "Best" here means best fit for a particular travel problem, not a permanent ranking.
     </p>
 
-    <h2 id="jsx">JSX: the semi-private option that may work for larger dogs</h2>
+    <h2 id="bark-air">BARK Air: The closest thing to a real airline for dogs</h2>
     <p>
-      <a href="https://www.jsx.com/petpolicy" rel="nofollow noopener" target="_blank">JSX</a> is not a dog airline, which is exactly why it matters. For many U.S. travelers, it is the most realistic upgrade from a crowded commercial terminal without jumping all the way to BARK Air or a private charter.
+      <a href="https://air.bark.co/" rel="nofollow noopener" target="_blank">BARK Air</a> is designed around dogs first, not around humans asking a conventional airline to tolerate pets. BARK Air describes its flight experience as built entirely around your dog's comfort in the air and on the ground. It has spacious cabins, no crates, and no cargo. They provide concierge service, charter flights, and relocation support.
     </p>
     <p>
-      JSX operates a semi-private public-charter-style model using smaller aircraft and private or dedicated terminals. The practical difference is the airport experience: shorter arrival windows, smaller passenger counts, and less of the giant-terminal chaos that can set anxious dogs off before the flight even starts. JSX's current route page lists U.S. destinations across California, Nevada, Texas, Arizona, Colorado, Florida, New York-area airports, and more, plus Cabo San Lucas.
+      Current BARK Air booking pages list one ticket as covering one dog and one human. Recent regular scheduled service routes include New York to and from Los Angeles, London, Lisbon, Madrid, Paris, and San Francisco. Shared charter routes include more destinations.
     </p>
     <p>
-      The pet policy is the part to verify before booking. JSX's official site links to a dedicated pet policy and Pet Acceptance Form, but the page content is not always easy to extract from the public site. Recent travel-policy summaries and JSX-linked booking resources describe the current model this way: small dogs and cats generally travel in a carrier, while larger dogs may fly in the cabin by purchasing the required adjacent seat arrangement. The commonly reported larger-dog ceiling is around 79 pounds, with the dog leashed and kept on the floor space rather than on the seat.
+      The cost is luxury/private flight pricing. Recently listed BARK Air fares were about $7,075 for a one way ticket from New York-Los Angeles; about $7,450 for San Francisco-New York; about $9,900 for New York-London, and about $10,225 for New York-Paris. One ticket flies one dog and one human. Prices can change by route, date, aircraft, and whether a flight is scheduled or a shared charter.
     </p>
     <p>
-      Recently reported JSX details include a carrier size around 13 by 11 by 17 inches for small pets, a $100 fee each way or per segment for small in-carrier pets, and a cap of about five pets per flight. Because seat maps, aircraft, route rules, and pet capacity can change, call JSX or use its official pet form before buying around a large dog.
-    </p>
-    <p>
-      In plain terms: JSX is not the most dog-luxury option, but it may be the practical standout. If your dog is too large for an under-seat carrier and your route lines up with JSX's network, this is one of the first options worth checking.
+      The appeal is the experience: no standard under-seat carriers, limited passenger count, a dog-focused traveling experience, and a calmer cabin than a major airline. The limitation is just as clear: BARK Air is expensive (prohibitively expensive for most people) and route-limited. But if your question is "what is the closest thing to a true dog airline?" this is probably it.
     </p>
 
-    <h2 id="k9-jets">K9 JETS: shared private flights for dogs and their people</h2>
+    <h2 id="jsx">JSX: The semi-private option that may work for larger dogs</h2>
     <p>
-      <a href="https://www.k9jets.com/" rel="nofollow noopener" target="_blank">K9 JETS</a> is a shared private-jet-style option for people traveling with pets, especially across the Atlantic. Dogs fly in the cabin with their humans, and K9 JETS emphasizes no queues, no cages, and no muzzles, with the option to buy a seat for a pet if needed.
+      <a href="https://www.jsx.com/petpolicy" rel="nofollow noopener" target="_blank">JSX</a> is not a dog airline. For many U.S. travelers, it is the most realistic upgrade from a crowded commercial terminal without paying for BARK Air or a private charter.
+    </p>
+    <p>
+      JSX operates a semi-private public-charter model using smaller aircraft and private or dedicated terminals. The difference is the airport experience: shorter arrival windows, fewer passengers, and less of the big-terminal activity that can make dogs anxious before the flight even starts. JSX's current route page lists destinations across California, Nevada, Texas, Arizona, Colorado, Florida, New York and Cabo San Lucas.
+    </p>
+    <p>
+      Verify the pet policy before booking at <a href="https://www.jsx.com/petpolicy" rel="nofollow noopener" target="_blank">https://www.jsx.com/petpolicy</a>.
+    </p>
+    <p>
+      Emotional support animals may not fly as service animals, but may be permitted to fly as pets. There is a limit of 5 pets (non service animals) allowed in the cabin per flight. Small dogs generally travel in a carrier. Larger dogs may fly in the cabin by purchasing the required adjacent seat arrangement for a fee of $100. Dogs must be under 80 pounds and kept leashed on the floor, rather than on the seat.
+    </p>
+    <p>
+      Because seat maps, aircraft, route rules, and pet capacity can change, call JSX or consult the Pet Policy page of their website before purchasing a ticket.
+    </p>
+    <p>
+      JSX is not the most luxurious option, but it may be the most practical. If your dog is too large for an under-seat carrier and your route lines up with JSX's network, this is one of the first options worth considering.
+    </p>
+
+    <h2 id="k9-jets">K9 JETS: Shared private flights for dogs and their people</h2>
+    <p>
+      <a href="https://www.k9jets.com/" rel="nofollow noopener" target="_blank">K9 JETS</a> is a shared private-jet option for people traveling with pets, especially across the Atlantic. Dogs fly in the cabin with their humans. K9 JETS emphasizes no queues, no cages, and no muzzles, with the option to buy a seat for a pet if needed.
     </p>
     <p>
       The company is careful about its model: it states that it is a public charter operator, not a scheduled airline or direct air carrier, and that flights are operated by licensed U.S. and EU air carriers. That means you are not booking it like a daily airline route. You are booking a seat on a route-based shared charter schedule.
     </p>
     <p>
-      Current K9 JETS route pages showed flights such as Teterboro/New Jersey to London, Toronto to London, London to Dubai, London to Toronto, routes between Europe and Van Nuys/Los Angeles, and higher-priced routes involving Dubai. Recently listed one-way fares commonly sat in the many-thousands range: examples included roughly $9,845 to $10,850 for New Jersey-London dates, $9,950 for Toronto-London, about $12,975 for London-Dubai, and $13,850 or more for some London-Los Angeles/Van Nuys routes.
+      Current K9 JETS route pages show flights such as Teterboro/New Jersey to London for $9000-$11,000, Toronto to London for about $10,000, London to Dubai for about $13,000, and London to Van Nuys/Los Angeles for about $14,000.
     </p>
     <p>
       This is especially relevant for relocation, transatlantic moves, and owners who will not put a dog in cargo. The limitation is schedule and cost. K9 JETS is not a normal airline with daily route choice; it is a high-end shared charter calendar that you plan around.
     </p>
 
-    <h2 id="retrievair">RetrievAir: promising, but verify availability before planning around it</h2>
+    <h2 id="retrievair">RetrievAir: Public charter planes operating like semi-private flights for dogs of all sizes</h2>
     <p>
-      <a href="https://retrievair.com/" rel="nofollow noopener" target="_blank">RetrievAir</a> now appears active enough to include, with current pages showing booking widgets, city pages, flight rules, and customer service contact details. The name is a dog-themed play on "retriever," and the service is aimed squarely at the pain point this article is about: in-cabin travel for larger dogs, not just small pets under the seat.
+      <a href="https://retrievair.com/" rel="nofollow noopener" target="_blank">RetrievAir</a> operates out of pet-friendly private terminals, ensuring a peaceful experience for you and your pet. They allow dogs to fly in the cabin with their humans, and they accommodate dogs of all sizes. On longer itineraries, they make regular stops at pet-friendly terminals to give your pet a chance to stretch their legs and take a break from flying.
     </p>
     <p>
-      RetrievAir says it flies pets and their families between major U.S. destinations and that dogs and cats of any size can travel together in the aircraft cabin. Its current booking rules say one adult equals one pet or one infant, pets up to 40 pounds may sit on your lap, pets from 41 to 74 pounds may use legroom space in some two-adult arrangements, and pets over 75 pounds require a separate seat.
+      RetrievAir flies pets and their families between major U.S. destinations. Each adult passenger may fly with one pet. Its current booking rules say pets up to 40 pounds may sit on your lap, pets from 41 to 74 pounds may use legroom space in some two-adult arrangements, and pets over 75 pounds require a separate seat.
     </p>
     <p>
-      The service also says flights operate out of pet-friendly private terminals, with a 45-minute arrival window, complimentary treats and fresh water for pets, and regular stops at pet-friendly terminals on longer itineraries. Current destination pages listed Los Angeles, New York City, Chicago, Scottsdale, Washington DC, Seattle, San Francisco, Atlanta, Dallas-Fort Worth, Denver, and Fort Lauderdale, though some were marked as new in 2026.
+      Current destinations include Los Angeles, New York City, Chicago, Scottsdale, Washington DC, Seattle, San Francisco, Atlanta, Dallas-Fort Worth, Denver, and Fort Lauderdale. One adult and one large dog fly for approximately $5,000 to $6,000. Flights are available about once a week.
     </p>
     <p>
-      Details are still more fluid than with a mature airline network. RetrievAir states that it is not a direct air carrier and that flights are operated by RVR Aviation, a licensed U.S. air carrier. I would treat it as a promising, active service to verify directly before planning a trip around a specific date, city pair, or large-dog seating setup.
+      RetrievAir states that it is not a direct air carrier and that flights are operated by RVR Aviation, a licensed U.S. air carrier. They fly public charter planes operating like semi-private flights from private terminals. The airplanes seat 30 people and hold up to 30 pets.
+    </p>
+    <p>
+      RetrievAir is also committed to helping pets find their forever homes by providing safe, reliable transportation and coordinating rescue efforts across state lines. Their goal is to reduce euthanasia rates in overcrowded shelters by connecting pets in need with families and shelters that can provide them with a second chance at life.
     </p>
 
-    <h2 id="private-charters">Private charters: the flexible but expensive fallback</h2>
+    <h2 id="private-charters">Private charters: A flexible but expensive option</h2>
     <p>
-      Private charter is not an airline category. It is the option you consider when route, dog size, number of pets, timing, or cargo avoidance matters more than price.
+      Private charter is an option when money is no object. It offers the most flexibility in terms of route, timing, dog size, and number of pets.
     </p>
     <p>
-      <a href="https://www.evojets.com/pets-on-private-jets/" rel="nofollow noopener" target="_blank">evoJets</a> is a useful example of the category, not a dog airline. Its pet page says pets can fly in the passenger area, dogs and cats can be loose in the cabin, there are no dog size restrictions, and larger dogs may call for a larger aircraft for comfort. evoJets also notes that it is an indirect air carrier and does not own or operate aircraft.
+      <a href="https://www.evojets.com/pets-on-private-jets/" rel="nofollow noopener" target="_blank">evoJets</a> is an example of a pet-friendly private jet company. Pets can fly in the passenger area. Dogs and cats (and other small animals) can be loose in the cabin. There are no dog size restrictions.
     </p>
     <p>
-      That operator-approval caveat matters. A broker can source pet-friendly aircraft and operators, but the final experience depends on aircraft size, cabin layout, route, timing, repositioning costs, and operator rules. Pricing varies too heavily to summarize honestly in one number.
+      evoJets notes that it is an indirect air carrier and does not own or operate aircraft. A broker can source pet-friendly aircraft and operators, but the final experience depends on aircraft size, cabin layout, route, timing, repositioning costs, and operator rules. Pricing varies heavily. evoJets operated in and out of more than 300 cities. A one way flight from Los Angeles to New York starts at about $30,000 and rises significantly based on route availability and aircraft size.
     </p>
     <p>
-      Private charter makes the most sense for multiple pets, very large dogs, unusual routes, urgent relocation, or owners who want to avoid cargo completely and have the budget to solve the trip privately.
+      evoJets are animal lovers and do lots of work with charities for animal rights and rescue missions. Their private aircraft charter allow individuals and organizations to do great work for animal welfare.
+    </p>
+    <p>
+      Private charter makes the most sense for multiple pets, very large dogs, unusual routes, or urgent relocation. It is for owners who want to avoid cargo completely and who can afford to fly privately.
     </p>
 
     <h2 id="comparison">Quick comparison: which dog-friendly flight option fits your situation?</h2>

--- a/src/content/articles/travel-dog-friendly-airlines.mdx
+++ b/src/content/articles/travel-dog-friendly-airlines.mdx
@@ -4,6 +4,14 @@ description: 'Most airlines only allow small dogs under the seat, but these dog-
 ogTitle: 'Best Dog-Friendly Airlines Where Dogs Fly With You'
 pubDate: 2026-05-01
 canonicalPath: '/travel/dog-friendly-airlines/'
+topics: [travel, flying, carriers, calming, anxiety]
+pinnedRelated:
+  - '/travel/how-to-fly-with-a-dog/'
+  - '/comforting/best-airline-approved-dog-carriers/'
+  - '/comforting/best-dog-travel-bags-for-flying/'
+  - '/calming/car-anxiety-for-dogs/'
+  - '/travel/dog-road-trip-gear/'
+relatedLabel: 'Dog-Friendly Airlines'
 ---
 
 import Toc from '@components/modules/Toc.astro';
@@ -43,14 +51,6 @@ export const dogFriendlyAirlineFaqs = [
     question: 'Are normal airlines included in this list?',
     answer: 'Not as the focus. Delta, Alaska, United, American, JetBlue, and similar carriers mostly use the standard small-dog-in-an-under-seat-carrier model. This guide is about the rarer options where dogs can stay meaningfully closer to their humans in the cabin, including larger-dog possibilities.',
   },
-];
-
-export const relatedLinks = [
-  { label: 'How to Fly With a Dog', href: '/travel/how-to-fly-with-a-dog/' },
-  { label: 'Best Airline-Approved Dog Carriers', href: '/comforting/best-airline-approved-dog-carriers/' },
-  { label: 'Best Dog Travel Bags for Flying', href: '/comforting/best-dog-travel-bags-for-flying/' },
-  { label: 'Calming Help for Travel Anxiety', href: '/calming/car-anxiety-for-dogs/' },
-  { label: 'Dog Road Trip Gear', href: '/travel/dog-road-trip-gear/' },
 ];
 
 <article class="collector-article container">
@@ -248,5 +248,10 @@ export const relatedLinks = [
 
   <FAQ faqs={dogFriendlyAirlineFaqs} />
   <Disclosure />
-  <InternalLinkStrip heading="More Dog Travel Guides" links={relatedLinks} fromPage="dog-friendly-airlines" />
+  <InternalLinkStrip
+    heading="More Dog Travel Guides"
+    currentHref="/travel/dog-friendly-airlines/"
+    limit={5}
+    fromPage="dog-friendly-airlines"
+  />
 </article>


### PR DESCRIPTION
## Summary
- Adds a new collector article at /travel/dog-friendly-airlines/ focused on dog-forward in-cabin flight options beyond standard under-seat commercial pet policies
- Covers BARK Air, JSX, K9 JETS, RetrievAir, and private charter options with cautious route/pricing language
- Adds TOC, FAQ, Disclosure, InternalLinkStrip, and system-definition inventory entry

## Sources used
- BARK Air official site and booking pages
- JSX official route pages, pet policy link, and Pet Acceptance Form link
- K9 JETS official site, route pages, and where-we-fly page
- RetrievAir official site, how-it-works page, FAQs, and city/service pages
- evoJets pets-on-private-jets page

## Branch history
Rebased onto current main — merge commit dropped, 2 clean commits.

## Notes
- JSX large-dog policy should be rechecked directly before future refreshes because the public policy page is difficult to extract reliably
- RetrievAir appears active with current U.S. route/service pages, but it is newer and route availability should be rechecked before planning guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)