### PR TITLE
Derive converter related content from sitemap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,8 @@ Repository guidance for coding agents working in `/Volumes/wanderer/dev/solo/chi
 - Complete sitemap inventory is the source of truth for related links. Static pages register metadata in `src/data/content-sitemap.ts`; article collectors can define metadata in MDX frontmatter.
 - Use `topics` as ranking signals when a section is too broad to infer good relationships.
 - Use `pinnedRelated` only for intentional editorial relationships, and `excludeRelated` for poor or conflicting matches. Exclusion wins over pinning.
-- Related derivation is available through `src/utils/related-pages.ts`, but existing rendered `InternalLinkStrip` and `RelatedGuides` arrays stay in place until their migration wave.
+- Use `relatedLabel` when a derived internal-link pill should be shorter than the page title.
+- Related derivation is active for migrated article/tracking `InternalLinkStrip` instances via `currentHref`. Manual arrays still exist for converter configs and `RelatedGuides` until their migration waves.
 - Keep article pages as `pageType: 'collector'` with `collectorSubtype: 'article'`; do not invent page types.
 
 ### Completion Gates

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ Repository guidance for coding agents working in `/Volumes/wanderer/dev/solo/chi
 - Use `topics` as ranking signals when a section is too broad to infer good relationships.
 - Use `pinnedRelated` only for intentional editorial relationships, and `excludeRelated` for poor or conflicting matches. Exclusion wins over pinning.
 - Use `relatedLabel` when a derived internal-link pill should be shorter than the page title.
-- Related derivation is active for migrated article/tracking and cooling converter `InternalLinkStrip` instances via `currentHref`. Manual arrays still exist for calming/comfort converter configs and `RelatedGuides` until their migration waves.
+- Related derivation is active for `InternalLinkStrip` and `RelatedGuides` in migrated article/tracking and converter flows via `currentHref`. Do not add new manual related arrays.
 - Keep article pages as `pageType: 'collector'` with `collectorSubtype: 'article'`; do not invent page types.
 
 ### Completion Gates

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ Repository guidance for coding agents working in `/Volumes/wanderer/dev/solo/chi
 - Use `topics` as ranking signals when a section is too broad to infer good relationships.
 - Use `pinnedRelated` only for intentional editorial relationships, and `excludeRelated` for poor or conflicting matches. Exclusion wins over pinning.
 - Use `relatedLabel` when a derived internal-link pill should be shorter than the page title.
-- Related derivation is active for migrated article/tracking `InternalLinkStrip` instances via `currentHref`. Manual arrays still exist for converter configs and `RelatedGuides` until their migration waves.
+- Related derivation is active for migrated article/tracking and cooling converter `InternalLinkStrip` instances via `currentHref`. Manual arrays still exist for calming/comfort converter configs and `RelatedGuides` until their migration waves.
 - Keep article pages as `pageType: 'collector'` with `collectorSubtype: 'article'`; do not invent page types.
 
 ### Completion Gates

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ bun run check:asins -- --quiet  # Same, issues only
 - Use `excludeRelated` to prevent poor, redundant, or conflicting recommendations. Exclusion wins over pinning.
 - Use `relatedLabel` when a derived `InternalLinkStrip` pill needs shorter text than the page title.
 - Keep the official page model: `pageType: 'collector'` plus `collectorSubtype: 'article' | 'section'`. Do not invent fake page types such as `article-collector`.
-- Derived `InternalLinkStrip` is active for migrated article/tracking pages through the `currentHref` prop. Existing manual arrays remain in converter configs and `RelatedGuides` until their migration waves.
+- Derived `InternalLinkStrip` is active for migrated article/tracking pages and cooling converters through the `currentHref` prop. Existing manual arrays remain in calming/comfort converter configs and `RelatedGuides` until their migration waves.
 
 ## Governing Principles
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ bun run check:asins -- --quiet  # Same, issues only
 - Use `excludeRelated` to prevent poor, redundant, or conflicting recommendations. Exclusion wins over pinning.
 - Use `relatedLabel` when a derived `InternalLinkStrip` pill needs shorter text than the page title.
 - Keep the official page model: `pageType: 'collector'` plus `collectorSubtype: 'article' | 'section'`. Do not invent fake page types such as `article-collector`.
-- Derived `InternalLinkStrip` is active for migrated article/tracking pages and cooling converters through the `currentHref` prop. Existing manual arrays remain in calming/comfort converter configs and `RelatedGuides` until their migration waves.
+- Derived `InternalLinkStrip` and `RelatedGuides` are active in migrated article/tracking and converter flows through the `currentHref` prop. Do not add new manual related arrays.
 
 ## Governing Principles
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,8 +30,9 @@ bun run check:asins -- --quiet  # Same, issues only
 - New pages should define `topics` when section membership is too broad to rank related pages well, especially Comfort, Travel, Tracking, Cooling, and Calming overlap.
 - Use `pinnedRelated` only for intentional editorial relationships that should outrank algorithmic matches.
 - Use `excludeRelated` to prevent poor, redundant, or conflicting recommendations. Exclusion wins over pinning.
+- Use `relatedLabel` when a derived `InternalLinkStrip` pill needs shorter text than the page title.
 - Keep the official page model: `pageType: 'collector'` plus `collectorSubtype: 'article' | 'section'`. Do not invent fake page types such as `article-collector`.
-- Wave 1 only makes metadata and helper functions available; existing rendered `InternalLinkStrip` and `RelatedGuides` arrays remain in place until the migration wave for that page type.
+- Derived `InternalLinkStrip` is active for migrated article/tracking pages through the `currentHref` prop. Existing manual arrays remain in converter configs and `RelatedGuides` until their migration waves.
 
 ## Governing Principles
 

--- a/docs/article-writing-guide.md
+++ b/docs/article-writing-guide.md
@@ -96,9 +96,10 @@ Related metadata may also be added in frontmatter:
 topics: [travel, road-trips, car-cooling]
 pinnedRelated: ['/cooling/car-cooling-for-dogs/']
 excludeRelated: ['/privacy-policy/']
+relatedLabel: 'Road Trip Gear'
 ```
 
-Until the related-content migration reaches article collectors, `InternalLinkStrip` remains manually rendered in the article body. Once migration is active, authors should manage relationship intent through `topics`, `pinnedRelated`, and `excludeRelated`.
+For migrated article collectors, render `InternalLinkStrip` with `currentHref` and keep relationship intent in `topics`, `pinnedRelated`, `excludeRelated`, and `relatedLabel`. Manual `links` arrays may still exist on older converter modules until those migration waves are complete.
 
 **`Disclosure`** — Required on any article that renders inline product cards. Place it after the prose, before or after `FAQ`. If no product cards appear inline, `Disclosure` is optional (the footer disclosure covers it).
 
@@ -222,13 +223,13 @@ Before submitting or shipping an article collector:
 
 - [ ] Page type declared: `collector · article`
 - [ ] Registered in the complete sitemap inventory
-- [ ] Added related metadata in frontmatter where useful: `topics`, `pinnedRelated`, `excludeRelated`
+- [ ] Added related metadata in frontmatter where useful: `topics`, `pinnedRelated`, `excludeRelated`, `relatedLabel`
 - [ ] Added to `docs/system-definition.yaml`
 - [ ] `Article` JSON-LD present with all required fields
 - [ ] `Toc` module included (if 4+ h2 sections) with matching `id` attributes
 - [ ] `FAQ` module included (minimum 3 questions)
 - [ ] `InternalLinkStrip` at the bottom, linking to relevant converters
-- [ ] Manual `InternalLinkStrip` kept in place unless this page type has been migrated to derived related links
+- [ ] `InternalLinkStrip` uses `currentHref` on migrated article collectors; manual `links` arrays are used only where migration has not reached yet
 - [ ] `Disclosure` included if inline product cards are present
 - [ ] No vet-authority language
 - [ ] No "we tested" claims

--- a/docs/article-writing-guide.md
+++ b/docs/article-writing-guide.md
@@ -99,7 +99,7 @@ excludeRelated: ['/privacy-policy/']
 relatedLabel: 'Road Trip Gear'
 ```
 
-For migrated article collectors, render `InternalLinkStrip` with `currentHref` and keep relationship intent in `topics`, `pinnedRelated`, `excludeRelated`, and `relatedLabel`. Manual `links` arrays may still exist on older converter modules until those migration waves are complete.
+For migrated article collectors, render `InternalLinkStrip` with `currentHref` and keep relationship intent in `topics`, `pinnedRelated`, `excludeRelated`, and `relatedLabel`. Do not add new manual related arrays.
 
 **`Disclosure`** — Required on any article that renders inline product cards. Place it after the prose, before or after `FAQ`. If no product cards appear inline, `Disclosure` is optional (the footer disclosure covers it).
 
@@ -229,7 +229,7 @@ Before submitting or shipping an article collector:
 - [ ] `Toc` module included (if 4+ h2 sections) with matching `id` attributes
 - [ ] `FAQ` module included (minimum 3 questions)
 - [ ] `InternalLinkStrip` at the bottom, linking to relevant converters
-- [ ] `InternalLinkStrip` uses `currentHref` on migrated article collectors; manual `links` arrays are used only where migration has not reached yet
+- [ ] `InternalLinkStrip` uses `currentHref` on migrated article collectors
 - [ ] `Disclosure` included if inline product cards are present
 - [ ] No vet-authority language
 - [ ] No "we tested" claims

--- a/docs/related-content.md
+++ b/docs/related-content.md
@@ -1,6 +1,6 @@
 # Related Content
 
-This document explains the related-content system. Derived `InternalLinkStrip` rendering is active for migrated article/tracking pages and cooling converters; calming/comfort converter configs and `RelatedGuides` still use manual arrays until later migration waves.
+This document explains the related-content system. Derived `InternalLinkStrip` and `RelatedGuides` rendering is active for migrated article/tracking and converter flows. New related relationships should be managed through sitemap metadata, not manual arrays.
 
 ## Source Of Truth
 
@@ -54,5 +54,5 @@ When adding a page:
 - Add `topics` if the page belongs to a broad section like Comfort, Travel, or Tracking.
 - Add `pinnedRelated` only for editorially important relationships.
 - Add `excludeRelated` when an automatic match would be unhelpful.
-- Use `currentHref` on migrated `InternalLinkStrip` instances instead of passing manual `links`.
-- Keep manual rendered related arrays in place for calming/comfort converter configs and `RelatedGuides` until the relevant migration wave replaces them.
+- Use `currentHref` on migrated `InternalLinkStrip` and `RelatedGuides` instances instead of passing manual `links` or `guides`.
+- Do not add new manual rendered related arrays; encode relationship intent in sitemap metadata.

--- a/docs/related-content.md
+++ b/docs/related-content.md
@@ -1,6 +1,6 @@
 # Related Content
 
-This document explains the Wave 1 related-content system. The helper and metadata are available, but public rendering still uses existing manual `InternalLinkStrip` and `RelatedGuides` arrays until later migration waves.
+This document explains the related-content system. Derived `InternalLinkStrip` rendering is active for migrated article and tracking pages; converter config arrays and `RelatedGuides` still use manual arrays until later migration waves.
 
 ## Source Of Truth
 
@@ -24,11 +24,13 @@ pinnedRelated:
   - /cooling/car-cooling-for-dogs/
 excludeRelated:
   - /cooling/freezable-dog-toys/
+relatedLabel: 'Car Cooling Picks'
 ```
 
 - `topics` are ranking signals, not mandatory filters. Use them when a section is too broad to produce good matches.
 - `pinnedRelated` is for intentional editorial relationships that should outrank algorithmic matches.
 - `excludeRelated` prevents poor, redundant, or conflicting recommendations.
+- `relatedLabel` gives derived `InternalLinkStrip` a short pill label without changing page titles or share previews.
 - If a href appears in both `pinnedRelated` and `excludeRelated`, exclusion wins.
 
 ## Ranking
@@ -52,4 +54,5 @@ When adding a page:
 - Add `topics` if the page belongs to a broad section like Comfort, Travel, or Tracking.
 - Add `pinnedRelated` only for editorially important relationships.
 - Add `excludeRelated` when an automatic match would be unhelpful.
-- Keep manual rendered related arrays in place until the relevant migration wave replaces them.
+- Use `currentHref` on migrated `InternalLinkStrip` instances instead of passing manual `links`.
+- Keep manual rendered related arrays in place for converter configs and `RelatedGuides` until the relevant migration wave replaces them.

--- a/docs/related-content.md
+++ b/docs/related-content.md
@@ -1,6 +1,6 @@
 # Related Content
 
-This document explains the related-content system. Derived `InternalLinkStrip` rendering is active for migrated article and tracking pages; converter config arrays and `RelatedGuides` still use manual arrays until later migration waves.
+This document explains the related-content system. Derived `InternalLinkStrip` rendering is active for migrated article/tracking pages and cooling converters; calming/comfort converter configs and `RelatedGuides` still use manual arrays until later migration waves.
 
 ## Source Of Truth
 
