### PR TITLE
Add dedicated newsletter signup page at /subscribe/

### DIFF
--- a/docs/system-definition.yaml
+++ b/docs/system-definition.yaml
@@ -269,6 +269,7 @@ site_system:
         - "/privacy-policy/"
         - "/terms/"
         - "/affiliate-disclosure/"
+        - "/subscribe/"
         - "/subscribe/thanks/"
         - "/subscribe/confirmed/"
       notes: "/admin/products/ is the canonical product inventory review page. Every product in any product data file must flow into this page through src/data/product-catalog.ts; do not hardcode product rows in the admin route. /content-sitemap/ is a hidden editor page that previews the complete build-time sitemap inventory from src/data/sitemap-inventory.ts, which merges static pages with article collection pages and final built share metadata, including post-build OG image rewrites."
@@ -338,10 +339,12 @@ site_system:
       - "email_signup_view"
       - "email_signup_start"
       - "email_signup_submit"
+      - "pageview:/subscribe/"
       - "pageview:/subscribe/thanks/"
       - "pageview:/subscribe/confirmed/"
     notes: >
       Converters intentionally exclude the footer signup so affiliate pages stay single-purpose.
+      /subscribe/ is a dedicated signup landing page (noindex, not linked from the site) for sharing directly.
       /subscribe/thanks/ and /subscribe/confirmed/ are informer pages, noindex, excluded from sitemap discovery,
       and include a minimal Chill-Dogs logo link back to the homepage without restoring full site chrome.
 

--- a/src/data/content-sitemap.ts
+++ b/src/data/content-sitemap.ts
@@ -579,6 +579,15 @@ export const staticSitemapSections: SitemapSection[] = [
         noindex: true,
       }),
       createSitemapPage({
+        baseTitle: 'Subscribe to Chill-Dogs',
+        ogTitle: 'Subscribe to Chill-Dogs | Dog Tips and Gear Picks',
+        description:
+          'Get practical tips, seasonal reminders, and researched gear picks for keeping your dog cool, calm, and comfortable. Sent occasionally.',
+        href: ROUTES.subscribe,
+        pageType: 'informer',
+        noindex: true,
+      }),
+      createSitemapPage({
         baseTitle: 'Check Your Email',
         ogTitle: 'Check Your Email to Confirm Your Chill-Dogs Signup',
         description:

--- a/src/data/routes.ts
+++ b/src/data/routes.ts
@@ -44,6 +44,7 @@ export const ROUTES = {
   affiliateDisclosure: '/affiliate-disclosure/',
   privacyPolicy: '/privacy-policy/',
   terms: '/terms/',
+  subscribe: '/subscribe/',
   subscribeThanks: '/subscribe/thanks/',
   subscribeConfirmed: '/subscribe/confirmed/',
 } as const;

--- a/src/pages/subscribe/index.astro
+++ b/src/pages/subscribe/index.astro
@@ -1,0 +1,157 @@
+---
+import { ROUTES } from '@data/routes';
+import BaseLayout from '@layouts/BaseLayout.astro';
+import EmailSignup from '@components/EmailSignup.astro';
+import SubscribeFlowHeader from '@components/SubscribeFlowHeader.astro';
+
+const title = 'Subscribe to Chill-Dogs';
+const description = 'Get practical tips, seasonal reminders, and researched gear picks for keeping your dog cool, calm, and comfortable. Sent occasionally.';
+
+const routingCards = [
+  {
+    title: 'Cooling Picks',
+    description: 'Start with the main cooling path for mats, vests, bandanas, and heat-ready gear.',
+    href: ROUTES.coolingHub,
+  },
+  {
+    title: 'Calming Picks',
+    description: 'See the main calming path for wraps, chews, lick mats, and travel-stress help.',
+    href: ROUTES.calmingHub,
+  },
+  {
+    title: 'Comfort & Rest',
+    description: 'Browse beds, crates, and comfort-focused guides for dogs who need better downtime.',
+    href: ROUTES.comfortHub,
+  },
+  {
+    title: 'Hot Weather Guide',
+    description: 'Read the heat-safety guide that explains when temperatures are too hot for dogs.',
+    href: ROUTES.coolingSafety,
+  },
+];
+---
+
+<BaseLayout
+  title={title}
+  ogTitle="Subscribe to Chill-Dogs | Dog Tips and Gear Picks"
+  description={description}
+  noindex={true}
+  hideChrome={true}
+>
+  <SubscribeFlowHeader />
+  <section class="subscribe-flow container">
+    <div class="subscribe-panel">
+      <p class="eyebrow">Newsletter</p>
+      <h1>Tips for your dog</h1>
+      <p class="lede">
+        Practical tips, seasonal safety reminders, and researched gear picks — focused on keeping dogs cool, calm, and comfortable.
+      </p>
+
+      <EmailSignup
+        placement="homepage_inline"
+        pageSlug={ROUTES.subscribe}
+        pageType="informer"
+        category="newsletter_signup"
+      />
+
+      <div class="routing-grid">
+        {routingCards.map((card) => (
+          <a href={card.href} class="routing-card">
+            <h2>{card.title}</h2>
+            <p>{card.description}</p>
+            <span>Explore -&gt;</span>
+          </a>
+        ))}
+      </div>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .subscribe-flow {
+    padding-top: var(--space-2xl);
+    padding-bottom: var(--space-4xl);
+  }
+
+  .subscribe-panel {
+    display: grid;
+    gap: var(--space-xl);
+    width: min(100%, 56rem);
+    margin: 0 auto;
+    padding: var(--space-2xl);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    background: var(--color-surface);
+    box-shadow: var(--shadow-md);
+  }
+
+  .eyebrow {
+    margin: 0;
+    color: var(--color-accent-text);
+    font-size: var(--text-xs);
+    font-weight: var(--weight-bold);
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+
+  h1 {
+    margin: 0;
+    font-size: var(--text-4xl);
+  }
+
+  .lede {
+    margin: 0;
+    font-size: var(--text-base);
+    line-height: var(--leading-relaxed);
+    color: var(--color-text-muted);
+  }
+
+  .routing-grid {
+    display: grid;
+    gap: var(--space-md);
+  }
+
+  .routing-card {
+    display: grid;
+    gap: var(--space-sm);
+    padding: var(--space-lg);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: linear-gradient(180deg, rgba(135, 183, 199, 0.14), rgba(245, 240, 232, 0.9));
+    text-decoration: none;
+    color: var(--color-text);
+    transition: transform var(--transition-fast), box-shadow var(--transition-fast);
+  }
+
+  .routing-card:hover {
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-sm);
+  }
+
+  .routing-card h2,
+  .routing-card p,
+  .routing-card span {
+    margin: 0;
+  }
+
+  .routing-card h2 {
+    font-size: var(--text-xl);
+  }
+
+  .routing-card p {
+    color: var(--color-text-muted);
+    line-height: var(--leading-relaxed);
+  }
+
+  .routing-card span {
+    font-size: var(--text-sm);
+    font-weight: var(--weight-bold);
+    color: var(--color-link);
+  }
+
+  @media (min-width: 700px) {
+    .routing-grid {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+</style>


### PR DESCRIPTION
Standalone landing page to share directly with people — not linked from
anywhere on the site. Has the same layout as the confirmed page with the
email signup form above the routing grid.

https://claude.ai/code/session_01TSs3vPbnoA2oQHz2MsgC1P