### PR TITLE
[codex] Add related page metadata helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,14 @@ Repository guidance for coding agents working in `/Volumes/wanderer/dev/solo/chi
 - At least one above-the-fold path to a `converter` is required.
 - `collector` pages should aggregate, qualify, and route intent, not duplicate full converter comparison implementations.
 
+### Related Content
+
+- Complete sitemap inventory is the source of truth for related links. Static pages register metadata in `src/data/content-sitemap.ts`; article collectors can define metadata in MDX frontmatter.
+- Use `topics` as ranking signals when a section is too broad to infer good relationships.
+- Use `pinnedRelated` only for intentional editorial relationships, and `excludeRelated` for poor or conflicting matches. Exclusion wins over pinning.
+- Related derivation is available through `src/utils/related-pages.ts`, but existing rendered `InternalLinkStrip` and `RelatedGuides` arrays stay in place until their migration wave.
+- Keep article pages as `pageType: 'collector'` with `collectorSubtype: 'article'`; do not invent page types.
+
 ### Completion Gates
 
 - Verify internal route integrity (no dead or malformed links).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,8 +20,18 @@ bun run check:asins -- --quiet  # Same, issues only
 
 ## Content Sitemap
 
-- `src/pages/content-sitemap.astro` is the live page inventory. **Every new page must be added to it before the work is considered done.** This includes section collectors, article collectors, converters, and attractor pages — not just informer pages.
+- `src/data/sitemap-inventory.ts` is the complete build-time page inventory. Static registrations live in `src/data/content-sitemap.ts`; article collectors are discovered from MDX frontmatter.
+- `src/pages/content-sitemap.astro` renders that inventory for editorial review. **Every new page must be registered in the inventory before the work is considered done.** This includes section collectors, article collectors, converters, and attractor pages — not just informer pages.
 - When adding a page: add it to the correct section (or create a new section if the pillar is new), set the correct `pageType` and `collectorSubtype` where applicable.
+
+## Related Content
+
+- Related links derive from the complete sitemap inventory through `src/utils/related-pages.ts`; see `docs/related-content.md`.
+- New pages should define `topics` when section membership is too broad to rank related pages well, especially Comfort, Travel, Tracking, Cooling, and Calming overlap.
+- Use `pinnedRelated` only for intentional editorial relationships that should outrank algorithmic matches.
+- Use `excludeRelated` to prevent poor, redundant, or conflicting recommendations. Exclusion wins over pinning.
+- Keep the official page model: `pageType: 'collector'` plus `collectorSubtype: 'article' | 'section'`. Do not invent fake page types such as `article-collector`.
+- Wave 1 only makes metadata and helper functions available; existing rendered `InternalLinkStrip` and `RelatedGuides` arrays remain in place until the migration wave for that page type.
 
 ## Governing Principles
 

--- a/docs/article-writing-guide.md
+++ b/docs/article-writing-guide.md
@@ -90,6 +90,16 @@ Optional modules (use when appropriate):
 
 **`InternalLinkStrip`** — Links must point to converter pages (or other article collectors where cross-linking adds value). This is the primary conversion mechanism for articles. It appears at the bottom, after `FAQ`. Labels should be short and descriptive: "Best Cooling Mats" not "Click here for cooling mats."
 
+Related metadata may also be added in frontmatter:
+
+```yaml
+topics: [travel, road-trips, car-cooling]
+pinnedRelated: ['/cooling/car-cooling-for-dogs/']
+excludeRelated: ['/privacy-policy/']
+```
+
+Until the related-content migration reaches article collectors, `InternalLinkStrip` remains manually rendered in the article body. Once migration is active, authors should manage relationship intent through `topics`, `pinnedRelated`, and `excludeRelated`.
+
 **`Disclosure`** — Required on any article that renders inline product cards. Place it after the prose, before or after `FAQ`. If no product cards appear inline, `Disclosure` is optional (the footer disclosure covers it).
 
 ---
@@ -211,12 +221,14 @@ The article's job is to be useful. A genuinely useful article earns the click. T
 Before submitting or shipping an article collector:
 
 - [ ] Page type declared: `collector · article`
-- [ ] Added to `content-sitemap.astro`
+- [ ] Registered in the complete sitemap inventory
+- [ ] Added related metadata in frontmatter where useful: `topics`, `pinnedRelated`, `excludeRelated`
 - [ ] Added to `docs/system-definition.yaml`
 - [ ] `Article` JSON-LD present with all required fields
 - [ ] `Toc` module included (if 4+ h2 sections) with matching `id` attributes
 - [ ] `FAQ` module included (minimum 3 questions)
 - [ ] `InternalLinkStrip` at the bottom, linking to relevant converters
+- [ ] Manual `InternalLinkStrip` kept in place unless this page type has been migrated to derived related links
 - [ ] `Disclosure` included if inline product cards are present
 - [ ] No vet-authority language
 - [ ] No "we tested" claims

--- a/docs/related-content.md
+++ b/docs/related-content.md
@@ -1,0 +1,55 @@
+# Related Content
+
+This document explains the Wave 1 related-content system. The helper and metadata are available, but public rendering still uses existing manual `InternalLinkStrip` and `RelatedGuides` arrays until later migration waves.
+
+## Source Of Truth
+
+Related pages are derived from the complete build-time sitemap inventory:
+
+- Static sitemap registrations live in `src/data/content-sitemap.ts`.
+- Article collectors are discovered by `src/data/sitemap-inventory.ts` from MDX frontmatter.
+- The related helper lives in `src/utils/related-pages.ts`.
+
+Every related target must be a real sitemap page. Do not add one-off links in page bodies when the relationship should be reusable across pages.
+
+## Metadata Fields
+
+Add these fields to `createSitemapPage()` calls or article frontmatter when a page needs relationship intent:
+
+```yaml
+topics:
+  - cooling
+  - car-cooling
+pinnedRelated:
+  - /cooling/car-cooling-for-dogs/
+excludeRelated:
+  - /cooling/freezable-dog-toys/
+```
+
+- `topics` are ranking signals, not mandatory filters. Use them when a section is too broad to produce good matches.
+- `pinnedRelated` is for intentional editorial relationships that should outrank algorithmic matches.
+- `excludeRelated` prevents poor, redundant, or conflicting recommendations.
+- If a href appears in both `pinnedRelated` and `excludeRelated`, exclusion wins.
+
+## Ranking
+
+`getRelatedPages()` filters out self, excluded hrefs, `noindex`, `attractor`, and `informer` pages. It then ranks eligible pages by:
+
+1. pinned order
+2. topic overlap
+3. same sitemap section
+4. page type: `converter` > `collector · article` > `collector · section`
+5. deterministic tie-breaker
+
+Use only official page types: `converter`, `collector`, `attractor`, and `informer`. For articles, keep `pageType: 'collector'` with `collectorSubtype: 'article'`; do not create fake page types.
+
+## Authoring Checklist
+
+When adding a page:
+
+- Register it in the sitemap inventory through the correct static section or article frontmatter.
+- Declare the correct `pageType` and `collectorSubtype`.
+- Add `topics` if the page belongs to a broad section like Comfort, Travel, or Tracking.
+- Add `pinnedRelated` only for editorially important relationships.
+- Add `excludeRelated` when an automatic match would be unhelpful.
+- Keep manual rendered related arrays in place until the relevant migration wave replaces them.

--- a/docs/system-definition.yaml
+++ b/docs/system-definition.yaml
@@ -25,6 +25,20 @@ site_system:
       - "AGENTS.md"
       - "CLAUDE.md"
 
+  related_content:
+    status: "metadata_and_helper_available_not_rendering_active"
+    source_of_truth: "complete build-time sitemap inventory"
+    helper: "src/utils/related-pages.ts"
+    metadata_fields:
+      - "topics"
+      - "pinnedRelated"
+      - "excludeRelated"
+    notes: >
+      Related-link derivation is available through sitemap metadata, but public rendering
+      still uses existing manual InternalLinkStrip and RelatedGuides arrays until migration
+      waves activate the helper by page type. Manual related arrays become deprecated only
+      after the relevant migration starts.
+
   keystone_metrics:
     primary: "Amazon affiliate revenue (qualified outbound clicks to purchases)"
     secondary: "collector_to_converter_click rate"

--- a/src/__tests__/related-pages.test.ts
+++ b/src/__tests__/related-pages.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from 'vitest';
+
+import type { SitemapPage, SitemapSection, SitemapTopic } from '../data/content-sitemap';
+import { getCompleteSitemapSections } from '../data/sitemap-inventory';
+import { getRelatedPages, toLinkStripItems, toRelatedGuideCards } from '../utils/related-pages';
+
+function createPage(input: {
+  href: string;
+  title?: string;
+  pageType?: SitemapPage['pageType'];
+  collectorSubtype?: SitemapPage['collectorSubtype'];
+  topics?: SitemapTopic[];
+  pinnedRelated?: string[];
+  excludeRelated?: string[];
+  noindex?: boolean;
+}): SitemapPage {
+  const title = input.title ?? input.href;
+
+  return {
+    href: input.href,
+    pageType: input.pageType ?? 'converter',
+    collectorSubtype: input.collectorSubtype,
+    topics: input.topics,
+    pinnedRelated: input.pinnedRelated,
+    excludeRelated: input.excludeRelated,
+    noindex: input.noindex,
+    preview: {
+      title,
+      description: `${title} description`,
+      image: '/og-default.jpg',
+    },
+  };
+}
+
+function createSection(title: string, pages: SitemapPage[]): SitemapSection {
+  return {
+    title,
+    description: `${title} description`,
+    pages,
+  };
+}
+
+describe('related pages', () => {
+  it('excludes self, noindex pages, informer pages, and attractor pages', async () => {
+    const sections = [
+      createSection('Current', [
+        createPage({ href: '/current/', topics: ['cooling'] }),
+        createPage({ href: '/self-duplicate/', topics: ['cooling'], noindex: true }),
+        createPage({ href: '/legal/', pageType: 'informer', topics: ['cooling'] }),
+        createPage({ href: '/', pageType: 'attractor', topics: ['cooling'] }),
+        createPage({ href: '/eligible/', topics: ['cooling'] }),
+      ]),
+    ];
+
+    const related = await getRelatedPages({ currentHref: '/current/', sections, limit: 10 });
+
+    expect(related.map((page) => page.href)).toEqual(['/eligible/']);
+  });
+
+  it('ranks pinned related hrefs first in pinned order', async () => {
+    const sections = [
+      createSection('Current', [
+        createPage({
+          href: '/current/',
+          topics: ['cooling'],
+          pinnedRelated: ['/third/', '/first/'],
+        }),
+        createPage({ href: '/first/', topics: ['cooling'] }),
+        createPage({ href: '/second/', topics: ['cooling'] }),
+        createPage({ href: '/third/', topics: [] }),
+      ]),
+    ];
+
+    const related = await getRelatedPages({ currentHref: '/current/', sections, limit: 3 });
+
+    expect(related.map((page) => page.href)).toEqual(['/third/', '/first/', '/second/']);
+  });
+
+  it('lets excludeRelated beat pinnedRelated', async () => {
+    const sections = [
+      createSection('Current', [
+        createPage({
+          href: '/current/',
+          topics: ['cooling'],
+          pinnedRelated: ['/excluded/', '/kept/'],
+          excludeRelated: ['/excluded/'],
+        }),
+        createPage({ href: '/excluded/', topics: ['cooling'] }),
+        createPage({ href: '/kept/', topics: ['cooling'] }),
+        createPage({ href: '/fallback/', topics: ['cooling'] }),
+      ]),
+    ];
+
+    const related = await getRelatedPages({ currentHref: '/current/', sections, limit: 3 });
+
+    expect(related.map((page) => page.href)).not.toContain('/excluded/');
+    expect(related[0]?.href).toBe('/kept/');
+  });
+
+  it('ranks topic overlap ahead of same-section matches', async () => {
+    const sections = [
+      createSection('Current', [
+        createPage({ href: '/current/', topics: ['cooling', 'travel'] }),
+        createPage({ href: '/same-section/', topics: ['calming'] }),
+      ]),
+      createSection('Other', [
+        createPage({ href: '/topic-match/', topics: ['cooling', 'travel'] }),
+      ]),
+    ];
+
+    const related = await getRelatedPages({ currentHref: '/current/', sections, limit: 2 });
+
+    expect(related.map((page) => page.href)).toEqual(['/topic-match/', '/same-section/']);
+  });
+
+  it('falls back to same section and page type rank when topics are absent', async () => {
+    const sections = [
+      createSection('Current', [
+        createPage({ href: '/current/' }),
+        createPage({
+          href: '/same-section-article/',
+          pageType: 'collector',
+          collectorSubtype: 'article',
+        }),
+      ]),
+      createSection('Other', [
+        createPage({ href: '/other-converter/' }),
+      ]),
+    ];
+
+    const related = await getRelatedPages({ currentHref: '/current/', sections, limit: 2 });
+
+    expect(related.map((page) => page.href)).toEqual(['/same-section-article/', '/other-converter/']);
+  });
+
+  it('uses deterministic ordering for repeated calls', async () => {
+    const sections = [
+      createSection('Current', [
+        createPage({ href: '/current/' }),
+        createPage({ href: '/a/' }),
+        createPage({ href: '/b/' }),
+        createPage({ href: '/c/' }),
+        createPage({ href: '/d/' }),
+      ]),
+    ];
+
+    const first = await getRelatedPages({ currentHref: '/current/', sections, limit: 4 });
+    const second = await getRelatedPages({ currentHref: '/current/', sections, limit: 4 });
+
+    expect(second.map((page) => page.href)).toEqual(first.map((page) => page.href));
+  });
+
+  it('can surface a newly registered sitemap page without caller edits', async () => {
+    const sections = [
+      createSection('Current', [
+        createPage({ href: '/current/', topics: ['gps-tracking'] }),
+      ]),
+      createSection('New Section', [
+        createPage({ href: '/newly-registered/', topics: ['gps-tracking'] }),
+      ]),
+    ];
+
+    const related = await getRelatedPages({ currentHref: '/current/', sections, limit: 1 });
+
+    expect(related[0]?.href).toBe('/newly-registered/');
+  });
+
+  it('adapts sitemap pages for InternalLinkStrip and RelatedGuides props', () => {
+    const pages = [
+      createPage({
+        href: '/cooling/cooling-mats/',
+        title: 'Best Dog Cooling Mats | Chill-Dogs',
+      }),
+    ];
+
+    expect(toLinkStripItems(pages)).toEqual([
+      {
+        label: 'Best Dog Cooling Mats',
+        href: '/cooling/cooling-mats/',
+      },
+    ]);
+    expect(toRelatedGuideCards(pages)).toEqual([
+      {
+        href: '/cooling/cooling-mats/',
+        title: 'Best Dog Cooling Mats',
+        description: 'Best Dog Cooling Mats | Chill-Dogs description',
+      },
+    ]);
+  });
+
+  it('resolves only hrefs that exist in the complete sitemap and never resolves self', async () => {
+    const sections = await getCompleteSitemapSections();
+    const pages = sections.flatMap((section) => section.pages);
+    const hrefs = new Set(pages.map((page) => page.href));
+    const indexablePages = pages.filter((page) => !page.noindex && page.pageType !== 'attractor' && page.pageType !== 'informer');
+
+    for (const page of indexablePages) {
+      const related = await getRelatedPages({ currentHref: page.href, sections, limit: 4 });
+
+      for (const relatedPage of related) {
+        expect(hrefs.has(relatedPage.href)).toBe(true);
+        expect(relatedPage.href).not.toBe(page.href);
+      }
+    }
+  });
+});

--- a/src/__tests__/sitemap-inventory.test.ts
+++ b/src/__tests__/sitemap-inventory.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
 
 const articleEntries = [
-  createArticle('/travel/dog-road-trip-gear/', 'Dog Road Trip Gear', '2026-03-31'),
+  createArticle('/travel/dog-road-trip-gear/', 'Dog Road Trip Gear', '2026-03-31', {
+    topics: ['travel', 'road-trips'],
+    pinnedRelated: ['/cooling/car-cooling-for-dogs/'],
+    excludeRelated: ['/privacy-policy/'],
+  }),
   createArticle('/travel/rhys-ran-away-cerro-san-luis-obispo/', 'The Day Rhys Ran Off', '2026-03-21'),
   createArticle('/travel/how-to-fly-with-a-dog/', 'How to Fly With a Dog', '2026-04-10'),
   createArticle('/cooling/how-hot-is-too-hot-for-dogs/', 'How Hot Is Too Hot for Dogs?', '2026-03-10'),
@@ -26,7 +30,16 @@ import {
   getCompleteSitemapSections,
 } from '../data/sitemap-inventory';
 
-function createArticle(canonicalPath: string, title: string, pubDate: string) {
+function createArticle(
+  canonicalPath: string,
+  title: string,
+  pubDate: string,
+  metadata: {
+    topics?: string[];
+    pinnedRelated?: string[];
+    excludeRelated?: string[];
+  } = {}
+) {
   return {
     id: canonicalPath,
     slug: canonicalPath,
@@ -37,6 +50,7 @@ function createArticle(canonicalPath: string, title: string, pubDate: string) {
       description: `${title} description`,
       pubDate: new Date(pubDate),
       canonicalPath,
+      ...metadata,
     },
   };
 }
@@ -73,6 +87,15 @@ describe('sitemap inventory', () => {
     const hrefs = pages.map((page) => page.href);
 
     expect(hrefs).toEqual(expect.arrayContaining(articleEntries.map((entry) => entry.data.canonicalPath)));
+  });
+
+  it('passes article related metadata from frontmatter into sitemap pages', async () => {
+    const pages = await getCompleteSitemapPages();
+    const roadTrip = pages.find((page) => page.href === '/travel/dog-road-trip-gear/');
+
+    expect(roadTrip?.topics).toEqual(['travel', 'road-trips']);
+    expect(roadTrip?.pinnedRelated).toEqual(['/cooling/car-cooling-for-dogs/']);
+    expect(roadTrip?.excludeRelated).toEqual(['/privacy-policy/']);
   });
 
   it('places article collectors after entry points and before remaining static sections', async () => {

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,4 +1,5 @@
 import { defineCollection, z } from 'astro:content';
+import { TOPICS } from '../data/content-sitemap';
 
 const articles = defineCollection({
   type: 'content',
@@ -10,6 +11,9 @@ const articles = defineCollection({
       pubDate: z.date(),
       canonicalPath: z.string(),
       ogImage: image().optional(),
+      topics: z.array(z.enum(TOPICS)).optional(),
+      pinnedRelated: z.array(z.string()).optional(),
+      excludeRelated: z.array(z.string()).optional(),
     }),
 });
 

--- a/src/data/content-sitemap.ts
+++ b/src/data/content-sitemap.ts
@@ -8,6 +8,33 @@ import { ROUTES } from './routes';
 
 export type SitemapPageType = 'converter' | 'collector' | 'attractor' | 'informer';
 export type SitemapCollectorSubtype = 'section' | 'article';
+export const TOPICS = [
+  'cooling',
+  'heat-safety',
+  'car-cooling',
+  'cooling-mats',
+  'cooling-wearables',
+  'frozen-toys',
+  'calming',
+  'anxiety',
+  'car-anxiety',
+  'crate-training',
+  'fireworks',
+  'comfort',
+  'sleep',
+  'beds',
+  'orthopedic',
+  'crates',
+  'travel',
+  'road-trips',
+  'flying',
+  'carriers',
+  'tracking',
+  'gps-tracking',
+  'lost-dog-safety',
+] as const;
+
+export type SitemapTopic = typeof TOPICS[number];
 
 export interface SitemapPreview {
   title: string;
@@ -19,6 +46,10 @@ export interface SitemapPage {
   href: string;
   pageType: SitemapPageType;
   collectorSubtype?: SitemapCollectorSubtype;
+  topics?: SitemapTopic[];
+  pinnedRelated?: string[];
+  excludeRelated?: string[];
+  noindex?: boolean;
   preview: SitemapPreview;
 }
 
@@ -28,12 +59,15 @@ export interface SitemapSection {
   pages: SitemapPage[];
 }
 
-interface SitemapPageInput {
+export interface SitemapPageInput {
   baseTitle: string;
   description: string;
   href: string;
   pageType: SitemapPageType;
   collectorSubtype?: SitemapCollectorSubtype;
+  topics?: SitemapTopic[];
+  pinnedRelated?: string[];
+  excludeRelated?: string[];
   ogTitle?: string;
   ogImage?: string | ImageMetadata;
   noindex?: boolean;
@@ -58,6 +92,10 @@ export function createSitemapPage(input: SitemapPageInput): SitemapPage {
     href: input.href,
     pageType: input.pageType,
     collectorSubtype: input.collectorSubtype,
+    topics: input.topics,
+    pinnedRelated: input.pinnedRelated,
+    excludeRelated: input.excludeRelated,
+    noindex: input.noindex,
     preview: {
       title: resolveShareTitle(input.baseTitle, input.ogTitle),
       description: input.description,
@@ -86,6 +124,7 @@ export const staticSitemapSections: SitemapSection[] = [
         href: ROUTES.coolingHub,
         pageType: 'collector',
         collectorSubtype: 'section',
+        topics: ['cooling'],
       }),
       createSitemapPage({
         baseTitle: 'Calm & Comfort',
@@ -95,6 +134,7 @@ export const staticSitemapSections: SitemapSection[] = [
         href: ROUTES.calmingHub,
         pageType: 'collector',
         collectorSubtype: 'section',
+        topics: ['calming', 'anxiety'],
       }),
       createSitemapPage({
         baseTitle: 'Comfort & Rest',
@@ -104,6 +144,7 @@ export const staticSitemapSections: SitemapSection[] = [
         href: ROUTES.comfortHub,
         pageType: 'collector',
         collectorSubtype: 'section',
+        topics: ['comfort', 'sleep', 'beds', 'crates'],
       }),
     ],
   },
@@ -117,36 +158,42 @@ export const staticSitemapSections: SitemapSection[] = [
           'Beat the heat with our top picks: cooling mats, bandanas, vests, and freezable toys compared for comfort, durability, and safety all summer.',
         href: ROUTES.coolingTop,
         pageType: 'converter',
+        topics: ['cooling', 'heat-safety'],
       }),
       createSitemapPage({
         baseTitle: categoryMeta['car-cooling'].title,
         description: categoryMeta['car-cooling'].description,
         href: ROUTES.coolingCar,
         pageType: 'converter',
+        topics: ['cooling', 'heat-safety', 'car-cooling', 'travel', 'road-trips'],
       }),
       createSitemapPage({
         baseTitle: categoryMeta['cooling-mats'].title,
         description: categoryMeta['cooling-mats'].description,
         href: ROUTES.coolingMats,
         pageType: 'converter',
+        topics: ['cooling', 'heat-safety', 'cooling-mats', 'comfort'],
       }),
       createSitemapPage({
         baseTitle: categoryMeta['cooling-bandanas'].title,
         description: categoryMeta['cooling-bandanas'].description,
         href: ROUTES.coolingBandanas,
         pageType: 'converter',
+        topics: ['cooling', 'heat-safety', 'cooling-wearables'],
       }),
       createSitemapPage({
         baseTitle: categoryMeta['cooling-vests'].title,
         description: categoryMeta['cooling-vests'].description,
         href: ROUTES.coolingVests,
         pageType: 'converter',
+        topics: ['cooling', 'heat-safety', 'cooling-wearables'],
       }),
       createSitemapPage({
         baseTitle: categoryMeta['freezable-dog-toys'].title,
         description: categoryMeta['freezable-dog-toys'].description,
         href: ROUTES.coolingToys,
         pageType: 'converter',
+        topics: ['cooling', 'heat-safety', 'frozen-toys'],
       }),
     ],
   },
@@ -159,18 +206,21 @@ export const staticSitemapSections: SitemapSection[] = [
         description: calmingConverterPages['best-calming-products-for-anxious-dogs'].description,
         href: ROUTES.calmingTop,
         pageType: 'converter',
+        topics: ['calming', 'anxiety'],
       }),
       createSitemapPage({
         baseTitle: calmingConverterPages['best-thundershirt-alternatives'].title,
         description: calmingConverterPages['best-thundershirt-alternatives'].description,
         href: ROUTES.calmingAlternatives,
         pageType: 'converter',
+        topics: ['calming', 'anxiety'],
       }),
       createSitemapPage({
         baseTitle: calmingConverterPages['car-anxiety-for-dogs'].title,
         description: calmingConverterPages['car-anxiety-for-dogs'].description,
         href: ROUTES.calmingCar,
         pageType: 'converter',
+        topics: ['calming', 'anxiety', 'car-anxiety', 'travel', 'road-trips'],
       }),
     ],
   },
@@ -185,6 +235,7 @@ export const staticSitemapSections: SitemapSection[] = [
           'Compare the top dog GPS trackers — cellular (Fi, Halo, Garmin LTE), off-grid Garmin systems, and Bluetooth tags (AirTag). Honest trade-offs for each.',
         href: ROUTES.trackingTop,
         pageType: 'converter',
+        topics: ['tracking', 'gps-tracking', 'lost-dog-safety'],
       }),
       createSitemapPage({
         baseTitle: 'Fi Dog Collar Review: GPS Tracking for Everyday Dogs (2026)',
@@ -193,6 +244,7 @@ export const staticSitemapSections: SitemapSection[] = [
           'An honest look at Fi Series 3+ — cellular GPS tracking, escape alerts, and geofencing. What it does well, what it costs, and where it fails without cell signal.',
         href: ROUTES.fiCollarReview,
         pageType: 'converter',
+        topics: ['tracking', 'gps-tracking', 'lost-dog-safety'],
       }),
       createSitemapPage({
         baseTitle: 'Garmin Dog Tracking Collars: Off-Grid GPS for Wilderness & Hiking (2026)',
@@ -202,6 +254,7 @@ export const staticSitemapSections: SitemapSection[] = [
         href: ROUTES.garminTracking,
         pageType: 'collector',
         collectorSubtype: 'article',
+        topics: ['tracking', 'gps-tracking', 'lost-dog-safety'],
       }),
       createSitemapPage({
         baseTitle: "AirTag for Dogs: What It Can (and Can't) Actually Do",
@@ -210,6 +263,7 @@ export const staticSitemapSections: SitemapSection[] = [
         href: ROUTES.airtagForDogs,
         pageType: 'collector',
         collectorSubtype: 'article',
+        topics: ['tracking', 'gps-tracking', 'lost-dog-safety'],
       }),
     ],
   },
@@ -222,60 +276,70 @@ export const staticSitemapSections: SitemapSection[] = [
         description: relaxationConverterPages['best-calming-dog-beds'].description,
         href: ROUTES.comfortCalmingBeds,
         pageType: 'converter',
+        topics: ['comfort', 'sleep', 'beds', 'calming', 'anxiety'],
       }),
       createSitemapPage({
         baseTitle: relaxationConverterPages['best-orthopedic-dog-beds'].title,
         description: relaxationConverterPages['best-orthopedic-dog-beds'].description,
         href: ROUTES.comfortOrthopedicBeds,
         pageType: 'converter',
+        topics: ['comfort', 'sleep', 'beds', 'orthopedic'],
       }),
       createSitemapPage({
         baseTitle: relaxationConverterPages['best-puppy-crates'].title,
         description: relaxationConverterPages['best-puppy-crates'].description,
         href: ROUTES.comfortPuppyCrates,
         pageType: 'converter',
+        topics: ['comfort', 'crates', 'crate-training'],
       }),
       createSitemapPage({
         baseTitle: relaxationConverterPages['best-anxiety-dog-crates'].title,
         description: relaxationConverterPages['best-anxiety-dog-crates'].description,
         href: ROUTES.comfortAnxietyCrates,
         pageType: 'converter',
+        topics: ['comfort', 'crates', 'calming', 'anxiety'],
       }),
       createSitemapPage({
         baseTitle: relaxationConverterPages['best-travel-crates-for-road-trips'].title,
         description: relaxationConverterPages['best-travel-crates-for-road-trips'].description,
         href: ROUTES.comfortTravelCrates,
         pageType: 'converter',
+        topics: ['comfort', 'crates', 'travel', 'road-trips'],
       }),
       createSitemapPage({
         baseTitle: relaxationConverterPages['best-airline-crates-for-flying-with-your-dog'].title,
         description: relaxationConverterPages['best-airline-crates-for-flying-with-your-dog'].description,
         href: ROUTES.comfortAirlineCrates,
         pageType: 'converter',
+        topics: ['comfort', 'crates', 'travel', 'flying'],
       }),
       createSitemapPage({
         baseTitle: relaxationConverterPages['best-airline-approved-dog-carriers'].title,
         description: relaxationConverterPages['best-airline-approved-dog-carriers'].description,
         href: ROUTES.comfortAirlineCarriers,
         pageType: 'converter',
+        topics: ['comfort', 'travel', 'flying', 'carriers'],
       }),
       createSitemapPage({
         baseTitle: relaxationConverterPages['best-dog-travel-bags-for-flying'].title,
         description: relaxationConverterPages['best-dog-travel-bags-for-flying'].description,
         href: ROUTES.comfortTravelBags,
         pageType: 'converter',
+        topics: ['comfort', 'travel', 'flying', 'carriers'],
       }),
       createSitemapPage({
         baseTitle: relaxationConverterPages['best-furniture-dog-crates'].title,
         description: relaxationConverterPages['best-furniture-dog-crates'].description,
         href: ROUTES.comfortFurnitureCrates,
         pageType: 'converter',
+        topics: ['comfort', 'crates'],
       }),
       createSitemapPage({
         baseTitle: relaxationConverterPages['best-heavy-duty-dog-crates'].title,
         description: relaxationConverterPages['best-heavy-duty-dog-crates'].description,
         href: ROUTES.comfortHeavyDutyCrates,
         pageType: 'converter',
+        topics: ['comfort', 'crates', 'anxiety'],
       }),
     ],
   },

--- a/src/data/sitemap-inventory.ts
+++ b/src/data/sitemap-inventory.ts
@@ -15,6 +15,9 @@ export async function getArticleSitemapSection(): Promise<SitemapSection> {
         href: entry.data.canonicalPath,
         pageType: 'collector',
         collectorSubtype: 'article',
+        topics: entry.data.topics,
+        pinnedRelated: entry.data.pinnedRelated,
+        excludeRelated: entry.data.excludeRelated,
       })
     );
 

--- a/src/utils/related-pages.ts
+++ b/src/utils/related-pages.ts
@@ -1,0 +1,144 @@
+import { getCompleteSitemapSections } from '@data/sitemap-inventory';
+import type { SitemapPage, SitemapSection } from '@data/content-sitemap';
+
+export interface RelatedPagesOptions {
+  currentHref: string;
+  limit?: number;
+  sections?: SitemapSection[];
+}
+
+export interface LinkStripItem {
+  label: string;
+  href: string;
+}
+
+export interface RelatedGuideCard {
+  href: string;
+  title: string;
+  description: string;
+}
+
+interface RankedPage {
+  page: SitemapPage;
+  pinnedIndex: number;
+  topicOverlap: number;
+  sameSection: number;
+  pageTypeRank: number;
+  tieBreaker: number;
+}
+
+const DEFAULT_RELATED_LIMIT = 4;
+
+export async function getRelatedPages(options: RelatedPagesOptions): Promise<SitemapPage[]> {
+  const limit = options.limit ?? DEFAULT_RELATED_LIMIT;
+  const sections = options.sections ?? await getCompleteSitemapSections();
+  const currentPage = sections.flatMap((section) => section.pages).find((page) => page.href === options.currentHref);
+
+  if (!currentPage) {
+    throw new Error(`Missing sitemap page for related links: ${options.currentHref}`);
+  }
+
+  const currentSection = sections.find((section) => section.pages.some((page) => page.href === currentPage.href));
+  const excludedHrefs = new Set([currentPage.href, ...(currentPage.excludeRelated ?? [])]);
+  const pinnedRelated = currentPage.pinnedRelated ?? [];
+  const pinnedOrder = new Map(pinnedRelated.map((href, index) => [href, index]));
+  const currentTopics = new Set(currentPage.topics ?? []);
+
+  const rankedPages = sections
+    .flatMap((section) =>
+      section.pages.map((page): RankedPage => ({
+        page,
+        pinnedIndex: pinnedOrder.get(page.href) ?? Number.POSITIVE_INFINITY,
+        topicOverlap: countTopicOverlap(currentTopics, page.topics),
+        sameSection: section === currentSection ? 1 : 0,
+        pageTypeRank: getPageTypeRank(page),
+        tieBreaker: stableHash(`${currentPage.href}:${page.href}`),
+      }))
+    )
+    .filter(({ page }) => isEligibleRelatedPage(page, excludedHrefs))
+    .sort(compareRankedPages);
+
+  return rankedPages.slice(0, limit).map(({ page }) => page);
+}
+
+export function toLinkStripItems(pages: SitemapPage[]): LinkStripItem[] {
+  return pages.map((page) => ({
+    label: cleanPreviewTitle(page.preview.title),
+    href: page.href,
+  }));
+}
+
+export function toRelatedGuideCards(pages: SitemapPage[]): RelatedGuideCard[] {
+  return pages.map((page) => ({
+    href: page.href,
+    title: cleanPreviewTitle(page.preview.title),
+    description: page.preview.description,
+  }));
+}
+
+function isEligibleRelatedPage(page: SitemapPage, excludedHrefs: Set<string>): boolean {
+  if (excludedHrefs.has(page.href)) {
+    return false;
+  }
+
+  if (page.noindex || page.pageType === 'attractor' || page.pageType === 'informer') {
+    return false;
+  }
+
+  return true;
+}
+
+function countTopicOverlap(currentTopics: Set<string>, candidateTopics: string[] | undefined): number {
+  if (currentTopics.size === 0 || !candidateTopics?.length) {
+    return 0;
+  }
+
+  return candidateTopics.filter((topic) => currentTopics.has(topic)).length;
+}
+
+function getPageTypeRank(page: SitemapPage): number {
+  if (page.pageType === 'converter') {
+    return 3;
+  }
+
+  if (page.pageType === 'collector' && page.collectorSubtype === 'article') {
+    return 2;
+  }
+
+  if (page.pageType === 'collector' && page.collectorSubtype === 'section') {
+    return 1;
+  }
+
+  return 0;
+}
+
+function compareRankedPages(a: RankedPage, b: RankedPage): number {
+  return compareAscending(a.pinnedIndex, b.pinnedIndex)
+    || compareDescending(a.topicOverlap, b.topicOverlap)
+    || compareDescending(a.sameSection, b.sameSection)
+    || compareDescending(a.pageTypeRank, b.pageTypeRank)
+    || compareAscending(a.tieBreaker, b.tieBreaker)
+    || a.page.href.localeCompare(b.page.href);
+}
+
+function compareAscending(a: number, b: number): number {
+  return a - b;
+}
+
+function compareDescending(a: number, b: number): number {
+  return b - a;
+}
+
+function stableHash(value: string): number {
+  let hash = 0;
+
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash * 31 + value.charCodeAt(index)) >>> 0;
+  }
+
+  return hash;
+}
+
+function cleanPreviewTitle(title: string): string {
+  return title.replace(/\s+\|\s+Chill-Dogs$/, '');
+}


### PR DESCRIPTION
## Summary

- add sitemap related metadata fields and a typed topic vocabulary
- add `getRelatedPages` plus adapters for `InternalLinkStrip` and `RelatedGuides`
- document how related-content metadata should be authored before rendering migration starts

## Notes

This is Wave 1 only. It does not change public rendering; existing manual `InternalLinkStrip` and `RelatedGuides` arrays remain active until later migration waves.

## Validation

- `bun run test`
- `bun run build`
- commit hook also ran `bun run test` and `bun run test:smoke`