@@ -55,4 +55,4 @@ When adding a page:
 - Add `pinnedRelated` only for editorially important relationships.
 - Add `excludeRelated` when an automatic match would be unhelpful.
 - Use `currentHref` on migrated `InternalLinkStrip` instances instead of passing manual `links`.
-- Keep manual rendered related arrays in place for converter configs and `RelatedGuides` until the relevant migration wave replaces them.
+- Keep manual rendered related arrays in place for calming/comfort converter configs and `RelatedGuides` until the relevant migration wave replaces them.

--- a/docs/system-definition.yaml
+++ b/docs/system-definition.yaml
@@ -26,7 +26,7 @@ site_system:
       - "CLAUDE.md"
 
   related_content:
-    status: "active_for_article_tracking_and_cooling_converter_internal_link_strip"
+    status: "active_for_migrated_internal_link_strip_and_related_guides"
     source_of_truth: "complete build-time sitemap inventory"
     helper: "src/utils/related-pages.ts"
     metadata_fields:
@@ -35,10 +35,11 @@ site_system:
       - "excludeRelated"
       - "relatedLabel"
     notes: >
-      Related-link derivation is active for migrated article/tracking and cooling converter
-      InternalLinkStrip instances via currentHref. Calming/comfort converter configs and
-      RelatedGuides still use existing manual arrays until their migration waves activate
-      the helper.
+      Related-link derivation is active for migrated InternalLinkStrip and RelatedGuides
+      instances via currentHref. New related relationships should be encoded as sitemap
+      metadata rather than manual rendered arrays. Manual related arrays are deprecated
+      now that related-content migration has started; preserve editorial intent with
+      pinnedRelated and excludeRelated instead.
 
   keystone_metrics:
     primary: "Amazon affiliate revenue (qualified outbound clicks to purchases)"

--- a/docs/system-definition.yaml
+++ b/docs/system-definition.yaml
@@ -26,18 +26,18 @@ site_system:
       - "CLAUDE.md"
 
   related_content:
-    status: "metadata_and_helper_available_not_rendering_active"
+    status: "active_for_article_and_tracking_internal_link_strip"
     source_of_truth: "complete build-time sitemap inventory"
     helper: "src/utils/related-pages.ts"
     metadata_fields:
       - "topics"
       - "pinnedRelated"
       - "excludeRelated"
+      - "relatedLabel"
     notes: >
-      Related-link derivation is available through sitemap metadata, but public rendering
-      still uses existing manual InternalLinkStrip and RelatedGuides arrays until migration
-      waves activate the helper by page type. Manual related arrays become deprecated only
-      after the relevant migration starts.
+      Related-link derivation is active for migrated article/tracking InternalLinkStrip
+      instances via currentHref. Converter config arrays and RelatedGuides still use
+      existing manual arrays until their migration waves activate the helper.
 
   keystone_metrics:
     primary: "Amazon affiliate revenue (qualified outbound clicks to purchases)"

--- a/docs/system-definition.yaml
+++ b/docs/system-definition.yaml
@@ -26,7 +26,7 @@ site_system:
       - "CLAUDE.md"
 
   related_content:
-    status: "active_for_article_and_tracking_internal_link_strip"
+    status: "active_for_article_tracking_and_cooling_converter_internal_link_strip"
     source_of_truth: "complete build-time sitemap inventory"
     helper: "src/utils/related-pages.ts"
     metadata_fields:
@@ -35,9 +35,10 @@ site_system:
       - "excludeRelated"
       - "relatedLabel"
     notes: >
-      Related-link derivation is active for migrated article/tracking InternalLinkStrip
-      instances via currentHref. Converter config arrays and RelatedGuides still use
-      existing manual arrays until their migration waves activate the helper.
+      Related-link derivation is active for migrated article/tracking and cooling converter
+      InternalLinkStrip instances via currentHref. Calming/comfort converter configs and
+      RelatedGuides still use existing manual arrays until their migration waves activate
+      the helper.
 
   keystone_metrics:
     primary: "Amazon affiliate revenue (qualified outbound clicks to purchases)"

--- a/src/__tests__/cooling-products.test.ts
+++ b/src/__tests__/cooling-products.test.ts
@@ -13,7 +13,7 @@ describe('cooling product data integrity', () => {
     }
   });
 
-  it('every category has complete meta with FAQs and internal links', () => {
+  it('every category has complete meta with FAQs', () => {
     const categories: ProductCategory[] = [
       'cooling-mats',
       'cooling-bandanas',
@@ -28,11 +28,6 @@ describe('cooling product data integrity', () => {
       expect(meta.heroHeadline).toBeTruthy();
       expect(meta.introCopy).toBeTruthy();
       expect(meta.faqs.length).toBeGreaterThan(0);
-
-      for (const link of meta.internalLinks) {
-        expect(link.label).toBeTruthy();
-        expect(link.href).toMatch(/^\//);
-      }
     }
   });
 });

--- a/src/__tests__/related-pages.test.ts
+++ b/src/__tests__/related-pages.test.ts
@@ -198,6 +198,8 @@ describe('related pages', () => {
         createPage({ href: '/travel/rhys-ran-away-cerro-san-luis-obispo/', pageType: 'collector', collectorSubtype: 'article' }),
         createPage({ href: '/safety/what-to-do-if-your-dog-runs-away/', pageType: 'collector', collectorSubtype: 'article' }),
         createPage({ href: '/travel/dog-road-trip-gear/', pageType: 'collector', collectorSubtype: 'article' }),
+        createPage({ href: '/calming/crate-training-for-dogs/', pageType: 'collector', collectorSubtype: 'article' }),
+        createPage({ href: '/travel/how-to-fly-with-a-dog/', pageType: 'collector', collectorSubtype: 'article' }),
       ]),
     ];
     const pages = sections.flatMap((section) => section.pages);
@@ -212,6 +214,19 @@ describe('related pages', () => {
       '/cooling/cooling-bandanas/',
       '/cooling/cooling-vests/',
       '/cooling/freezable-dog-toys/',
+      '/calming/best-calming-products-for-anxious-dogs/',
+      '/calming/best-thundershirt-alternatives/',
+      '/calming/car-anxiety-for-dogs/',
+      '/comforting/best-calming-dog-beds/',
+      '/comforting/best-orthopedic-dog-beds/',
+      '/comforting/best-puppy-crates/',
+      '/comforting/best-anxiety-dog-crates/',
+      '/comforting/best-travel-crates-for-road-trips/',
+      '/comforting/best-airline-crates-for-flying-with-your-dog/',
+      '/comforting/best-airline-approved-dog-carriers/',
+      '/comforting/best-dog-travel-bags-for-flying/',
+      '/comforting/best-furniture-dog-crates/',
+      '/comforting/best-heavy-duty-dog-crates/',
     ];
 
     for (const href of migratedHrefs) {

--- a/src/__tests__/related-pages.test.ts
+++ b/src/__tests__/related-pages.test.ts
@@ -207,6 +207,11 @@ describe('related pages', () => {
       '/gear/fi-dog-collar-review/',
       '/gear/garmin-dog-tracking-collars/',
       '/gear/airtag-for-dogs/',
+      '/cooling/car-cooling-for-dogs/',
+      '/cooling/cooling-mats/',
+      '/cooling/cooling-bandanas/',
+      '/cooling/cooling-vests/',
+      '/cooling/freezable-dog-toys/',
     ];
 
     for (const href of migratedHrefs) {

--- a/src/__tests__/related-pages.test.ts
+++ b/src/__tests__/related-pages.test.ts
@@ -12,6 +12,7 @@ function createPage(input: {
   topics?: SitemapTopic[];
   pinnedRelated?: string[];
   excludeRelated?: string[];
+  relatedLabel?: string;
   noindex?: boolean;
 }): SitemapPage {
   const title = input.title ?? input.href;
@@ -23,6 +24,7 @@ function createPage(input: {
     topics: input.topics,
     pinnedRelated: input.pinnedRelated,
     excludeRelated: input.excludeRelated,
+    relatedLabel: input.relatedLabel,
     noindex: input.noindex,
     preview: {
       title,
@@ -170,12 +172,13 @@ describe('related pages', () => {
       createPage({
         href: '/cooling/cooling-mats/',
         title: 'Best Dog Cooling Mats | Chill-Dogs',
+        relatedLabel: 'Cooling Mat Picks',
       }),
     ];
 
     expect(toLinkStripItems(pages)).toEqual([
       {
-        label: 'Best Dog Cooling Mats',
+        label: 'Cooling Mat Picks',
         href: '/cooling/cooling-mats/',
       },
     ]);
@@ -186,6 +189,37 @@ describe('related pages', () => {
         description: 'Best Dog Cooling Mats | Chill-Dogs description',
       },
     ]);
+  });
+
+  it('keeps migrated static related hrefs in the complete sitemap and excludes self', async () => {
+    const sections = [
+      ...await getCompleteSitemapSections(),
+      createSection('Articles', [
+        createPage({ href: '/travel/rhys-ran-away-cerro-san-luis-obispo/', pageType: 'collector', collectorSubtype: 'article' }),
+        createPage({ href: '/safety/what-to-do-if-your-dog-runs-away/', pageType: 'collector', collectorSubtype: 'article' }),
+        createPage({ href: '/travel/dog-road-trip-gear/', pageType: 'collector', collectorSubtype: 'article' }),
+      ]),
+    ];
+    const pages = sections.flatMap((section) => section.pages);
+    const hrefs = new Set(pages.map((page) => page.href));
+    const migratedHrefs = [
+      '/gear/best-dog-gps-trackers/',
+      '/gear/fi-dog-collar-review/',
+      '/gear/garmin-dog-tracking-collars/',
+      '/gear/airtag-for-dogs/',
+    ];
+
+    for (const href of migratedHrefs) {
+      const page = pages.find((candidate) => candidate.href === href);
+      expect(page?.pinnedRelated?.length).toBeGreaterThan(0);
+
+      const related = await getRelatedPages({ currentHref: href, sections, limit: page?.pinnedRelated?.length });
+      expect(related.map((relatedPage) => relatedPage.href)).not.toContain(href);
+
+      for (const relatedHref of page?.pinnedRelated ?? []) {
+        expect(hrefs.has(relatedHref)).toBe(true);
+      }
+    }
   });
 
   it('resolves only hrefs that exist in the complete sitemap and never resolves self', async () => {

--- a/src/__tests__/site-smoke.test.ts
+++ b/src/__tests__/site-smoke.test.ts
@@ -142,6 +142,24 @@ describe('site smoke tests', () => {
           '/safety/what-to-do-if-your-dog-runs-away/',
         ],
       },
+      {
+        page: path.join('cooling', 'cooling-mats', 'index.html'),
+        expected: [
+          '/cooling/cooling-bandanas/',
+          '/cooling/cooling-vests/',
+          '/cooling/freezable-dog-toys/',
+          '/cooling/best-cooling-products-for-dogs/',
+        ],
+      },
+      {
+        page: path.join('cooling', 'car-cooling-for-dogs', 'index.html'),
+        expected: [
+          '/travel/dog-road-trip-gear/',
+          '/cooling/cooling-mats/',
+          '/cooling/cooling-vests/',
+          '/cooling/best-cooling-products-for-dogs/',
+        ],
+      },
     ];
 
     for (const testCase of cases) {

--- a/src/__tests__/site-smoke.test.ts
+++ b/src/__tests__/site-smoke.test.ts
@@ -115,7 +115,7 @@ describe('site smoke tests', () => {
     expect(links).toContain('/comforting/best-travel-crates-for-road-trips/');
   });
 
-  it('renders derived InternalLinkStrip links on migrated article and tracking pages', () => {
+  it('renders derived InternalLinkStrip links on migrated pages', () => {
     const cases = [
       {
         page: path.join('cooling', 'keep-dog-cool-in-car', 'index.html'),
@@ -160,11 +160,58 @@ describe('site smoke tests', () => {
           '/cooling/best-cooling-products-for-dogs/',
         ],
       },
+      {
+        page: path.join('calming', 'best-calming-products-for-anxious-dogs', 'index.html'),
+        expected: [
+          '/travel/dog-road-trip-gear/',
+          '/cooling/best-cooling-products-for-dogs/',
+          '/calming/',
+          '/calming/best-thundershirt-alternatives/',
+          '/gear/best-dog-gps-trackers/',
+          '/safety/what-to-do-if-your-dog-runs-away/',
+        ],
+      },
+      {
+        page: path.join('comforting', 'best-anxiety-dog-crates', 'index.html'),
+        expected: [
+          '/calming/crate-training-for-dogs/',
+          '/calming/best-calming-products-for-anxious-dogs/',
+          '/comforting/best-heavy-duty-dog-crates/',
+          '/comforting/best-puppy-crates/',
+        ],
+      },
     ];
 
     for (const testCase of cases) {
       const doc = readBuiltPage(testCase.page);
       const links = Array.from(doc.querySelectorAll<HTMLAnchorElement>('.ils-link'));
+
+      expect(links.map((link) => link.getAttribute('href'))).toEqual(testCase.expected);
+      for (const link of links) {
+        expect(link.getAttribute('data-track')).toBe('collector_to_converter_click');
+      }
+    }
+  });
+
+  it('renders derived RelatedGuides cards on migrated converter pages', () => {
+    const cases = [
+      {
+        page: path.join('calming', 'best-calming-products-for-anxious-dogs', 'index.html'),
+        expected: ['/travel/dog-road-trip-gear/', '/cooling/best-cooling-products-for-dogs/'],
+      },
+      {
+        page: path.join('comforting', 'best-travel-crates-for-road-trips', 'index.html'),
+        expected: [
+          '/travel/dog-road-trip-gear/',
+          '/calming/crate-training-for-dogs/',
+          '/comforting/best-airline-crates-for-flying-with-your-dog/',
+        ],
+      },
+    ];
+
+    for (const testCase of cases) {
+      const doc = readBuiltPage(testCase.page);
+      const links = Array.from(doc.querySelectorAll<HTMLAnchorElement>('.related-guide-card'));
 
       expect(links.map((link) => link.getAttribute('href'))).toEqual(testCase.expected);
       for (const link of links) {

--- a/src/__tests__/site-smoke.test.ts
+++ b/src/__tests__/site-smoke.test.ts
@@ -115,6 +115,46 @@ describe('site smoke tests', () => {
     expect(links).toContain('/comforting/best-travel-crates-for-road-trips/');
   });
 
+  it('renders derived InternalLinkStrip links on migrated article and tracking pages', () => {
+    const cases = [
+      {
+        page: path.join('cooling', 'keep-dog-cool-in-car', 'index.html'),
+        expected: ['/cooling/car-cooling-for-dogs/', '/cooling/cooling-mats/', '/cooling/cooling-bandanas/', '/travel/dog-road-trip-gear/'],
+      },
+      {
+        page: path.join('travel', 'how-to-fly-with-a-dog', 'index.html'),
+        expected: [
+          '/comforting/best-airline-approved-dog-carriers/',
+          '/comforting/best-dog-travel-bags-for-flying/',
+          '/comforting/best-airline-crates-for-flying-with-your-dog/',
+          '/calming/best-calming-products-for-anxious-dogs/',
+          '/calming/car-anxiety-for-dogs/',
+          '/travel/dog-road-trip-gear/',
+        ],
+      },
+      {
+        page: path.join('gear', 'fi-dog-collar-review', 'index.html'),
+        expected: [
+          '/gear/best-dog-gps-trackers/',
+          '/gear/garmin-dog-tracking-collars/',
+          '/gear/airtag-for-dogs/',
+          '/travel/rhys-ran-away-cerro-san-luis-obispo/',
+          '/safety/what-to-do-if-your-dog-runs-away/',
+        ],
+      },
+    ];
+
+    for (const testCase of cases) {
+      const doc = readBuiltPage(testCase.page);
+      const links = Array.from(doc.querySelectorAll<HTMLAnchorElement>('.ils-link'));
+
+      expect(links.map((link) => link.getAttribute('href'))).toEqual(testCase.expected);
+      for (const link of links) {
+        expect(link.getAttribute('data-track')).toBe('collector_to_converter_click');
+      }
+    }
+  });
+
   it('orders homepage article cards by article publish date', () => {
     const doc = readBuiltPage('index.html');
     const renderedArticleLinks = [

--- a/src/__tests__/sitemap-inventory.test.ts
+++ b/src/__tests__/sitemap-inventory.test.ts
@@ -5,6 +5,7 @@ const articleEntries = [
     topics: ['travel', 'road-trips'],
     pinnedRelated: ['/cooling/car-cooling-for-dogs/'],
     excludeRelated: ['/privacy-policy/'],
+    relatedLabel: 'Dog Road Trip Gear',
   }),
   createArticle('/travel/rhys-ran-away-cerro-san-luis-obispo/', 'The Day Rhys Ran Off', '2026-03-21'),
   createArticle('/travel/how-to-fly-with-a-dog/', 'How to Fly With a Dog', '2026-04-10'),
@@ -38,6 +39,7 @@ function createArticle(
     topics?: string[];
     pinnedRelated?: string[];
     excludeRelated?: string[];
+    relatedLabel?: string;
   } = {}
 ) {
   return {
@@ -96,6 +98,7 @@ describe('sitemap inventory', () => {
     expect(roadTrip?.topics).toEqual(['travel', 'road-trips']);
     expect(roadTrip?.pinnedRelated).toEqual(['/cooling/car-cooling-for-dogs/']);
     expect(roadTrip?.excludeRelated).toEqual(['/privacy-policy/']);
+    expect(roadTrip?.relatedLabel).toBe('Dog Road Trip Gear');
   });
 
   it('places article collectors after entry points and before remaining static sections', async () => {

--- a/src/components/modules/CalmingConverterPage.astro
+++ b/src/components/modules/CalmingConverterPage.astro
@@ -169,18 +169,23 @@ function quickPickProduct(item: QuickPickItem) {
       </section>
     )}
 
-    {config.relatedGuides && (
-      <RelatedGuides heading={config.relatedGuides.heading} guides={config.relatedGuides.guides} />
+    {config.relatedGuidesHeading && (
+      <RelatedGuides
+        heading={config.relatedGuidesHeading}
+        currentHref={`/calming/${config.pageSlug}/`}
+        limit={config.relatedGuidesLimit}
+      />
     )}
 
     <CalmingDisclaimer variant={config.disclaimerVariant} />
 
     <Disclosure showSafety={config.disclosureShowSafety} />
 
-    {config.internalLinkStrip && (
+    {config.internalLinkStripHeading && (
       <InternalLinkStrip
-        heading={config.internalLinkStrip.heading}
-        links={config.internalLinkStrip.links}
+        heading={config.internalLinkStripHeading}
+        currentHref={`/calming/${config.pageSlug}/`}
+        limit={config.internalLinkStripLimit}
         fromPage={config.pageSlug}
       />
     )}

--- a/src/components/modules/CoolingConverterPage.astro
+++ b/src/components/modules/CoolingConverterPage.astro
@@ -74,7 +74,7 @@ const itemListSchema = {
     <Disclosure />
 
     <InternalLinkStrip
-      links={meta.internalLinks}
+      currentHref={`/cooling/${config.pageSlug}/`}
       fromPage={config.pageSlug}
       heading={config.linkStripHeading}
     />

--- a/src/components/modules/InternalLinkStrip.astro
+++ b/src/components/modules/InternalLinkStrip.astro
@@ -1,4 +1,6 @@
 ---
+import { getRelatedPages, toLinkStripItems } from '@utils/related-pages';
+
 interface LinkItem {
   label: string;
   href: string;
@@ -6,17 +8,20 @@ interface LinkItem {
 
 interface Props {
   heading?: string;
-  links: LinkItem[];
+  links?: LinkItem[];
+  currentHref?: string;
+  limit?: number;
   fromPage?: string;
 }
 
-const { heading = 'More Cooling Guides', links, fromPage = '' } = Astro.props;
+const { heading = 'More Cooling Guides', links, currentHref, limit, fromPage = '' } = Astro.props;
+const resolvedLinks = links ?? (currentHref ? toLinkStripItems(await getRelatedPages({ currentHref, limit })) : []);
 ---
 
 <nav class="ils" aria-label="Related guides">
   <h2 class="ils-heading">{heading}</h2>
   <ul class="ils-list">
-    {links.map((link) => (
+    {resolvedLinks.map((link) => (
       <li>
         <a
           href={link.href}

--- a/src/components/modules/RelatedGuides.astro
+++ b/src/components/modules/RelatedGuides.astro
@@ -1,4 +1,6 @@
 ---
+import { getRelatedPages, toRelatedGuideCards } from '@utils/related-pages';
+
 interface RelatedGuide {
   href: string;
   title: string;
@@ -7,17 +9,20 @@ interface RelatedGuide {
 
 interface Props {
   heading?: string;
-  guides: RelatedGuide[];
+  guides?: RelatedGuide[];
+  currentHref?: string;
+  limit?: number;
 }
 
-const { heading = 'Related Guides', guides } = Astro.props;
+const { heading = 'Related Guides', guides, currentHref, limit } = Astro.props;
+const resolvedGuides = guides ?? (currentHref ? toRelatedGuideCards(await getRelatedPages({ currentHref, limit })) : []);
 ---
 
 <section class="related-guides">
   <div class="related-guides-inner">
     <h2>{heading}</h2>
     <div class="related-guides-grid">
-      {guides.map(({ href, title, description }) => (
+      {resolvedGuides.map(({ href, title, description }) => (
         <a
           href={href}
           class="related-guide-card"

--- a/src/components/modules/RelaxationConverterPage.astro
+++ b/src/components/modules/RelaxationConverterPage.astro
@@ -159,16 +159,21 @@ function quickPickProduct(item: QuickPickItem) {
       </section>
     )}
 
-    {config.relatedGuides && (
-      <RelatedGuides heading={config.relatedGuides.heading} guides={config.relatedGuides.guides} />
+    {config.relatedGuidesHeading && (
+      <RelatedGuides
+        heading={config.relatedGuidesHeading}
+        currentHref={`/comforting/${config.pageSlug}/`}
+        limit={config.relatedGuidesLimit}
+      />
     )}
 
     <Disclosure showSafety={config.disclosureShowSafety} />
 
-    {config.internalLinkStrip && (
+    {config.internalLinkStripHeading && (
       <InternalLinkStrip
-        heading={config.internalLinkStrip.heading}
-        links={config.internalLinkStrip.links}
+        heading={config.internalLinkStripHeading}
+        currentHref={`/comforting/${config.pageSlug}/`}
+        limit={config.internalLinkStripLimit}
         fromPage={config.pageSlug}
       />
     )}

--- a/src/content/articles/calming-crate-training-for-dogs.mdx
+++ b/src/content/articles/calming-crate-training-for-dogs.mdx
@@ -3,6 +3,16 @@ title: 'How to Crate Train Your Dog'
 description: "Crate training gives your dog a safe, familiar space. It is a practical tool for housebreaking, anxiety management, and travel. Here's how to do it right."
 pubDate: 2026-04-09
 canonicalPath: '/calming/crate-training-for-dogs/'
+topics: [calming, comfort, crates, crate-training, anxiety]
+pinnedRelated:
+  - '/comforting/best-puppy-crates/'
+  - '/comforting/best-anxiety-dog-crates/'
+  - '/comforting/best-furniture-dog-crates/'
+  - '/comforting/best-heavy-duty-dog-crates/'
+  - '/comforting/best-travel-crates-for-road-trips/'
+  - '/calming/best-calming-products-for-anxious-dogs/'
+  - '/comforting/best-calming-dog-beds/'
+relatedLabel: 'Crate Training Guide'
 ---
 
 import Toc from '@components/modules/Toc.astro';
@@ -49,16 +59,6 @@ export const faqs = [
     answer:
       'For most dogs, yes — a machine-washable pad or blanket makes the crate more comfortable and inviting. However, some puppies or anxious dogs will shred bedding or use it as a potty spot. If that happens, try a bare crate floor or a chew-proof crate mat until the behavior settles.',
   },
-];
-
-export const internalLinks = [
-  { label: 'Best Puppy Crates', href: ROUTES.comfortPuppyCrates },
-  { label: 'Best Anxiety Dog Crates', href: ROUTES.comfortAnxietyCrates },
-  { label: 'Best Furniture Dog Crates', href: ROUTES.comfortFurnitureCrates },
-  { label: 'Best Heavy-Duty Dog Crates', href: ROUTES.comfortHeavyDutyCrates },
-  { label: 'Best Travel Crates', href: ROUTES.comfortTravelCrates },
-  { label: 'Best Calming Products for Anxious Dogs', href: ROUTES.calmingTop },
-  { label: 'Best Calming Dog Beds', href: ROUTES.comfortCalmingBeds },
 ];
 
 <article class="collector-article container">
@@ -231,5 +231,5 @@ export const internalLinks = [
 
   <FAQ faqs={faqs} />
 
-  <InternalLinkStrip links={internalLinks} fromPage={pageSlug} />
+  <InternalLinkStrip currentHref="/calming/crate-training-for-dogs/" limit={7} fromPage={pageSlug} />
 </article>

--- a/src/content/articles/comforting-how-much-do-dogs-sleep.mdx
+++ b/src/content/articles/comforting-how-much-do-dogs-sleep.mdx
@@ -3,6 +3,12 @@ title: 'How Much Do Dogs Sleep? What Rest Really Looks Like'
 description: "Most adult dogs sleep 12 to 14 hours a day — and sleep quality matters as much as quantity. Here's what normal rest looks like, what disrupts it, and how to help."
 pubDate: 2026-03-24
 canonicalPath: '/comforting/how-much-do-dogs-sleep/'
+topics: [comfort, sleep, beds]
+pinnedRelated:
+  - '/comforting/best-calming-dog-beds/'
+  - '/comforting/best-orthopedic-dog-beds/'
+  - '/comforting/'
+relatedLabel: 'How Much Do Dogs Sleep?'
 ---
 
 import Toc from '@components/modules/Toc.astro';
@@ -41,12 +47,6 @@ export const faqs = [
     question: 'What kind of bed helps a dog sleep better?',
     answer: "It depends on your dog's sleep style and age. Dogs who curl up tightly or press against walls tend to sleep better with a raised-rim or donut-shaped bed. Older dogs, large breeds, and dogs with joint issues benefit most from orthopedic foam that distributes weight evenly and holds its shape over time. A flat, thin, or collapsed bed causes dogs to frequently shift positions, which disrupts their sleep and yours.",
   },
-];
-
-export const internalLinks = [
-  { label: 'Best Calming Dog Beds', href: '/comforting/best-calming-dog-beds/' },
-  { label: 'Best Orthopedic Dog Beds', href: '/comforting/best-orthopedic-dog-beds/' },
-  { label: 'Comfort & Rest Hub', href: '/comforting/' },
 ];
 
 <article class="collector-article container">
@@ -186,7 +186,7 @@ export const internalLinks = [
 
   <FAQ faqs={faqs} />
 
-  <InternalLinkStrip links={internalLinks} fromPage="how-much-do-dogs-sleep" />
+  <InternalLinkStrip currentHref="/comforting/how-much-do-dogs-sleep/" limit={3} fromPage="how-much-do-dogs-sleep" />
 
   <Disclosure />
 </article>

--- a/src/content/articles/cooling-how-hot-is-too-hot-for-dogs.mdx
+++ b/src/content/articles/cooling-how-hot-is-too-hot-for-dogs.mdx
@@ -3,6 +3,13 @@ title: 'How Hot Is Too Hot for Dogs?'
 description: 'A practical temperature guide for dog owners: when heat is safe, when to take caution, and how to protect your dog from overheating.'
 pubDate: 2026-03-10
 canonicalPath: '/cooling/how-hot-is-too-hot-for-dogs/'
+topics: [cooling, heat-safety]
+pinnedRelated:
+  - '/cooling/cooling-mats/'
+  - '/cooling/cooling-vests/'
+  - '/cooling/cooling-bandanas/'
+  - '/cooling/freezable-dog-toys/'
+relatedLabel: 'How Hot Is Too Hot?'
 ---
 
 import FAQ from '@components/modules/FAQ.astro';
@@ -22,13 +29,6 @@ export const faqs = [
     question: 'What temperature do dogs overheat?',
     answer: "Many dogs begin to struggle once temperatures reach roughly 85–90 °F, particularly in direct sun or high humidity. Brachycephalic (flat-faced) breeds, senior dogs, and overweight dogs may show signs of heat stress at lower temperatures. No single threshold applies to every dog — knowing your individual dog's limits matters.",
   },
-];
-
-export const internalLinks = [
-  { label: 'Best Cooling Mats', href: '/cooling/cooling-mats/' },
-  { label: 'Best Cooling Vests', href: '/cooling/cooling-vests/' },
-  { label: 'Best Cooling Bandanas', href: '/cooling/cooling-bandanas/' },
-  { label: 'Freezable Dog Toys', href: '/cooling/freezable-dog-toys/' },
 ];
 
 <article class="collector-article container">
@@ -124,5 +124,5 @@ export const internalLinks = [
 
   <FAQ faqs={faqs} />
 
-  <InternalLinkStrip links={internalLinks} fromPage="how-hot-is-too-hot-for-dogs" />
+  <InternalLinkStrip currentHref="/cooling/how-hot-is-too-hot-for-dogs/" limit={4} fromPage="how-hot-is-too-hot-for-dogs" />
 </article>

--- a/src/content/articles/cooling-keep-dog-cool-in-car.mdx
+++ b/src/content/articles/cooling-keep-dog-cool-in-car.mdx
@@ -3,6 +3,13 @@ title: 'How to Keep a Dog Cool in a Car'
 description: 'The back seat gets hotter than you think — even with the AC running. These products help keep your dog comfortable on any drive.'
 pubDate: 2026-03-17
 canonicalPath: '/cooling/keep-dog-cool-in-car/'
+topics: [cooling, heat-safety, car-cooling, travel, road-trips]
+pinnedRelated:
+  - '/cooling/car-cooling-for-dogs/'
+  - '/cooling/cooling-mats/'
+  - '/cooling/cooling-bandanas/'
+  - '/travel/dog-road-trip-gear/'
+relatedLabel: 'Keep a Dog Cool in a Car'
 ---
 
 import Toc from '@components/modules/Toc.astro';
@@ -10,7 +17,6 @@ import CarCoolingArticleProducts from '@components/modules/CarCoolingArticleProd
 import FAQ from '@components/modules/FAQ.astro';
 import InternalLinkStrip from '@components/modules/InternalLinkStrip.astro';
 import Disclosure from '@components/modules/Disclosure.astro';
-import { ROUTES } from '@data/routes';
 
 export const tocHeadings = [
   { label: 'Why the back seat gets so hot', anchor: 'back-seat-heat' },
@@ -41,13 +47,6 @@ export const faqs = [
     question: 'Are some dogs at higher risk of overheating in the car?',
     answer: 'Yes. Brachycephalic breeds (Bulldogs, Pugs, Boston Terriers, Boxers) have restricted airways and overheat faster. Overweight dogs, senior dogs, puppies, and dark or double-coated dogs are also at elevated risk. These dogs need extra airflow and shorter drive windows. Consider using a cooling vest or bandana.',
   },
-];
-
-export const internalLinks = [
-  { label: 'Best Car Cooling Products', href: '/cooling/car-cooling-for-dogs/' },
-  { label: 'Best Cooling Mats', href: '/cooling/cooling-mats/' },
-  { label: 'Best Cooling Bandanas', href: '/cooling/cooling-bandanas/' },
-  { label: 'Road Trip Chill Kit', href: '/travel/dog-road-trip-gear/' },
 ];
 
 <article class="collector-article container">
@@ -155,7 +154,7 @@ export const internalLinks = [
 
   <FAQ faqs={faqs} />
 
-  <InternalLinkStrip links={internalLinks} fromPage="keep-dog-cool-in-car" />
+  <InternalLinkStrip currentHref="/cooling/keep-dog-cool-in-car/" limit={4} fromPage="keep-dog-cool-in-car" />
 
   <Disclosure />
 </article>

--- a/src/content/articles/safety-what-to-do-if-your-dog-runs-away.mdx
+++ b/src/content/articles/safety-what-to-do-if-your-dog-runs-away.mdx
@@ -3,6 +3,14 @@ title: 'What to Do If Your Dog Runs Away: Step-by-Step Guide'
 description: 'A practical guide for the minutes and hours after a dog escapes — immediate search steps, community outreach, and how to prevent it with GPS trackers.'
 pubDate: 2026-04-03
 canonicalPath: '/safety/what-to-do-if-your-dog-runs-away/'
+topics: [tracking, gps-tracking, lost-dog-safety]
+pinnedRelated:
+  - '/gear/best-dog-gps-trackers/'
+  - '/gear/fi-dog-collar-review/'
+  - '/gear/garmin-dog-tracking-collars/'
+  - '/gear/airtag-for-dogs/'
+  - '/travel/rhys-ran-away-cerro-san-luis-obispo/'
+relatedLabel: 'Dog Ran Away Guide'
 ---
 
 import Hero from '@components/modules/Hero.astro';
@@ -354,13 +362,8 @@ export const faqs = [
 
   <InternalLinkStrip
     heading="Related Dog Safety Guides"
-    links={[
-      { label: 'Best GPS Trackers', href: '/gear/best-dog-gps-trackers/' },
-      { label: 'Fi Collar Review', href: '/gear/fi-dog-collar-review/' },
-      { label: 'Garmin Dog Tracking', href: '/gear/garmin-dog-tracking-collars/' },
-      { label: 'AirTag for Dogs', href: '/gear/airtag-for-dogs/' },
-      { label: 'When Rhys Ran Away', href: '/travel/rhys-ran-away-cerro-san-luis-obispo/' },
-    ]}
+    currentHref="/safety/what-to-do-if-your-dog-runs-away/"
+    limit={5}
     fromPage="what-to-do-if-your-dog-runs-away"
   />
 

--- a/src/content/articles/travel-dog-road-trip-gear.mdx
+++ b/src/content/articles/travel-dog-road-trip-gear.mdx
@@ -5,6 +5,13 @@ ogTitle: 'Dog Road Trip Gear | Cooling & Calming Essentials'
 pubDate: 2026-03-31
 canonicalPath: '/travel/dog-road-trip-gear/'
 ogImage: '../../images/watermarked/rhys-road-trip/20250629_131343.jpg'
+topics: [travel, road-trips, cooling, calming, car-cooling, car-anxiety, comfort, crates]
+pinnedRelated:
+  - '/comforting/best-travel-crates-for-road-trips/'
+  - '/cooling/car-cooling-for-dogs/'
+  - '/calming/car-anxiety-for-dogs/'
+  - '/calming/best-calming-products-for-anxious-dogs/'
+relatedLabel: 'Dog Road Trip Gear'
 ---
 
 import { Image } from 'astro:assets';
@@ -427,12 +434,8 @@ export const roadTripFaqs = [
 
   <InternalLinkStrip
     heading="More Dog Travel Guides"
-    links={[
-      { label: 'Travel Crates for Road Trips', href: '/comforting/best-travel-crates-for-road-trips/' },
-      { label: 'Car Cooling Picks', href: '/cooling/car-cooling-for-dogs/' },
-      { label: 'Car Anxiety Picks', href: '/calming/car-anxiety-for-dogs/' },
-      { label: 'All Calming Products', href: '/calming/best-calming-products-for-anxious-dogs/' },
-    ]}
+    currentHref="/travel/dog-road-trip-gear/"
+    limit={4}
     fromPage="dog-road-trip-gear"
   />
 

--- a/src/content/articles/travel-how-to-fly-with-a-dog.mdx
+++ b/src/content/articles/travel-how-to-fly-with-a-dog.mdx
@@ -4,6 +4,15 @@ description: 'A practical guide to flying with a dog: airline carrier rules, anx
 ogTitle: 'How to Fly With a Dog: Carriers, Anxiety, and Vet Questions'
 pubDate: 2026-04-10
 canonicalPath: '/travel/how-to-fly-with-a-dog/'
+topics: [travel, flying, carriers, calming, anxiety, comfort]
+pinnedRelated:
+  - '/comforting/best-airline-approved-dog-carriers/'
+  - '/comforting/best-dog-travel-bags-for-flying/'
+  - '/comforting/best-airline-crates-for-flying-with-your-dog/'
+  - '/calming/best-calming-products-for-anxious-dogs/'
+  - '/calming/car-anxiety-for-dogs/'
+  - '/travel/dog-road-trip-gear/'
+relatedLabel: 'Flying With a Dog'
 ---
 
 import Toc from '@components/modules/Toc.astro';
@@ -286,14 +295,8 @@ export const faqs = [
 
   <InternalLinkStrip
     heading="Related dog travel and calming guides"
-    links={[
-      { label: 'Best Airline-Approved Carriers', href: '/comforting/best-airline-approved-dog-carriers/' },
-      { label: 'Best Dog Travel Bags', href: '/comforting/best-dog-travel-bags-for-flying/' },
-      { label: 'Best Airline Crates', href: '/comforting/best-airline-crates-for-flying-with-your-dog/' },
-      { label: 'Best Calming Products for Anxious Dogs', href: '/calming/best-calming-products-for-anxious-dogs/' },
-      { label: 'Car Anxiety Picks', href: '/calming/car-anxiety-for-dogs/' },
-      { label: 'Dog Road Trip Gear', href: '/travel/dog-road-trip-gear/' },
-    ]}
+    currentHref="/travel/how-to-fly-with-a-dog/"
+    limit={6}
     fromPage="how-to-fly-with-a-dog"
   />
 

--- a/src/content/articles/travel-rhys-ran-away-cerro-san-luis-obispo.mdx
+++ b/src/content/articles/travel-rhys-ran-away-cerro-san-luis-obispo.mdx
@@ -5,6 +5,15 @@ ogTitle: 'The Day Rhys Ran Off: What We Learned About Dog Tracking'
 pubDate: 2026-03-21
 canonicalPath: '/travel/rhys-ran-away-cerro-san-luis-obispo/'
 ogImage: '../../images/watermarked/bishop-peak/bishop-peak-expert-trail-marker.jpg'
+topics: [tracking, gps-tracking, lost-dog-safety, travel]
+pinnedRelated:
+  - '/gear/best-dog-gps-trackers/'
+  - '/gear/fi-dog-collar-review/'
+  - '/gear/garmin-dog-tracking-collars/'
+  - '/gear/airtag-for-dogs/'
+  - '/safety/what-to-do-if-your-dog-runs-away/'
+  - '/travel/dog-road-trip-gear/'
+relatedLabel: 'When Rhys Ran Away'
 ---
 
 import { Image } from 'astro:assets';
@@ -390,14 +399,8 @@ export const faqs = [
 
   <InternalLinkStrip
     heading="More Dog Safety + Tracking Guides"
-    links={[
-      { label: 'Best GPS Trackers', href: '/gear/best-dog-gps-trackers/' },
-      { label: 'Fi Collar Review', href: '/gear/fi-dog-collar-review/' },
-      { label: 'Garmin Dog Tracking', href: '/gear/garmin-dog-tracking-collars/' },
-      { label: 'AirTag for Dogs', href: '/gear/airtag-for-dogs/' },
-      { label: 'Dog Ran Away Guide', href: '/safety/what-to-do-if-your-dog-runs-away/' },
-      { label: 'Road Trip Chill Kit', href: '/travel/dog-road-trip-gear/' },
-    ]}
+    currentHref="/travel/rhys-ran-away-cerro-san-luis-obispo/"
+    limit={6}
     fromPage="rhys-ran-away-cerro-san-luis-obispo"
   />
 

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -14,6 +14,7 @@ const articles = defineCollection({
       topics: z.array(z.enum(TOPICS)).optional(),
       pinnedRelated: z.array(z.string()).optional(),
       excludeRelated: z.array(z.string()).optional(),
+      relatedLabel: z.string().optional(),
     }),
 });
 

--- a/src/data/calming-converter-pages.ts
+++ b/src/data/calming-converter-pages.ts
@@ -96,16 +96,12 @@ export interface CalmingConverterPageConfig {
   toc?: TocHeading[];
   blocks: CalmingBlock[];
   faq?: { heading: string; items: Array<{ question: string; answer: string }> };
-  relatedGuides?: {
-    heading: string;
-    guides: Array<{ href: string; title: string; description: string }>;
-  };
+  relatedGuidesHeading?: string;
+  relatedGuidesLimit?: number;
   disclaimerVariant?: 'standard' | 'supplement' | 'cbd';
   disclosureShowSafety?: boolean;
-  internalLinkStrip?: {
-    heading: string;
-    links: Array<{ label: string; href: string }>;
-  };
+  internalLinkStripHeading?: string;
+  internalLinkStripLimit?: number;
   itemListSchema?: {
     name: string;
     url: string;
@@ -349,34 +345,12 @@ export const calmingConverterPages: Record<string, CalmingConverterPageConfig> =
         },
       ],
     },
-    relatedGuides: {
-      heading: "Don't Forget the Heat",
-      guides: [
-        {
-          href: ROUTES.roadTrip,
-          title: "Rhys's Road Trip Chill Kit",
-          description:
-            'Taking your dog on a long drive? See how to combine cooling and calming gear — window shades, fans, mats, wraps, and chews — for a cross-country road trip.',
-        },
-        {
-          href: ROUTES.coolingTop,
-          title: 'Best Cooling Products for Dogs',
-          description:
-            'Anxious dogs often overheat faster. If summer heat is part of the problem, our cooling guide covers mats, vests, bandanas, and freezable toys.',
-        },
-      ],
-    },
+    relatedGuidesHeading: "Don't Forget the Heat",
+    relatedGuidesLimit: 2,
     disclaimerVariant: 'supplement',
     disclosureShowSafety: false,
-    internalLinkStrip: {
-      heading: 'More Calming & Safety Guides',
-      links: [
-        { label: 'Back to Calming Hub', href: ROUTES.calmingHub },
-        { label: 'ThunderShirt Alternatives', href: ROUTES.calmingAlternatives },
-        { label: 'GPS Trackers for Dogs', href: ROUTES.trackingTop },
-        { label: 'What To Do If Your Dog Runs Away', href: ROUTES.dogRanAwaySafety },
-      ],
-    },
+    internalLinkStripHeading: 'More Calming & Safety Guides',
+    internalLinkStripLimit: 6,
     itemListSchema: {
       name: 'Best Calming Products for Anxious Dogs',
       url: 'https://www.chill-dogs.com/calming/best-calming-products-for-anxious-dogs/',
@@ -501,13 +475,8 @@ export const calmingConverterPages: Record<string, CalmingConverterPageConfig> =
     },
     disclaimerVariant: 'standard',
     disclosureShowSafety: false,
-    internalLinkStrip: {
-      heading: 'More Calming Guides',
-      links: [
-        { label: 'Calming Hub', href: ROUTES.calmingHub },
-        { label: 'Best Calming Products for Anxious Dogs', href: ROUTES.calmingTop },
-      ],
-    },
+    internalLinkStripHeading: 'More Calming Guides',
+    internalLinkStripLimit: 2,
     itemListSchema: {
       name: 'Best ThunderShirt Alternatives: Anxiety Wraps Compared',
       url: 'https://www.chill-dogs.com/calming/best-thundershirt-alternatives/',
@@ -616,15 +585,8 @@ export const calmingConverterPages: Record<string, CalmingConverterPageConfig> =
     },
     disclaimerVariant: 'supplement',
     disclosureShowSafety: false,
-    internalLinkStrip: {
-      heading: 'More Calming Guides',
-      links: [
-        { label: 'Back to Calming Hub', href: ROUTES.calmingHub },
-        { label: 'All Calming Products', href: ROUTES.calmingTop },
-        { label: 'ThunderShirt Alternatives', href: ROUTES.calmingAlternatives },
-        { label: 'Road Trip Chill Kit', href: ROUTES.roadTrip },
-      ],
-    },
+    internalLinkStripHeading: 'More Calming Guides',
+    internalLinkStripLimit: 4,
   },
 };
 

--- a/src/data/content-sitemap.ts
+++ b/src/data/content-sitemap.ts
@@ -249,6 +249,14 @@ export const staticSitemapSections: SitemapSection[] = [
         href: ROUTES.calmingTop,
         pageType: 'converter',
         topics: ['calming', 'anxiety'],
+        pinnedRelated: [
+          ROUTES.roadTrip,
+          ROUTES.coolingTop,
+          ROUTES.calmingHub,
+          ROUTES.calmingAlternatives,
+          ROUTES.trackingTop,
+          ROUTES.dogRanAwaySafety,
+        ],
         relatedLabel: 'Best Calming Products',
       }),
       createSitemapPage({
@@ -257,6 +265,10 @@ export const staticSitemapSections: SitemapSection[] = [
         href: ROUTES.calmingAlternatives,
         pageType: 'converter',
         topics: ['calming', 'anxiety'],
+        pinnedRelated: [
+          ROUTES.calmingHub,
+          ROUTES.calmingTop,
+        ],
         relatedLabel: 'ThunderShirt Alternatives',
       }),
       createSitemapPage({
@@ -265,6 +277,12 @@ export const staticSitemapSections: SitemapSection[] = [
         href: ROUTES.calmingCar,
         pageType: 'converter',
         topics: ['calming', 'anxiety', 'car-anxiety', 'travel', 'road-trips'],
+        pinnedRelated: [
+          ROUTES.calmingHub,
+          ROUTES.calmingTop,
+          ROUTES.calmingAlternatives,
+          ROUTES.roadTrip,
+        ],
         relatedLabel: 'Car Anxiety Picks',
       }),
     ],
@@ -355,6 +373,11 @@ export const staticSitemapSections: SitemapSection[] = [
         href: ROUTES.comfortCalmingBeds,
         pageType: 'converter',
         topics: ['comfort', 'sleep', 'beds', 'calming', 'anxiety'],
+        pinnedRelated: [
+          ROUTES.comfortOrthopedicBeds,
+          ROUTES.calmingTop,
+          ROUTES.calmingHub,
+        ],
         relatedLabel: 'Best Calming Dog Beds',
       }),
       createSitemapPage({
@@ -363,6 +386,11 @@ export const staticSitemapSections: SitemapSection[] = [
         href: ROUTES.comfortOrthopedicBeds,
         pageType: 'converter',
         topics: ['comfort', 'sleep', 'beds', 'orthopedic'],
+        pinnedRelated: [
+          ROUTES.comfortCalmingBeds,
+          ROUTES.calmingTop,
+          ROUTES.calmingHub,
+        ],
         relatedLabel: 'Best Orthopedic Dog Beds',
       }),
       createSitemapPage({
@@ -371,6 +399,11 @@ export const staticSitemapSections: SitemapSection[] = [
         href: ROUTES.comfortPuppyCrates,
         pageType: 'converter',
         topics: ['comfort', 'crates', 'crate-training'],
+        pinnedRelated: [
+          ROUTES.calmingCrateGuide,
+          ROUTES.comfortCalmingBeds,
+          ROUTES.comfortHub,
+        ],
         relatedLabel: 'Best Puppy Crates',
       }),
       createSitemapPage({
@@ -379,6 +412,12 @@ export const staticSitemapSections: SitemapSection[] = [
         href: ROUTES.comfortAnxietyCrates,
         pageType: 'converter',
         topics: ['comfort', 'crates', 'calming', 'anxiety'],
+        pinnedRelated: [
+          ROUTES.calmingCrateGuide,
+          ROUTES.calmingTop,
+          ROUTES.comfortHeavyDutyCrates,
+          ROUTES.comfortPuppyCrates,
+        ],
         relatedLabel: 'Best Anxiety Dog Crates',
       }),
       createSitemapPage({
@@ -387,6 +426,12 @@ export const staticSitemapSections: SitemapSection[] = [
         href: ROUTES.comfortTravelCrates,
         pageType: 'converter',
         topics: ['comfort', 'crates', 'travel', 'road-trips'],
+        pinnedRelated: [
+          ROUTES.roadTrip,
+          ROUTES.calmingCrateGuide,
+          ROUTES.comfortAirlineCrates,
+          ROUTES.comfortAnxietyCrates,
+        ],
         relatedLabel: 'Travel Crates for Road Trips',
       }),
       createSitemapPage({
@@ -395,6 +440,11 @@ export const staticSitemapSections: SitemapSection[] = [
         href: ROUTES.comfortAirlineCrates,
         pageType: 'converter',
         topics: ['comfort', 'crates', 'travel', 'flying'],
+        pinnedRelated: [
+          ROUTES.calmingCrateGuide,
+          ROUTES.comfortTravelCrates,
+          ROUTES.comfortAnxietyCrates,
+        ],
         relatedLabel: 'Best Airline Crates',
       }),
       createSitemapPage({
@@ -403,6 +453,13 @@ export const staticSitemapSections: SitemapSection[] = [
         href: ROUTES.comfortAirlineCarriers,
         pageType: 'converter',
         topics: ['comfort', 'travel', 'flying', 'carriers'],
+        pinnedRelated: [
+          ROUTES.travelFlyWithDog,
+          ROUTES.comfortAirlineCrates,
+          ROUTES.calmingTop,
+          ROUTES.calmingCar,
+          ROUTES.roadTrip,
+        ],
         relatedLabel: 'Best Airline-Approved Carriers',
       }),
       createSitemapPage({
@@ -411,6 +468,12 @@ export const staticSitemapSections: SitemapSection[] = [
         href: ROUTES.comfortTravelBags,
         pageType: 'converter',
         topics: ['comfort', 'travel', 'flying', 'carriers'],
+        pinnedRelated: [
+          ROUTES.travelFlyWithDog,
+          ROUTES.comfortAirlineCrates,
+          ROUTES.calmingTop,
+          ROUTES.roadTrip,
+        ],
         relatedLabel: 'Best Dog Travel Bags',
       }),
       createSitemapPage({
@@ -419,6 +482,11 @@ export const staticSitemapSections: SitemapSection[] = [
         href: ROUTES.comfortFurnitureCrates,
         pageType: 'converter',
         topics: ['comfort', 'crates'],
+        pinnedRelated: [
+          ROUTES.calmingCrateGuide,
+          ROUTES.comfortHeavyDutyCrates,
+          ROUTES.comfortPuppyCrates,
+        ],
         relatedLabel: 'Best Furniture Dog Crates',
       }),
       createSitemapPage({
@@ -427,6 +495,11 @@ export const staticSitemapSections: SitemapSection[] = [
         href: ROUTES.comfortHeavyDutyCrates,
         pageType: 'converter',
         topics: ['comfort', 'crates', 'anxiety'],
+        pinnedRelated: [
+          ROUTES.comfortAnxietyCrates,
+          ROUTES.calmingCrateGuide,
+          ROUTES.comfortFurnitureCrates,
+        ],
         relatedLabel: 'Best Heavy-Duty Dog Crates',
       }),
     ],

--- a/src/data/content-sitemap.ts
+++ b/src/data/content-sitemap.ts
@@ -49,6 +49,7 @@ export interface SitemapPage {
   topics?: SitemapTopic[];
   pinnedRelated?: string[];
   excludeRelated?: string[];
+  relatedLabel?: string;
   noindex?: boolean;
   preview: SitemapPreview;
 }
@@ -68,6 +69,7 @@ export interface SitemapPageInput {
   topics?: SitemapTopic[];
   pinnedRelated?: string[];
   excludeRelated?: string[];
+  relatedLabel?: string;
   ogTitle?: string;
   ogImage?: string | ImageMetadata;
   noindex?: boolean;
@@ -95,6 +97,7 @@ export function createSitemapPage(input: SitemapPageInput): SitemapPage {
     topics: input.topics,
     pinnedRelated: input.pinnedRelated,
     excludeRelated: input.excludeRelated,
+    relatedLabel: input.relatedLabel,
     noindex: input.noindex,
     preview: {
       title: resolveShareTitle(input.baseTitle, input.ogTitle),
@@ -125,6 +128,7 @@ export const staticSitemapSections: SitemapSection[] = [
         pageType: 'collector',
         collectorSubtype: 'section',
         topics: ['cooling'],
+        relatedLabel: 'Cooling Relief',
       }),
       createSitemapPage({
         baseTitle: 'Calm & Comfort',
@@ -135,6 +139,7 @@ export const staticSitemapSections: SitemapSection[] = [
         pageType: 'collector',
         collectorSubtype: 'section',
         topics: ['calming', 'anxiety'],
+        relatedLabel: 'Calm & Comfort',
       }),
       createSitemapPage({
         baseTitle: 'Comfort & Rest',
@@ -145,6 +150,7 @@ export const staticSitemapSections: SitemapSection[] = [
         pageType: 'collector',
         collectorSubtype: 'section',
         topics: ['comfort', 'sleep', 'beds', 'crates'],
+        relatedLabel: 'Comfort & Rest',
       }),
     ],
   },
@@ -159,6 +165,7 @@ export const staticSitemapSections: SitemapSection[] = [
         href: ROUTES.coolingTop,
         pageType: 'converter',
         topics: ['cooling', 'heat-safety'],
+        relatedLabel: 'Best Cooling Products',
       }),
       createSitemapPage({
         baseTitle: categoryMeta['car-cooling'].title,
@@ -166,6 +173,7 @@ export const staticSitemapSections: SitemapSection[] = [
         href: ROUTES.coolingCar,
         pageType: 'converter',
         topics: ['cooling', 'heat-safety', 'car-cooling', 'travel', 'road-trips'],
+        relatedLabel: 'Car Cooling Picks',
       }),
       createSitemapPage({
         baseTitle: categoryMeta['cooling-mats'].title,
@@ -173,6 +181,7 @@ export const staticSitemapSections: SitemapSection[] = [
         href: ROUTES.coolingMats,
         pageType: 'converter',
         topics: ['cooling', 'heat-safety', 'cooling-mats', 'comfort'],
+        relatedLabel: 'Best Cooling Mats',
       }),
       createSitemapPage({
         baseTitle: categoryMeta['cooling-bandanas'].title,
@@ -180,6 +189,7 @@ export const staticSitemapSections: SitemapSection[] = [
         href: ROUTES.coolingBandanas,
         pageType: 'converter',
         topics: ['cooling', 'heat-safety', 'cooling-wearables'],
+        relatedLabel: 'Best Cooling Bandanas',
       }),
       createSitemapPage({
         baseTitle: categoryMeta['cooling-vests'].title,
@@ -187,6 +197,7 @@ export const staticSitemapSections: SitemapSection[] = [
         href: ROUTES.coolingVests,
         pageType: 'converter',
         topics: ['cooling', 'heat-safety', 'cooling-wearables'],
+        relatedLabel: 'Best Cooling Vests',
       }),
       createSitemapPage({
         baseTitle: categoryMeta['freezable-dog-toys'].title,
@@ -194,6 +205,7 @@ export const staticSitemapSections: SitemapSection[] = [
         href: ROUTES.coolingToys,
         pageType: 'converter',
         topics: ['cooling', 'heat-safety', 'frozen-toys'],
+        relatedLabel: 'Freezable Dog Toys',
       }),
     ],
   },
@@ -207,6 +219,7 @@ export const staticSitemapSections: SitemapSection[] = [
         href: ROUTES.calmingTop,
         pageType: 'converter',
         topics: ['calming', 'anxiety'],
+        relatedLabel: 'Best Calming Products',
       }),
       createSitemapPage({
         baseTitle: calmingConverterPages['best-thundershirt-alternatives'].title,
@@ -214,6 +227,7 @@ export const staticSitemapSections: SitemapSection[] = [
         href: ROUTES.calmingAlternatives,
         pageType: 'converter',
         topics: ['calming', 'anxiety'],
+        relatedLabel: 'ThunderShirt Alternatives',
       }),
       createSitemapPage({
         baseTitle: calmingConverterPages['car-anxiety-for-dogs'].title,
@@ -221,6 +235,7 @@ export const staticSitemapSections: SitemapSection[] = [
         href: ROUTES.calmingCar,
         pageType: 'converter',
         topics: ['calming', 'anxiety', 'car-anxiety', 'travel', 'road-trips'],
+        relatedLabel: 'Car Anxiety Picks',
       }),
     ],
   },
@@ -236,6 +251,15 @@ export const staticSitemapSections: SitemapSection[] = [
         href: ROUTES.trackingTop,
         pageType: 'converter',
         topics: ['tracking', 'gps-tracking', 'lost-dog-safety'],
+        pinnedRelated: [
+          ROUTES.rhysRanAway,
+          ROUTES.fiCollarReview,
+          ROUTES.garminTracking,
+          ROUTES.airtagForDogs,
+          ROUTES.dogRanAwaySafety,
+          ROUTES.roadTrip,
+        ],
+        relatedLabel: 'All GPS Trackers',
       }),
       createSitemapPage({
         baseTitle: 'Fi Dog Collar Review: GPS Tracking for Everyday Dogs (2026)',
@@ -245,6 +269,14 @@ export const staticSitemapSections: SitemapSection[] = [
         href: ROUTES.fiCollarReview,
         pageType: 'converter',
         topics: ['tracking', 'gps-tracking', 'lost-dog-safety'],
+        pinnedRelated: [
+          ROUTES.trackingTop,
+          ROUTES.garminTracking,
+          ROUTES.airtagForDogs,
+          ROUTES.rhysRanAway,
+          ROUTES.dogRanAwaySafety,
+        ],
+        relatedLabel: 'Fi Collar Review',
       }),
       createSitemapPage({
         baseTitle: 'Garmin Dog Tracking Collars: Off-Grid GPS for Wilderness & Hiking (2026)',
@@ -255,6 +287,14 @@ export const staticSitemapSections: SitemapSection[] = [
         pageType: 'collector',
         collectorSubtype: 'article',
         topics: ['tracking', 'gps-tracking', 'lost-dog-safety'],
+        pinnedRelated: [
+          ROUTES.trackingTop,
+          ROUTES.fiCollarReview,
+          ROUTES.airtagForDogs,
+          ROUTES.rhysRanAway,
+          ROUTES.dogRanAwaySafety,
+        ],
+        relatedLabel: 'Garmin Off-Grid Systems',
       }),
       createSitemapPage({
         baseTitle: "AirTag for Dogs: What It Can (and Can't) Actually Do",
@@ -264,6 +304,14 @@ export const staticSitemapSections: SitemapSection[] = [
         pageType: 'collector',
         collectorSubtype: 'article',
         topics: ['tracking', 'gps-tracking', 'lost-dog-safety'],
+        pinnedRelated: [
+          ROUTES.trackingTop,
+          ROUTES.fiCollarReview,
+          ROUTES.garminTracking,
+          ROUTES.rhysRanAway,
+          ROUTES.dogRanAwaySafety,
+        ],
+        relatedLabel: 'AirTag for Dogs',
       }),
     ],
   },
@@ -277,6 +325,7 @@ export const staticSitemapSections: SitemapSection[] = [
         href: ROUTES.comfortCalmingBeds,
         pageType: 'converter',
         topics: ['comfort', 'sleep', 'beds', 'calming', 'anxiety'],
+        relatedLabel: 'Best Calming Dog Beds',
       }),
       createSitemapPage({
         baseTitle: relaxationConverterPages['best-orthopedic-dog-beds'].title,
@@ -284,6 +333,7 @@ export const staticSitemapSections: SitemapSection[] = [
         href: ROUTES.comfortOrthopedicBeds,
         pageType: 'converter',
         topics: ['comfort', 'sleep', 'beds', 'orthopedic'],
+        relatedLabel: 'Best Orthopedic Dog Beds',
       }),
       createSitemapPage({
         baseTitle: relaxationConverterPages['best-puppy-crates'].title,
@@ -291,6 +341,7 @@ export const staticSitemapSections: SitemapSection[] = [
         href: ROUTES.comfortPuppyCrates,
         pageType: 'converter',
         topics: ['comfort', 'crates', 'crate-training'],
+        relatedLabel: 'Best Puppy Crates',
       }),
       createSitemapPage({
         baseTitle: relaxationConverterPages['best-anxiety-dog-crates'].title,
@@ -298,6 +349,7 @@ export const staticSitemapSections: SitemapSection[] = [
         href: ROUTES.comfortAnxietyCrates,
         pageType: 'converter',
         topics: ['comfort', 'crates', 'calming', 'anxiety'],
+        relatedLabel: 'Best Anxiety Dog Crates',
       }),
       createSitemapPage({
         baseTitle: relaxationConverterPages['best-travel-crates-for-road-trips'].title,
@@ -305,6 +357,7 @@ export const staticSitemapSections: SitemapSection[] = [
         href: ROUTES.comfortTravelCrates,
         pageType: 'converter',
         topics: ['comfort', 'crates', 'travel', 'road-trips'],
+        relatedLabel: 'Travel Crates for Road Trips',
       }),
       createSitemapPage({
         baseTitle: relaxationConverterPages['best-airline-crates-for-flying-with-your-dog'].title,
@@ -312,6 +365,7 @@ export const staticSitemapSections: SitemapSection[] = [
         href: ROUTES.comfortAirlineCrates,
         pageType: 'converter',
         topics: ['comfort', 'crates', 'travel', 'flying'],
+        relatedLabel: 'Best Airline Crates',
       }),
       createSitemapPage({
         baseTitle: relaxationConverterPages['best-airline-approved-dog-carriers'].title,
@@ -319,6 +373,7 @@ export const staticSitemapSections: SitemapSection[] = [
         href: ROUTES.comfortAirlineCarriers,
         pageType: 'converter',
         topics: ['comfort', 'travel', 'flying', 'carriers'],
+        relatedLabel: 'Best Airline-Approved Carriers',
       }),
       createSitemapPage({
         baseTitle: relaxationConverterPages['best-dog-travel-bags-for-flying'].title,
@@ -326,6 +381,7 @@ export const staticSitemapSections: SitemapSection[] = [
         href: ROUTES.comfortTravelBags,
         pageType: 'converter',
         topics: ['comfort', 'travel', 'flying', 'carriers'],
+        relatedLabel: 'Best Dog Travel Bags',
       }),
       createSitemapPage({
         baseTitle: relaxationConverterPages['best-furniture-dog-crates'].title,
@@ -333,6 +389,7 @@ export const staticSitemapSections: SitemapSection[] = [
         href: ROUTES.comfortFurnitureCrates,
         pageType: 'converter',
         topics: ['comfort', 'crates'],
+        relatedLabel: 'Best Furniture Dog Crates',
       }),
       createSitemapPage({
         baseTitle: relaxationConverterPages['best-heavy-duty-dog-crates'].title,
@@ -340,6 +397,7 @@ export const staticSitemapSections: SitemapSection[] = [
         href: ROUTES.comfortHeavyDutyCrates,
         pageType: 'converter',
         topics: ['comfort', 'crates', 'anxiety'],
+        relatedLabel: 'Best Heavy-Duty Dog Crates',
       }),
     ],
   },

--- a/src/data/content-sitemap.ts
+++ b/src/data/content-sitemap.ts
@@ -173,6 +173,12 @@ export const staticSitemapSections: SitemapSection[] = [
         href: ROUTES.coolingCar,
         pageType: 'converter',
         topics: ['cooling', 'heat-safety', 'car-cooling', 'travel', 'road-trips'],
+        pinnedRelated: [
+          ROUTES.roadTrip,
+          ROUTES.coolingMats,
+          ROUTES.coolingVests,
+          ROUTES.coolingTop,
+        ],
         relatedLabel: 'Car Cooling Picks',
       }),
       createSitemapPage({
@@ -181,6 +187,12 @@ export const staticSitemapSections: SitemapSection[] = [
         href: ROUTES.coolingMats,
         pageType: 'converter',
         topics: ['cooling', 'heat-safety', 'cooling-mats', 'comfort'],
+        pinnedRelated: [
+          ROUTES.coolingBandanas,
+          ROUTES.coolingVests,
+          ROUTES.coolingToys,
+          ROUTES.coolingTop,
+        ],
         relatedLabel: 'Best Cooling Mats',
       }),
       createSitemapPage({
@@ -189,6 +201,12 @@ export const staticSitemapSections: SitemapSection[] = [
         href: ROUTES.coolingBandanas,
         pageType: 'converter',
         topics: ['cooling', 'heat-safety', 'cooling-wearables'],
+        pinnedRelated: [
+          ROUTES.coolingMats,
+          ROUTES.coolingVests,
+          ROUTES.coolingToys,
+          ROUTES.coolingTop,
+        ],
         relatedLabel: 'Best Cooling Bandanas',
       }),
       createSitemapPage({
@@ -197,6 +215,12 @@ export const staticSitemapSections: SitemapSection[] = [
         href: ROUTES.coolingVests,
         pageType: 'converter',
         topics: ['cooling', 'heat-safety', 'cooling-wearables'],
+        pinnedRelated: [
+          ROUTES.coolingMats,
+          ROUTES.coolingBandanas,
+          ROUTES.coolingToys,
+          ROUTES.coolingTop,
+        ],
         relatedLabel: 'Best Cooling Vests',
       }),
       createSitemapPage({
@@ -205,6 +229,12 @@ export const staticSitemapSections: SitemapSection[] = [
         href: ROUTES.coolingToys,
         pageType: 'converter',
         topics: ['cooling', 'heat-safety', 'frozen-toys'],
+        pinnedRelated: [
+          ROUTES.coolingMats,
+          ROUTES.coolingBandanas,
+          ROUTES.coolingVests,
+          ROUTES.coolingTop,
+        ],
         relatedLabel: 'Freezable Dog Toys',
       }),
     ],

--- a/src/data/cooling-products.ts
+++ b/src/data/cooling-products.ts
@@ -25,7 +25,6 @@ export interface CategoryMeta {
   heroHeadline: string;
   introCopy: string;
   faqs: { question: string; answer: string }[];
-  internalLinks: { label: string; href: string }[];
 }
 
 // ─── Products ────────────────────────────────────────────────────────
@@ -335,12 +334,6 @@ export const categoryMeta: Record<ProductCategory, CategoryMeta> = {
           'Every 1–2 hours is a reasonable baseline, but dogs that are stressed, panting heavily, or in hot weather may need more frequent breaks. Always offer cool (not ice cold) water.',
       },
     ],
-    internalLinks: [
-      { label: 'Road Trip Chill Kit', href: '/travel/dog-road-trip-gear/' },
-      { label: 'Cooling Mats', href: '/cooling/cooling-mats/' },
-      { label: 'Cooling Vests', href: '/cooling/cooling-vests/' },
-      { label: 'All Cooling Products', href: '/cooling/best-cooling-products-for-dogs/' },
-    ],
   },
   'cooling-mats': {
     title: 'Best Cooling Mats for Dogs (2026)',
@@ -366,12 +359,6 @@ export const categoryMeta: Record<ProductCategory, CategoryMeta> = {
           'Absolutely — most mats are designed to fold or trim to fit standard crate sizes. The Arf Pets mat is especially good for crates.',
       },
     ],
-    internalLinks: [
-      { label: 'Cooling Bandanas', href: '/cooling/cooling-bandanas/' },
-      { label: 'Cooling Vests', href: '/cooling/cooling-vests/' },
-      { label: 'Freezable Toys', href: '/cooling/freezable-dog-toys/' },
-      { label: 'All Cooling Products', href: '/cooling/best-cooling-products-for-dogs/' },
-    ],
   },
   'cooling-bandanas': {
     title: 'Best Cooling Bandanas for Dogs (2026)',
@@ -396,12 +383,6 @@ export const categoryMeta: Record<ProductCategory, CategoryMeta> = {
         answer:
           'Yes, as long as the bandana fits snugly without being too tight. Always supervise puppies to prevent chewing.',
       },
-    ],
-    internalLinks: [
-      { label: 'Cooling Mats', href: '/cooling/cooling-mats/' },
-      { label: 'Cooling Vests', href: '/cooling/cooling-vests/' },
-      { label: 'Freezable Toys', href: '/cooling/freezable-dog-toys/' },
-      { label: 'All Cooling Products', href: '/cooling/best-cooling-products-for-dogs/' },
     ],
   },
   'cooling-vests': {
@@ -433,12 +414,6 @@ export const categoryMeta: Record<ProductCategory, CategoryMeta> = {
           'Most can be hand-washed with mild soap and air-dried. Check the label — machine washing can damage evaporative layers.',
       },
     ],
-    internalLinks: [
-      { label: 'Cooling Mats', href: '/cooling/cooling-mats/' },
-      { label: 'Cooling Bandanas', href: '/cooling/cooling-bandanas/' },
-      { label: 'Freezable Toys', href: '/cooling/freezable-dog-toys/' },
-      { label: 'All Cooling Products', href: '/cooling/best-cooling-products-for-dogs/' },
-    ],
   },
   'freezable-dog-toys': {
     title: 'Best Freezable Dog Toys (2026)',
@@ -463,12 +438,6 @@ export const categoryMeta: Record<ProductCategory, CategoryMeta> = {
         answer:
           'A fully frozen KONG can last 20–45 minutes depending on the filling and your dog\'s determination. The Chilly Penguin will usually last 10–20 minutes.',
       },
-    ],
-    internalLinks: [
-      { label: 'Cooling Mats', href: '/cooling/cooling-mats/' },
-      { label: 'Cooling Bandanas', href: '/cooling/cooling-bandanas/' },
-      { label: 'Cooling Vests', href: '/cooling/cooling-vests/' },
-      { label: 'All Cooling Products', href: '/cooling/best-cooling-products-for-dogs/' },
     ],
   },
 };

--- a/src/data/relaxation-converter-pages.ts
+++ b/src/data/relaxation-converter-pages.ts
@@ -102,15 +102,11 @@ export interface RelaxationConverterPageConfig {
   toc?: TocHeading[];
   blocks: RelaxationBlock[];
   faq?: { heading: string; items: Array<{ question: string; answer: string }> };
-  relatedGuides?: {
-    heading: string;
-    guides: Array<{ href: string; title: string; description: string }>;
-  };
+  relatedGuidesHeading?: string;
+  relatedGuidesLimit?: number;
   disclosureShowSafety?: boolean;
-  internalLinkStrip?: {
-    heading: string;
-    links: Array<{ label: string; href: string }>;
-  };
+  internalLinkStripHeading?: string;
+  internalLinkStripLimit?: number;
   itemListSchema?: {
     name: string;
     url: string;
@@ -323,32 +319,11 @@ export const relaxationConverterPages: Record<string, RelaxationConverterPageCon
         },
       ],
     },
-    relatedGuides: {
-      heading: 'More Rest & Recovery',
-      guides: [
-        {
-          href: ROUTES.comfortOrthopedicBeds,
-          title: 'Best Orthopedic Dog Beds',
-          description:
-            'For older dogs, large breeds, or heavy resters, orthopedic foam and full-surround bolsters make a real difference in sustained daily comfort.',
-        },
-        {
-          href: ROUTES.calmingTop,
-          title: 'Best Calming Products for Anxious Dogs',
-          description:
-            'If sleep trouble is anxiety-driven, compare anxiety wraps, calming chews, and lick mats that work before and during stressful events.',
-        },
-      ],
-    },
+    relatedGuidesHeading: 'More Rest & Recovery',
+    relatedGuidesLimit: 2,
     disclosureShowSafety: false,
-    internalLinkStrip: {
-      heading: 'More Relaxation Guides',
-      links: [
-        { label: 'Orthopedic Dog Beds', href: ROUTES.comfortOrthopedicBeds },
-        { label: 'Best Calming Products', href: ROUTES.calmingTop },
-        { label: 'Calming Hub', href: ROUTES.calmingHub },
-      ],
-    },
+    internalLinkStripHeading: 'More Relaxation Guides',
+    internalLinkStripLimit: 3,
     itemListSchema: {
       name: 'Best Calming Dog Beds',
       url: 'https://www.chill-dogs.com/comforting/best-calming-dog-beds/',
@@ -520,32 +495,11 @@ export const relaxationConverterPages: Record<string, RelaxationConverterPageCon
         },
       ],
     },
-    relatedGuides: {
-      heading: 'More Crate Training Help',
-      guides: [
-        {
-          href: ROUTES.calmingCrateGuide,
-          title: 'How to Crate Train Your Dog',
-          description:
-            'Step-by-step crate training guidance for puppies, anxious dogs, travel, and common mistakes to avoid.',
-        },
-        {
-          href: ROUTES.comfortCalmingBeds,
-          title: 'Best Calming Dog Beds',
-          description:
-            'If your puppy settles better with soft edges and a defined rest area, compare calming beds and bolster beds.',
-        },
-      ],
-    },
+    relatedGuidesHeading: 'More Crate Training Help',
+    relatedGuidesLimit: 2,
     disclosureShowSafety: false,
-    internalLinkStrip: {
-      heading: 'More Puppy Comfort Guides',
-      links: [
-        { label: 'Crate Training Guide', href: ROUTES.calmingCrateGuide },
-        { label: 'Calming Dog Beds', href: ROUTES.comfortCalmingBeds },
-        { label: 'Comfort & Rest', href: ROUTES.comfortHub },
-      ],
-    },
+    internalLinkStripHeading: 'More Puppy Comfort Guides',
+    internalLinkStripLimit: 3,
     itemListSchema: {
       name: 'Best Puppy Crates',
       url: 'https://www.chill-dogs.com/comforting/best-puppy-crates/',
@@ -690,39 +644,11 @@ export const relaxationConverterPages: Record<string, RelaxationConverterPageCon
         },
       ],
     },
-    relatedGuides: {
-      heading: 'More Anxiety & Crate Training Help',
-      guides: [
-        {
-          href: ROUTES.calmingCrateGuide,
-          title: 'How to Crate Train Your Dog',
-          description:
-            'Crate training basics, puppy setup, anxiety cautions, travel use, and common mistakes to avoid.',
-        },
-        {
-          href: ROUTES.calmingTop,
-          title: 'Best Calming Products for Anxious Dogs',
-          description:
-            'Compare wraps, chews, lick mats, and snuffle mats for dogs who need support beyond crate management.',
-        },
-        {
-          href: ROUTES.comfortHeavyDutyCrates,
-          title: 'Best Heavy-Duty Dog Crates',
-          description:
-            'See reinforced crate options when you already know a standard wire setup is not enough.',
-        },
-      ],
-    },
+    relatedGuidesHeading: 'More Anxiety & Crate Training Help',
+    relatedGuidesLimit: 3,
     disclosureShowSafety: true,
-    internalLinkStrip: {
-      heading: 'More Anxiety Guides',
-      links: [
-        { label: 'Crate Training Guide', href: ROUTES.calmingCrateGuide },
-        { label: 'Heavy-Duty Crates', href: ROUTES.comfortHeavyDutyCrates },
-        { label: 'Puppy Crates', href: ROUTES.comfortPuppyCrates },
-        { label: 'Best Calming Products', href: ROUTES.calmingTop },
-      ],
-    },
+    internalLinkStripHeading: 'More Anxiety Guides',
+    internalLinkStripLimit: 4,
     itemListSchema: {
       name: 'Best Dog Crates for Anxiety',
       url: 'https://www.chill-dogs.com/comforting/best-anxiety-dog-crates/',
@@ -928,39 +854,11 @@ export const relaxationConverterPages: Record<string, RelaxationConverterPageCon
         },
       ],
     },
-    relatedGuides: {
-      heading: 'More Road Trip & Crate Help',
-      guides: [
-        {
-          href: ROUTES.roadTrip,
-          title: "Rhys's Road Trip Chill Kit",
-          description:
-            'A road trip setup that combines cooling, calming, hydration, and rest gear for long drives with dogs.',
-        },
-        {
-          href: ROUTES.calmingCrateGuide,
-          title: 'How to Crate Train Your Dog',
-          description:
-            'Crate training guidance for puppies, anxious dogs, travel, and common crate mistakes.',
-        },
-        {
-          href: ROUTES.comfortAirlineCrates,
-          title: 'Best Airline Crates for Flying With Your Dog',
-          description:
-            'Compare rigid airline-style kennels separately from soft road-trip and hotel-travel crate picks.',
-        },
-      ],
-    },
+    relatedGuidesHeading: 'More Road Trip & Crate Help',
+    relatedGuidesLimit: 3,
     disclosureShowSafety: false,
-    internalLinkStrip: {
-      heading: 'More Travel & Crate Guides',
-      links: [
-        { label: 'Road Trip Gear', href: ROUTES.roadTrip },
-        { label: 'Airline Crates', href: ROUTES.comfortAirlineCrates },
-        { label: 'Crate Training Guide', href: ROUTES.calmingCrateGuide },
-        { label: 'Anxiety Crates', href: ROUTES.comfortAnxietyCrates },
-      ],
-    },
+    internalLinkStripHeading: 'More Travel & Crate Guides',
+    internalLinkStripLimit: 4,
     itemListSchema: {
       name: 'Best Travel Crates for Road Trips',
       url: 'https://www.chill-dogs.com/comforting/best-travel-crates-for-road-trips/',
@@ -1156,32 +1054,11 @@ export const relaxationConverterPages: Record<string, RelaxationConverterPageCon
         },
       ],
     },
-    relatedGuides: {
-      heading: 'More Travel & Crate Help',
-      guides: [
-        {
-          href: ROUTES.calmingCrateGuide,
-          title: 'How to Crate Train Your Dog',
-          description:
-            'Build crate comfort before any major trip so the flight crate is not a stressful confinement experience.',
-        },
-        {
-          href: ROUTES.comfortTravelCrates,
-          title: 'Best Travel Crates for Road Trips',
-          description:
-            'Compare hard-sided and soft folding road-trip crates separately from flight-focused kennels.',
-        },
-      ],
-    },
+    relatedGuidesHeading: 'More Travel & Crate Help',
+    relatedGuidesLimit: 2,
     disclosureShowSafety: false,
-    internalLinkStrip: {
-      heading: 'More Travel & Crate Guides',
-      links: [
-        { label: 'Crate Training Guide', href: ROUTES.calmingCrateGuide },
-        { label: 'Road Trip Crates', href: ROUTES.comfortTravelCrates },
-        { label: 'Anxiety Crates', href: ROUTES.comfortAnxietyCrates },
-      ],
-    },
+    internalLinkStripHeading: 'More Travel & Crate Guides',
+    internalLinkStripLimit: 3,
     itemListSchema: {
       name: 'Best Airline Crates for Flying With Your Dog',
       url: 'https://www.chill-dogs.com/comforting/best-airline-crates-for-flying-with-your-dog/',
@@ -1368,32 +1245,11 @@ export const relaxationConverterPages: Record<string, RelaxationConverterPageCon
         },
       ],
     },
-    relatedGuides: {
-      heading: 'More Crate & Comfort Help',
-      guides: [
-        {
-          href: ROUTES.calmingCrateGuide,
-          title: 'How to Crate Train Your Dog',
-          description:
-            'Crate comfort still matters even when the crate is chosen mainly for indoor furniture fit.',
-        },
-        {
-          href: ROUTES.comfortHeavyDutyCrates,
-          title: 'Best Heavy-Duty Dog Crates',
-          description:
-            'If your dog needs stronger containment than decorative crate furniture can realistically provide, start there instead.',
-        },
-      ],
-    },
+    relatedGuidesHeading: 'More Crate & Comfort Help',
+    relatedGuidesLimit: 2,
     disclosureShowSafety: false,
-    internalLinkStrip: {
-      heading: 'More Crate Guides',
-      links: [
-        { label: 'Crate Training Guide', href: ROUTES.calmingCrateGuide },
-        { label: 'Heavy-Duty Crates', href: ROUTES.comfortHeavyDutyCrates },
-        { label: 'Puppy Crates', href: ROUTES.comfortPuppyCrates },
-      ],
-    },
+    internalLinkStripHeading: 'More Crate Guides',
+    internalLinkStripLimit: 3,
     itemListSchema: {
       name: 'Best Furniture Dog Crates',
       url: 'https://www.chill-dogs.com/comforting/best-furniture-dog-crates/',
@@ -1568,32 +1424,11 @@ export const relaxationConverterPages: Record<string, RelaxationConverterPageCon
         },
       ],
     },
-    relatedGuides: {
-      heading: 'More Anxiety & Crate Help',
-      guides: [
-        {
-          href: ROUTES.comfortAnxietyCrates,
-          title: 'Best Dog Crates for Anxiety',
-          description:
-            'When you are still deciding between wire, enclosed, and heavy-duty containment categories.',
-        },
-        {
-          href: ROUTES.calmingCrateGuide,
-          title: 'How to Crate Train Your Dog',
-          description:
-            'Consider crate-training tips and anxiety mitigation before investing in a stronger crate.',
-        },
-      ],
-    },
+    relatedGuidesHeading: 'More Anxiety & Crate Help',
+    relatedGuidesLimit: 2,
     disclosureShowSafety: true,
-    internalLinkStrip: {
-      heading: 'More Crate Guides',
-      links: [
-        { label: 'Anxiety Crates', href: ROUTES.comfortAnxietyCrates },
-        { label: 'Crate Training Guide', href: ROUTES.calmingCrateGuide },
-        { label: 'Furniture Crates', href: ROUTES.comfortFurnitureCrates },
-      ],
-    },
+    internalLinkStripHeading: 'More Crate Guides',
+    internalLinkStripLimit: 3,
     itemListSchema: {
       name: 'Best Heavy-Duty Dog Crates',
       url: 'https://www.chill-dogs.com/comforting/best-heavy-duty-dog-crates/',
@@ -1740,32 +1575,11 @@ export const relaxationConverterPages: Record<string, RelaxationConverterPageCon
         },
       ],
     },
-    relatedGuides: {
-      heading: 'More Rest & Recovery',
-      guides: [
-        {
-          href: ROUTES.comfortCalmingBeds,
-          title: 'Best Calming Dog Beds',
-          description:
-            'Donut beds, cuddler beds, and bolster beds for dogs who need extra comfort and security — not just a supportive surface.',
-        },
-        {
-          href: ROUTES.calmingTop,
-          title: 'Best Calming Products for Anxious Dogs',
-          description:
-            'Compare anxiety wraps, calming chews, lick mats, and snuffle mats for dogs who need support beyond a better sleeping setup.',
-        },
-      ],
-    },
+    relatedGuidesHeading: 'More Rest & Recovery',
+    relatedGuidesLimit: 2,
     disclosureShowSafety: false,
-    internalLinkStrip: {
-      heading: 'More Relaxation Guides',
-      links: [
-        { label: 'Calming Dog Beds', href: ROUTES.comfortCalmingBeds },
-        { label: 'Best Calming Products', href: ROUTES.calmingTop },
-        { label: 'Calming Hub', href: ROUTES.calmingHub },
-      ],
-    },
+    internalLinkStripHeading: 'More Relaxation Guides',
+    internalLinkStripLimit: 3,
     itemListSchema: {
       name: 'Best Orthopedic Dog Beds',
       url: 'https://www.chill-dogs.com/comforting/best-orthopedic-dog-beds/',
@@ -1894,16 +1708,8 @@ export const relaxationConverterPages: Record<string, RelaxationConverterPageCon
         },
       ],
     },
-    internalLinkStrip: {
-      heading: 'Related dog travel guides',
-      links: [
-        { label: 'How to Fly With a Dog', href: ROUTES.travelFlyWithDog },
-        { label: 'Best Airline Crates', href: ROUTES.comfortAirlineCrates },
-        { label: 'Best Calming Products', href: ROUTES.calmingTop },
-        { label: 'Car Anxiety Picks', href: ROUTES.calmingCar },
-        { label: 'Dog Road Trip Gear', href: ROUTES.roadTrip },
-      ],
-    },
+    internalLinkStripHeading: 'Related dog travel guides',
+    internalLinkStripLimit: 5,
     itemListSchema: {
       name: 'Best Airline-Approved Soft-Sided Dog Carriers',
       url: 'https://www.chill-dogs.com/comforting/best-airline-approved-dog-carriers/',
@@ -2038,15 +1844,8 @@ export const relaxationConverterPages: Record<string, RelaxationConverterPageCon
         },
       ],
     },
-    internalLinkStrip: {
-      heading: 'Related dog travel guides',
-      links: [
-        { label: 'How to Fly With a Dog', href: ROUTES.travelFlyWithDog },
-        { label: 'Best Airline Crates', href: ROUTES.comfortAirlineCrates },
-        { label: 'Best Calming Products', href: ROUTES.calmingTop },
-        { label: 'Dog Road Trip Gear', href: ROUTES.roadTrip },
-      ],
-    },
+    internalLinkStripHeading: 'Related dog travel guides',
+    internalLinkStripLimit: 4,
     itemListSchema: {
       name: 'Best Dog Travel Bags for Flying',
       url: 'https://www.chill-dogs.com/comforting/best-dog-travel-bags-for-flying/',

--- a/src/data/sitemap-inventory.ts
+++ b/src/data/sitemap-inventory.ts
@@ -18,6 +18,7 @@ export async function getArticleSitemapSection(): Promise<SitemapSection> {
         topics: entry.data.topics,
         pinnedRelated: entry.data.pinnedRelated,
         excludeRelated: entry.data.excludeRelated,
+        relatedLabel: entry.data.relatedLabel,
       })
     );
 

--- a/src/pages/gear/airtag-for-dogs.astro
+++ b/src/pages/gear/airtag-for-dogs.astro
@@ -295,13 +295,8 @@ const collectionSchema = {
 
     <InternalLinkStrip
       heading="More Dog Tracking Guides"
-      links={[
-        { label: 'All GPS Trackers', href: ROUTES.trackingTop },
-        { label: 'Fi Collar Review', href: ROUTES.fiCollarReview },
-        { label: 'Garmin Off-Grid Systems', href: ROUTES.garminTracking },
-        { label: 'When Rhys Ran Away', href: ROUTES.rhysRanAway },
-        { label: 'Dog Ran Away Guide', href: ROUTES.dogRanAwaySafety },
-      ]}
+      currentHref={ROUTES.airtagForDogs}
+      limit={5}
       fromPage={pageSlug}
     />
   </div>

--- a/src/pages/gear/best-dog-gps-trackers.astro
+++ b/src/pages/gear/best-dog-gps-trackers.astro
@@ -466,14 +466,8 @@ const itemListSchema = {
 
     <InternalLinkStrip
       heading="More Dog Tracking + Safety Guides"
-      links={[
-        { label: 'When Rhys Ran Away', href: ROUTES.rhysRanAway },
-        { label: 'Fi Collar Review', href: ROUTES.fiCollarReview },
-        { label: 'Garmin Dog Tracking', href: ROUTES.garminTracking },
-        { label: 'AirTag for Dogs', href: ROUTES.airtagForDogs },
-        { label: 'Dog Ran Away Guide', href: ROUTES.dogRanAwaySafety },
-        { label: 'Road Trip Chill Kit', href: ROUTES.roadTrip },
-      ]}
+      currentHref={ROUTES.trackingTop}
+      limit={6}
       fromPage={pageSlug}
     />
   </div>

--- a/src/pages/gear/fi-dog-collar-review.astro
+++ b/src/pages/gear/fi-dog-collar-review.astro
@@ -318,13 +318,8 @@ const articleSchema = {
 
     <InternalLinkStrip
       heading="More Dog Tracking Guides"
-      links={[
-        { label: 'All GPS Trackers', href: ROUTES.trackingTop },
-        { label: 'Garmin Off-Grid Systems', href: ROUTES.garminTracking },
-        { label: 'AirTag for Dogs', href: ROUTES.airtagForDogs },
-        { label: 'When Rhys Ran Away', href: ROUTES.rhysRanAway },
-        { label: 'Dog Ran Away Guide', href: ROUTES.dogRanAwaySafety },
-      ]}
+      currentHref={ROUTES.fiCollarReview}
+      limit={5}
       fromPage={pageSlug}
     />
   </div>

--- a/src/pages/gear/garmin-dog-tracking-collars.astro
+++ b/src/pages/gear/garmin-dog-tracking-collars.astro
@@ -322,13 +322,8 @@ const collectionSchema = {
 
     <InternalLinkStrip
       heading="More Dog Tracking Guides"
-      links={[
-        { label: 'All GPS Trackers', href: ROUTES.trackingTop },
-        { label: 'Fi Collar Review', href: ROUTES.fiCollarReview },
-        { label: 'AirTag for Dogs', href: ROUTES.airtagForDogs },
-        { label: 'When Rhys Ran Away', href: ROUTES.rhysRanAway },
-        { label: 'Dog Ran Away Guide', href: ROUTES.dogRanAwaySafety },
-      ]}
+      currentHref={ROUTES.garminTracking}
+      limit={5}
       fromPage={pageSlug}
     />
   </div>

--- a/src/utils/related-pages.ts
+++ b/src/utils/related-pages.ts
@@ -63,7 +63,7 @@ export async function getRelatedPages(options: RelatedPagesOptions): Promise<Sit
 
 export function toLinkStripItems(pages: SitemapPage[]): LinkStripItem[] {
   return pages.map((page) => ({
-    label: cleanPreviewTitle(page.preview.title),
+    label: page.relatedLabel ?? cleanPreviewTitle(page.preview.title),
     href: page.href,
   }));
 }


### PR DESCRIPTION
## Summary
- derive converter related-content surfaces from sitemap metadata instead of per-page static arrays
- add sitemap topics and editorial related-content metadata for calming/comfort converter pages
- update docs and smoke/unit coverage for derived related links

## Verification
- pre-commit hook passed: bun run test + bun run test:smoke
- bun run build