### PR TITLE
Add Fuse.js client-side search at /search/

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,6 +14,7 @@
         "@vercel/speed-insights": "^1.3.1",
         "astro": "^5.18.0",
         "astro-robots-txt": "^1.0.0",
+        "fuse.js": "^7.3.0",
         "typescript": "^6.0.3",
       },
       "devDependencies": {
@@ -547,6 +548,8 @@
     "fontkitten": ["fontkitten@1.0.2", "", { "dependencies": { "tiny-inflate": "^1.0.3" } }, "sha512-piJxbLnkD9Xcyi7dWJRnqszEURixe7CrF/efBfbffe2DPyabmuIuqraruY8cXTs19QoM8VJzx47BDRVNXETM7Q=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "fuse.js": ["fuse.js@7.3.0", "", {}, "sha512-plz8RVjfcDedTGfVngWH1jmJvBvAwi1v2jecfDerbEnMcmOYUEEwKFTHbNoCiYyzaK2Ws8lABkTCcRSqCY1q4w=="],
 
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 

--- a/docs/ai/engineering/analytics-events.md
+++ b/docs/ai/engineering/analytics-events.md
@@ -91,7 +91,7 @@ track('hero_impression', { variant: 'a', page: 'cooling' });
 | `email_signup_start` | Email field is focused | — |
 | `email_signup_submit` | Form submitted | — |
 | `search_query` | User search produces results (fired after 150 ms debounce) | `query`, `result_count`, `filter` |
-| `search_result_click` | User clicks a page result card from `/search/` | `result_href`, `result_title`, `result_type`, `query` |
+| `search_result_click` | User clicks a page or product result card from `/search/` | `result_href`, `result_title`, `result_type`, `query` |
 
 ---
 

--- a/docs/ai/engineering/analytics-events.md
+++ b/docs/ai/engineering/analytics-events.md
@@ -3,7 +3,7 @@ title: Analytics Events
 type: canonical
 domain: engineering
 status: active
-updated: 2026-05-23
+updated: 2026-05-24
 tags:
   - chill-dogs
   - engineering
@@ -90,6 +90,8 @@ track('hero_impression', { variant: 'a', page: 'cooling' });
 | `email_signup_view` | Email signup form is viewed | — |
 | `email_signup_start` | Email field is focused | — |
 | `email_signup_submit` | Form submitted | — |
+| `search_query` | User search produces results (fired after 150 ms debounce) | `query`, `result_count`, `filter` |
+| `search_result_click` | User clicks a page result card from `/search/` | `result_href`, `result_title`, `result_type`, `query` |
 
 ---
 

--- a/docs/ai/engineering/search.md
+++ b/docs/ai/engineering/search.md
@@ -1,0 +1,146 @@
+---
+title: Search — Architecture & Pattern
+type: canonical
+domain: engineering
+status: active
+updated: 2026-05-24
+tags:
+  - chill-dogs
+  - engineering
+  - search
+  - fuse.js
+  - client-side
+related:
+  - analytics-events.md
+  - routes-and-sitemap.md
+  - architecture.md
+---
+
+# Search — Architecture & Pattern
+
+How client-side search works on chill-dogs.com: index generation, Fuse.js configuration, the `/search/` page, and how to maintain it.
+
+## Use this when
+
+Adding new searchable content types, tuning relevance weights, updating the search UI, or wiring search analytics.
+
+---
+
+## Overview
+
+Search is fully static — no server. The index is prerendered at build time as a JSON file. Fuse.js runs in the browser against that file.
+
+| Part | File |
+|---|---|
+| Index endpoint | `src/pages/search-index.json.ts` |
+| Search page | `src/pages/search.astro` |
+| Route constant | `ROUTES.search = '/search/'` in `src/data/routes.ts` |
+
+---
+
+## Index endpoint (`/search-index.json`)
+
+`src/pages/search-index.json.ts` is an Astro API route that prerenders at build time.
+
+**Sources:**
+- All non-noindex pages from `getCompleteSitemapPages()` (`src/data/sitemap-inventory.ts`)
+- All products from `productCatalogItems` (`src/data/product-catalog.ts`)
+
+**Output shape:**
+
+```typescript
+type SearchIndexItem =
+  | {
+      type: 'page';
+      title: string;         // SitemapPage.baseTitle
+      description: string;   // SitemapPage.preview.description
+      pageType: string;      // 'converter' | 'collector' | 'attractor' | 'informer'
+      href: string;
+      topics: string[];
+    }
+  | {
+      type: 'product';
+      name: string;
+      pillar: string;        // 'cooling' | 'calming' | 'comfort' | 'gear'
+      category: string;
+      bestFor: string;
+      bullets: string;       // bullets array joined to a single string for Fuse weight matching
+      amazonUrl: string;
+    };
+```
+
+When new product data files or page sections are added, they automatically appear in the index on next build — no manual update required.
+
+---
+
+## Fuse.js configuration
+
+```javascript
+new Fuse(items, {
+  keys: [
+    { name: 'title',       weight: 0.40 },
+    { name: 'name',        weight: 0.40 },
+    { name: 'description', weight: 0.25 },
+    { name: 'bestFor',     weight: 0.25 },
+    { name: 'bullets',     weight: 0.15 },
+    { name: 'category',    weight: 0.10 },
+    { name: 'topics',      weight: 0.10 },
+  ],
+  threshold: 0.35,    // lower = stricter match
+  includeScore: true,
+  minMatchCharLength: 2,
+})
+```
+
+Threshold 0.35 is the working sweet spot: tight enough to avoid noise, loose enough for common misspellings like "bandana" vs "bandanas" or "orthopedic" vs "orthopaedic". Adjust if results feel too noisy or too sparse.
+
+---
+
+## Search page (`/search/`)
+
+- Page type: `informer`, `noindex: true`
+- Registered in `src/data/content-sitemap.ts` (Admin & Legal section)
+- Registered in `src/data/routes.ts` as `ROUTES.search`
+- A magnifying-glass icon in `src/components/Header.astro` links to it
+
+### UI features
+
+- **Search input** — debounced 150 ms; updates `?q=` URL param for shareable links
+- **Filter bar** — pill buttons: All / Guides (converter) / Hubs (collector) / Products
+- **Result cards:**
+  - Page card — badge (Guide/Hub/Home/Info), title, description, "Read guide →" text link
+  - Product card — badge (Cooling/Calming/Comfort/Gear), name, bestFor, styled "Buy on Amazon" CTA button
+- **Zero-state** — "No results for …" message
+
+### Analytics
+
+| Event | When |
+|---|---|
+| `search_query` | After debounce, when results render. Props: `query`, `result_count`, `filter` |
+| `search_result_click` | Click on a page result card. Props: `result_href`, `result_title`, `result_type`, `query` |
+| `amazon_outbound_click` | Click on any product Buy button. Props: `product_name` (via `data-track` + `data-product-name`) |
+
+The Amazon buy buttons in search results carry `data-affiliate="true"` and `data-track="amazon_outbound_click"` so they fire the same keystone event as all other affiliate links.
+
+---
+
+## Smoke test exemption
+
+`src/__tests__/site-smoke.test.ts` exempts `search/` from the JSON-LD presence check (noindex pages do not get breadcrumb schema from `BaseLayout`).
+
+---
+
+## Maintenance notes
+
+- **New product pillar**: add to `productCatalogItems` — search index picks it up automatically
+- **New page section**: add to `staticSitemapSections` in `src/data/content-sitemap.ts` — search index picks it up automatically
+- **Relevance tuning**: adjust key weights or `threshold` in `src/pages/search.astro`
+- **Do not** add a sitemap entry or canonical link for `/search/` — it is noindex by design
+
+---
+
+## Related knowledge
+
+- [`analytics-events.md`](analytics-events.md) — Full event table and tracking rules
+- [`routes-and-sitemap.md`](routes-and-sitemap.md) — How to add pages to the sitemap
+- [`architecture.md`](architecture.md) — PostHog and build pipeline

--- a/docs/ai/engineering/search.md
+++ b/docs/ai/engineering/search.md
@@ -60,12 +60,13 @@ type SearchIndexItem =
     }
   | {
       type: 'product';
+      id: string;
       name: string;
       pillar: string;        // 'cooling' | 'calming' | 'comfort' | 'gear'
       category: string;
       bestFor: string;
       bullets: string;       // bullets array joined to a single string for Fuse weight matching
-      amazonUrl: string;
+      href: string;          // Internal /shop/?q=... route
     };
 ```
 
@@ -86,41 +87,41 @@ new Fuse(items, {
     { name: 'category',    weight: 0.10 },
     { name: 'topics',      weight: 0.10 },
   ],
-  threshold: 0.35,    // lower = stricter match
+  threshold: 0.2,     // lower = stricter match
   includeScore: true,
   minMatchCharLength: 2,
 })
 ```
 
-Threshold 0.35 is the working sweet spot: tight enough to avoid noise, loose enough for common misspellings like "bandana" vs "bandanas" or "orthopedic" vs "orthopaedic". Adjust if results feel too noisy or too sparse.
+Threshold 0.2 is the working setting: tight enough to avoid noisy product matches while preserving useful matches on names, topics, categories, and descriptions. Adjust if results feel too noisy or too sparse.
 
 ---
 
 ## Search page (`/search/`)
 
-- Page type: `informer`, `noindex: true`
-- Registered in `src/data/content-sitemap.ts` (Admin & Legal section)
+- Page type: `collector`, `noindex: true`
+- Registered in `src/data/content-sitemap.ts`
 - Registered in `src/data/routes.ts` as `ROUTES.search`
 - A magnifying-glass icon in `src/components/Header.astro` links to it
 
 ### UI features
 
 - **Search input** — debounced 150 ms; updates `?q=` URL param for shareable links
-- **Filter bar** — pill buttons: All / Guides (converter) / Hubs (collector) / Products
+- **Filter bar** — pill buttons: All / Guides (converter) / Collectors / Products
+- **Suggested paths** — static internal links to high-intent cooling, calming, comfort, and GPS tracker pages
 - **Result cards:**
-  - Page card — badge (Guide/Hub/Home/Info), title, description, "Read guide →" text link
-  - Product card — badge (Cooling/Calming/Comfort/Gear), name, bestFor, styled "Buy on Amazon" CTA button
-- **Zero-state** — "No results for …" message
+  - Page card — badge (Guide/Collector/Home/Info), title, description, page-type-specific CTA
+  - Product card — badge (Cooling/Calming/Comfort/Gear), name, bestFor, internal "View in shop →" link
+- **State handling** — loading, short-query, empty-result, filtered-empty, and index-fetch-error messages
 
 ### Analytics
 
 | Event | When |
 |---|---|
 | `search_query` | After debounce, when results render. Props: `query`, `result_count`, `filter` |
-| `search_result_click` | Click on a page result card. Props: `result_href`, `result_title`, `result_type`, `query` |
-| `amazon_outbound_click` | Click on any product Buy button. Props: `product_name` (via `data-track` + `data-product-name`) |
+| `search_result_click` | Click on a page or product result card. Props: `result_href`, `result_title`, `result_type`, `query` |
 
-The Amazon buy buttons in search results carry `data-affiliate="true"` and `data-track="amazon_outbound_click"` so they fire the same keystone event as all other affiliate links.
+Product results route internally to `/shop/?q=...`, where product cards render Amazon links through `AffiliateLink.astro` and fire the shared `amazon_outbound_click` event.
 
 ---
 
@@ -135,7 +136,7 @@ The Amazon buy buttons in search results carry `data-affiliate="true"` and `data
 - **New product pillar**: add to `productCatalogItems` — search index picks it up automatically
 - **New page section**: add to `staticSitemapSections` in `src/data/content-sitemap.ts` — search index picks it up automatically
 - **Relevance tuning**: adjust key weights or `threshold` in `src/pages/search.astro`
-- **Do not** add a sitemap entry or canonical link for `/search/` — it is noindex by design
+- **Do not** make `/search/` indexable or add direct Amazon links there — it is a noindex collector by design
 
 ---
 

--- a/docs/system-definition.yaml
+++ b/docs/system-definition.yaml
@@ -8,7 +8,7 @@
 
 site_system:
   status: "active"
-  as_of: "2026-04-14"
+  as_of: "2026-05-24"
   owner: "chill-dogs"
   purpose: "Define the website as a modular conversion system and keep implementation aligned."
 
@@ -277,16 +277,16 @@ site_system:
         Page type is converter (not informer) because it drives Amazon affiliate clicks.
 
     - name: "Search"
-      type: "informer"
-      target_action: "Surface pages and products by keyword; route to converters and affiliate links"
-      metric: "search_query, search_result_click, amazon_outbound_click"
+      type: "collector"
+      target_action: "Surface pages and products by keyword; route users to converters"
+      metric: "search_query, search_result_click, downstream amazon_outbound_click on converter pages"
       routes:
         - "/search/"
       notes: >
         Client-side Fuse.js search at /search/. Index prerendered at build time via src/pages/search-index.json.ts,
-        which merges all non-noindex sitemap pages with the full product catalog. Filter bar (All/Guides/Hubs/Products).
-        Product result cards include a styled Buy on Amazon button with data-affiliate="true" and
-        data-track="amazon_outbound_click". Page is noindex. See docs/ai/engineering/search.md.
+        which merges all non-noindex sitemap pages with the full product catalog. Filter bar (All/Guides/Collectors/Products).
+        Page result cards route to indexed site pages. Product result cards route internally to /shop/?q=... so
+        Amazon outbound links remain centralized in converter pages/components. Page is noindex. See docs/ai/engineering/search.md.
 
     - name: "Informer pages"
       type: "informer"

--- a/docs/system-definition.yaml
+++ b/docs/system-definition.yaml
@@ -276,6 +276,18 @@ site_system:
         with client-side filtering by pillar, category, and search. Linked from site footer.
         Page type is converter (not informer) because it drives Amazon affiliate clicks.
 
+    - name: "Search"
+      type: "informer"
+      target_action: "Surface pages and products by keyword; route to converters and affiliate links"
+      metric: "search_query, search_result_click, amazon_outbound_click"
+      routes:
+        - "/search/"
+      notes: >
+        Client-side Fuse.js search at /search/. Index prerendered at build time via src/pages/search-index.json.ts,
+        which merges all non-noindex sitemap pages with the full product catalog. Filter bar (All/Guides/Hubs/Products).
+        Product result cards include a styled Buy on Amazon button with data-affiliate="true" and
+        data-track="amazon_outbound_click". Page is noindex. See docs/ai/engineering/search.md.
+
     - name: "Informer pages"
       type: "informer"
       target_action: "Trust and compliance clarity"

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@vercel/speed-insights": "^1.3.1",
     "astro": "^5.18.0",
     "astro-robots-txt": "^1.0.0",
+    "fuse.js": "^7.3.0",
     "typescript": "^6.0.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "astro build && node scripts/apply-first-page-image-og.mjs && node scripts/apply-content-sitemap-share-preview.mjs && node scripts/indexnow-submit.mjs",
     "preview": "astro preview",
     "astro": "astro",
-    "test": "vitest run",
+    "test": "bun run build && vitest run",
     "test:smoke": "vitest run src/__tests__/site-smoke.test.ts",
     "test:coverage": "vitest run --coverage",
     "prepare": "simple-git-hooks",

--- a/src/__tests__/search.test.ts
+++ b/src/__tests__/search.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { productCatalogItems } from '../data/product-catalog';
+
+describe('search index — product data shape', () => {
+  it('every product has the fields the search index requires', () => {
+    for (const p of productCatalogItems) {
+      expect(typeof p.name, `${p.id} missing name`).toBe('string');
+      expect(p.name.length, `${p.id} empty name`).toBeGreaterThan(0);
+      expect(typeof p.amazonUrl, `${p.id} missing amazonUrl`).toBe('string');
+      expect(p.amazonUrl.length, `${p.id} empty amazonUrl`).toBeGreaterThan(0);
+      expect(typeof p.bestFor, `${p.id} missing bestFor`).toBe('string');
+      expect(p.bestFor.length, `${p.id} empty bestFor`).toBeGreaterThan(0);
+      expect(Array.isArray(p.bullets), `${p.id} bullets not array`).toBe(true);
+      expect(p.bullets.length, `${p.id} empty bullets`).toBeGreaterThan(0);
+    }
+  });
+
+  it('every product has a valid pillar', () => {
+    const validPillars = new Set(['cooling', 'calming', 'comfort', 'gear']);
+    for (const p of productCatalogItems) {
+      expect(validPillars.has(p.pillar), `${p.id} invalid pillar: ${p.pillar}`).toBe(true);
+    }
+  });
+
+  it('product count is non-zero', () => {
+    expect(productCatalogItems.length).toBeGreaterThan(0);
+  });
+});

--- a/src/__tests__/search.test.ts
+++ b/src/__tests__/search.test.ts
@@ -1,13 +1,15 @@
 import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
 import { productCatalogItems } from '../data/product-catalog';
+import { ROUTES } from '../data/routes';
+import { GET as getSearchIndex } from '../pages/search-index.json';
 
 describe('search index — product data shape', () => {
   it('every product has the fields the search index requires', () => {
     for (const p of productCatalogItems) {
       expect(typeof p.name, `${p.id} missing name`).toBe('string');
       expect(p.name.length, `${p.id} empty name`).toBeGreaterThan(0);
-      expect(typeof p.amazonUrl, `${p.id} missing amazonUrl`).toBe('string');
-      expect(p.amazonUrl.length, `${p.id} empty amazonUrl`).toBeGreaterThan(0);
       expect(typeof p.bestFor, `${p.id} missing bestFor`).toBe('string');
       expect(p.bestFor.length, `${p.id} empty bestFor`).toBeGreaterThan(0);
       expect(Array.isArray(p.bullets), `${p.id} bullets not array`).toBe(true);
@@ -24,5 +26,45 @@ describe('search index — product data shape', () => {
 
   it('product count is non-zero', () => {
     expect(productCatalogItems.length).toBeGreaterThan(0);
+  });
+
+  it('routes product search entries internally to the shop converter', async () => {
+    const response = await getSearchIndex({} as never);
+    const items = await response.json();
+    const productItems = items.filter((item: { type: string }) => item.type === 'product');
+
+    expect(productItems.length).toBe(productCatalogItems.length);
+
+    for (const item of productItems) {
+      const catalogItem = productCatalogItems.find((product) => product.id === item.id);
+      expect(catalogItem, `${item.id} missing from product catalog`).toBeTruthy();
+      expect(item.href).toBe(`${ROUTES.shop}?q=${encodeURIComponent(item.name)}`);
+      expect(item.href.startsWith(ROUTES.shop)).toBe(true);
+      expect(item.href).not.toContain('amazon.');
+      expect(item).not.toHaveProperty('amazonUrl');
+    }
+  });
+
+  it('keeps search-specific UI and docs on collector terminology', () => {
+    const projectRoot = path.resolve(__dirname, '../..');
+    const searchPage = readFileSync(path.join(projectRoot, 'src/pages/search.astro'), 'utf8');
+    const searchDoc = readFileSync(path.join(projectRoot, 'docs/ai/engineering/search.md'), 'utf8');
+
+    expect(searchPage).toContain('Collectors');
+    expect(searchPage).not.toContain('Hubs');
+    expect(searchDoc).toContain('Collectors');
+    expect(searchDoc).not.toContain('Hubs');
+  });
+
+  it('documents and renders collector search UI states', () => {
+    const projectRoot = path.resolve(__dirname, '../..');
+    const searchPage = readFileSync(path.join(projectRoot, 'src/pages/search.astro'), 'utf8');
+    const searchDoc = readFileSync(path.join(projectRoot, 'docs/ai/engineering/search.md'), 'utf8');
+
+    expect(searchPage).toContain('Loading search...');
+    expect(searchPage).toContain('View in shop');
+    expect(searchPage).toContain('Compare picks');
+    expect(searchDoc).toContain('Suggested paths');
+    expect(searchDoc).toContain('State handling');
   });
 });

--- a/src/__tests__/seo-meta.test.ts
+++ b/src/__tests__/seo-meta.test.ts
@@ -11,7 +11,7 @@
 
 import { readdirSync, readFileSync, existsSync } from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 
 const distRoot = path.join(process.cwd(), 'dist');
 
@@ -56,7 +56,11 @@ function collectMeta(): PageMeta[] {
 }
 
 describe('SEO meta tag lengths', () => {
-  const pages = collectMeta();
+  let pages: PageMeta[] = [];
+
+  beforeAll(() => {
+    pages = collectMeta();
+  });
 
   it('dist/ contains indexable pages to check', () => {
     expect(pages.length).toBeGreaterThan(0);

--- a/src/__tests__/site-smoke.test.ts
+++ b/src/__tests__/site-smoke.test.ts
@@ -461,6 +461,23 @@ describe('site smoke tests', () => {
     expect(affiliateDoc.body.textContent).toContain('no additional cost to you');
   });
 
+  it('renders search as a noindex collector with internal product result routes', () => {
+    const searchDoc = readBuiltPage(path.join('search', 'index.html'));
+    const searchIndex = JSON.parse(readBuiltAsset('search-index.json'));
+    const productItems = searchIndex.filter((item: { type: string }) => item.type === 'product');
+
+    expect(searchDoc.querySelector('meta[name="robots"]')?.getAttribute('content'))
+      .toBe('noindex, nofollow');
+    expect(searchDoc.querySelectorAll('a[href*="amazon."]').length).toBe(0);
+    expect(productItems.length).toBeGreaterThan(0);
+
+    for (const item of productItems) {
+      expect(item.href).toMatch(/^\/shop\/\?q=/);
+      expect(item.href).not.toContain('amazon.');
+      expect(item).not.toHaveProperty('amazonUrl');
+    }
+  });
+
   it('renders subscribe flow pages without site chrome and keeps them noindex', () => {
     const subscribeDoc = readBuiltPage(path.join('subscribe', 'index.html'));
     const thanksDoc = readBuiltPage(path.join('subscribe', 'thanks', 'index.html'));

--- a/src/__tests__/site-smoke.test.ts
+++ b/src/__tests__/site-smoke.test.ts
@@ -658,7 +658,7 @@ describe('site smoke tests', () => {
   });
 
   it('content pages have at least one JSON-LD script', () => {
-    const noSchemaExpected = ['404.html', 'privacy-policy', 'terms', 'content-sitemap', 'admin/', 'subscribe/'];
+    const noSchemaExpected = ['404.html', 'privacy-policy', 'terms', 'content-sitemap', 'admin/', 'subscribe/', 'search/'];
     const htmlFiles = collectHtmlFiles(distRoot);
     const failures: string[] = [];
 

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -12,6 +12,7 @@ const navItems = [
 
 const currentPath = Astro.url.pathname;
 const isHome = currentPath === '/' || currentPath.startsWith('/v/');
+const isSearch = currentPath === ROUTES.search;
 ---
 
 <header class="site-header">
@@ -37,6 +38,18 @@ const isHome = currentPath === '/' || currentPath.startsWith('/v/');
             </a>
           </li>
         ))}
+        <li>
+          <a
+            href={ROUTES.search}
+            class:list={['search-link', { active: isSearch }]}
+            aria-label="Search"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <circle cx="11" cy="11" r="8"/>
+              <line x1="21" y1="21" x2="16.65" y2="16.65"/>
+            </svg>
+          </a>
+        </li>
       </ul>
     </nav>
   </div>
@@ -120,6 +133,12 @@ const isHome = currentPath === '/' || currentPath.startsWith('/v/');
   .main-nav a.active {
     color: var(--color-nav-accent, var(--color-primary));
     border-bottom-color: var(--color-nav-accent, var(--color-primary));
+  }
+
+  .search-link {
+    display: flex;
+    align-items: center;
+    padding: var(--space-xs) 0;
   }
 
   .menu-toggle {

--- a/src/content/articles/travel-dog-road-trip-gear.mdx
+++ b/src/content/articles/travel-dog-road-trip-gear.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Dog Road Trip Gear: Cooling & Calming Essentials That Work'
+title: "Dog Road Trip Gear: Rhys's Cooling & Calming Kit for Long Drives"
 description: 'Dog road trip gear tested on a 6,000-mile cross-country drive — cooling fan, magnetic shades, water bowl, and calming essentials for long drives with dogs.'
 ogTitle: 'Dog Road Trip Gear | Cooling & Calming Essentials'
 pubDate: 2026-03-31

--- a/src/data/content-sitemap.ts
+++ b/src/data/content-sitemap.ts
@@ -556,6 +556,13 @@ export const staticSitemapSections: SitemapSection[] = [
     description: 'Informer pages — compliance, trust, contact, and product inventory review. New products must flow into Product Catalog via data files, not hardcoded admin rows.',
     pages: [
       createSitemapPage({
+        baseTitle: 'Search',
+        description: 'Search all Chill-Dogs guides and products.',
+        href: ROUTES.search,
+        pageType: 'informer',
+        noindex: true,
+      }),
+      createSitemapPage({
         baseTitle: 'Product Catalog (Admin)',
         description: 'Curated gear, gift guides, and party ideas for dogs who live the good life.',
         href: '/admin/products/',

--- a/src/data/content-sitemap.ts
+++ b/src/data/content-sitemap.ts
@@ -155,6 +155,13 @@ export const staticSitemapSections: SitemapSection[] = [
         topics: ['comfort', 'sleep', 'beds', 'orthopedic', 'crates', 'crate-training', 'flying', 'carriers', 'travel'],
         relatedLabel: 'Comfort & Rest',
       }),
+      createSitemapPage({
+        baseTitle: 'Search',
+        description: 'Search all Chill-Dogs guides and products, then route to relevant product and guide pages.',
+        href: ROUTES.search,
+        pageType: 'collector',
+        noindex: true,
+      }),
     ],
   },
   {
@@ -555,13 +562,6 @@ export const staticSitemapSections: SitemapSection[] = [
     title: 'Admin & Legal',
     description: 'Informer pages — compliance, trust, contact, and product inventory review. New products must flow into Product Catalog via data files, not hardcoded admin rows.',
     pages: [
-      createSitemapPage({
-        baseTitle: 'Search',
-        description: 'Search all Chill-Dogs guides and products.',
-        href: ROUTES.search,
-        pageType: 'informer',
-        noindex: true,
-      }),
       createSitemapPage({
         baseTitle: 'Product Catalog (Admin)',
         description: 'Curated gear, gift guides, and party ideas for dogs who live the good life.',

--- a/src/data/routes.ts
+++ b/src/data/routes.ts
@@ -43,6 +43,7 @@ export const ROUTES = {
   comfortHeavyDutyCrates: '/comforting/best-heavy-duty-dog-crates/',
   comfortSleepArticle: '/comforting/how-much-do-dogs-sleep/',
   shop: '/shop/',
+  search: '/search/',
   affiliateDisclosure: '/affiliate-disclosure/',
   privacyPolicy: '/privacy-policy/',
   terms: '/terms/',

--- a/src/pages/search-index.json.ts
+++ b/src/pages/search-index.json.ts
@@ -1,0 +1,32 @@
+import type { APIRoute } from 'astro';
+import { productCatalogItems } from '@data/product-catalog';
+import { getCompleteSitemapPages } from '@data/sitemap-inventory';
+
+export const GET: APIRoute = async () => {
+  const pages = await getCompleteSitemapPages();
+
+  const pageItems = pages
+    .filter((p) => !p.noindex)
+    .map((p) => ({
+      type: 'page' as const,
+      title: p.baseTitle,
+      description: p.preview.description,
+      pageType: p.pageType,
+      href: p.href,
+      topics: p.topics ?? [],
+    }));
+
+  const productItems = productCatalogItems.map((p) => ({
+    type: 'product' as const,
+    name: p.name,
+    pillar: p.pillar,
+    category: p.category,
+    bestFor: p.bestFor,
+    bullets: p.bullets.join(' '),
+    amazonUrl: p.amazonUrl,
+  }));
+
+  return new Response(JSON.stringify([...pageItems, ...productItems]), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+};

--- a/src/pages/search-index.json.ts
+++ b/src/pages/search-index.json.ts
@@ -1,10 +1,21 @@
 import type { APIRoute } from 'astro';
 import { productCatalogItems } from '@data/product-catalog';
+import { buildProductPageMap } from '@data/product-page-map';
 import { ROUTES } from '@data/routes';
 import { getCompleteSitemapPages } from '@data/sitemap-inventory';
 
 export const GET: APIRoute = async () => {
   const pages = await getCompleteSitemapPages();
+
+  // Invert productPageMap → pageHref: productName[]
+  const pageProductNames: Record<string, string[]> = {};
+  for (const [productId, refs] of Object.entries(buildProductPageMap())) {
+    const product = productCatalogItems.find((p) => p.id === productId);
+    if (!product) continue;
+    for (const ref of refs) {
+      (pageProductNames[ref.href] ??= []).push(product.name);
+    }
+  }
 
   const pageItems = pages
     .filter((p) => !p.noindex)
@@ -15,6 +26,7 @@ export const GET: APIRoute = async () => {
       pageType: p.pageType,
       href: p.href,
       topics: p.topics ?? [],
+      productNames: pageProductNames[p.href] ?? [],
     }));
 
   const productItems = productCatalogItems.map((p) => ({

--- a/src/pages/search-index.json.ts
+++ b/src/pages/search-index.json.ts
@@ -1,5 +1,6 @@
 import type { APIRoute } from 'astro';
 import { productCatalogItems } from '@data/product-catalog';
+import { ROUTES } from '@data/routes';
 import { getCompleteSitemapPages } from '@data/sitemap-inventory';
 
 export const GET: APIRoute = async () => {
@@ -18,12 +19,13 @@ export const GET: APIRoute = async () => {
 
   const productItems = productCatalogItems.map((p) => ({
     type: 'product' as const,
+    id: p.id,
     name: p.name,
     pillar: p.pillar,
     category: p.category,
     bestFor: p.bestFor,
     bullets: p.bullets.join(' '),
-    amazonUrl: p.amazonUrl,
+    href: `${ROUTES.shop}?q=${encodeURIComponent(p.name)}`,
   }));
 
   return new Response(JSON.stringify([...pageItems, ...productItems]), {

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -19,7 +19,7 @@ const suggestedSearchPaths = [
   <section class="search-page container">
     <header class="search-header">
       <h1>Search</h1>
-      <p>Find Chill-Dogs guides, product categories, and researched gear picks.</p>
+      <p>Find Chill-Dogs articles, researched gear picks, and individual products.</p>
     </header>
     <div class="search-input-wrap">
       <input
@@ -32,8 +32,7 @@ const suggestedSearchPaths = [
     </div>
     <div class="filter-bar" id="filter-bar" role="group" aria-label="Filter results">
       <button class="filter-btn active" data-filter="all">All</button>
-      <button class="filter-btn" data-filter="converter">Guides</button>
-      <button class="filter-btn" data-filter="collector">Collectors</button>
+      <button class="filter-btn" data-filter="article">Articles</button>
       <button class="filter-btn" data-filter="product">Products</button>
     </div>
     <div id="search-status" class="search-status" aria-live="polite"></div>
@@ -72,7 +71,7 @@ const suggestedSearchPaths = [
   };
 
   type SearchItem = PageItem | ProductItem;
-  type FilterKey = 'all' | 'converter' | 'collector' | 'product';
+  type FilterKey = 'all' | 'article' | 'product';
 
   const input = document.getElementById('search-input') as HTMLInputElement;
   const resultsEl = document.getElementById('search-results') as HTMLDivElement;
@@ -86,8 +85,7 @@ const suggestedSearchPaths = [
 
   const FILTER_LABELS: Record<FilterKey, string> = {
     all: 'all',
-    converter: 'guide',
-    collector: 'collector',
+    article: 'article',
     product: 'product',
   };
 
@@ -112,15 +110,15 @@ const suggestedSearchPaths = [
   }
 
   const PAGE_TYPE_LABELS: Record<string, string> = {
-    converter: 'Guide',
-    collector: 'Collector',
+    converter: 'Article',
+    collector: 'Article',
     attractor: 'Home',
     informer:  'Info',
   };
 
   const PAGE_CTA_LABELS: Record<string, string> = {
     converter: 'Compare picks',
-    collector: 'Explore collector',
+    collector: 'Read article',
     attractor: 'Start here',
     informer: 'Read info',
   };
@@ -192,9 +190,9 @@ const suggestedSearchPaths = [
   function applyFilter(results: Fuse.FuseResult<SearchItem>[]): Fuse.FuseResult<SearchItem>[] {
     if (activeFilter === 'all') return results;
     if (activeFilter === 'product') return results.filter((r) => r.item.type === 'product');
-    // 'converter' or 'collector' filters page items by pageType.
+    // 'article' covers both converter and collector page types.
     return results.filter(
-      (r) => r.item.type === 'page' && r.item.pageType === activeFilter
+      (r) => r.item.type === 'page' && (r.item.pageType === 'converter' || r.item.pageType === 'collector')
     );
   }
 

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -1,5 +1,13 @@
 ---
 import BaseLayout from '@layouts/BaseLayout.astro';
+import { ROUTES } from '@data/routes';
+
+const suggestedSearchPaths = [
+  { href: ROUTES.coolingTop, label: 'Cooling picks' },
+  { href: ROUTES.calmingTop, label: 'Calming aids' },
+  { href: ROUTES.comfortCalmingBeds, label: 'Calming beds' },
+  { href: ROUTES.trackingTop, label: 'GPS trackers' },
+];
 ---
 
 <BaseLayout
@@ -9,7 +17,10 @@ import BaseLayout from '@layouts/BaseLayout.astro';
   noindex={true}
 >
   <section class="search-page container">
-    <h1>Search</h1>
+    <header class="search-header">
+      <h1>Search</h1>
+      <p>Find Chill-Dogs guides, product categories, and researched gear picks.</p>
+    </header>
     <div class="search-input-wrap">
       <input
         id="search-input"
@@ -22,10 +33,16 @@ import BaseLayout from '@layouts/BaseLayout.astro';
     <div class="filter-bar" id="filter-bar" role="group" aria-label="Filter results">
       <button class="filter-btn active" data-filter="all">All</button>
       <button class="filter-btn" data-filter="converter">Guides</button>
-      <button class="filter-btn" data-filter="collector">Hubs</button>
+      <button class="filter-btn" data-filter="collector">Collectors</button>
       <button class="filter-btn" data-filter="product">Products</button>
     </div>
     <div id="search-status" class="search-status" aria-live="polite"></div>
+    <div class="suggested-paths" id="suggested-paths" aria-label="Suggested searches">
+      <span>Popular paths</span>
+      {suggestedSearchPaths.map((path) => (
+        <a href={path.href}>{path.label}</a>
+      ))}
+    </div>
     <div id="search-results" class="search-results" role="list"></div>
   </section>
 </BaseLayout>
@@ -45,12 +62,13 @@ import BaseLayout from '@layouts/BaseLayout.astro';
 
   type ProductItem = {
     type: 'product';
+    id: string;
     name: string;
     pillar: string;
     category: string;
     bestFor: string;
     bullets: string;
-    amazonUrl: string;
+    href: string;
   };
 
   type SearchItem = PageItem | ProductItem;
@@ -66,8 +84,16 @@ import BaseLayout from '@layouts/BaseLayout.astro';
   let activeFilter: FilterKey = 'all';
   let currentQuery = '';
 
+  const FILTER_LABELS: Record<FilterKey, string> = {
+    all: 'all',
+    converter: 'guide',
+    collector: 'collector',
+    product: 'product',
+  };
+
   async function loadIndex() {
     const res = await fetch('/search-index.json');
+    if (!res.ok) throw new Error('Search index failed to load');
     const items: SearchItem[] = await res.json();
     fuse = new Fuse(items, {
       keys: [
@@ -87,9 +113,16 @@ import BaseLayout from '@layouts/BaseLayout.astro';
 
   const PAGE_TYPE_LABELS: Record<string, string> = {
     converter: 'Guide',
-    collector: 'Hub',
+    collector: 'Collector',
     attractor: 'Home',
     informer:  'Info',
+  };
+
+  const PAGE_CTA_LABELS: Record<string, string> = {
+    converter: 'Compare picks',
+    collector: 'Explore collector',
+    attractor: 'Start here',
+    informer: 'Read info',
   };
 
   const PILLAR_LABELS: Record<string, string> = {
@@ -109,6 +142,7 @@ import BaseLayout from '@layouts/BaseLayout.astro';
 
   function renderPageCard(item: PageItem): string {
     const label = PAGE_TYPE_LABELS[item.pageType] ?? item.pageType;
+    const cta = PAGE_CTA_LABELS[item.pageType] ?? 'Read guide';
     return `
       <a
         class="result-card result-card--page"
@@ -120,10 +154,13 @@ import BaseLayout from '@layouts/BaseLayout.astro';
         data-result-type="page"
         data-query="${esc(currentQuery)}"
       >
-        <span class="result-badge result-badge--${esc(item.pageType)}">${label}</span>
+        <div class="result-meta">
+          <span class="result-badge result-badge--${esc(item.pageType)}">${label}</span>
+          ${item.pageType === 'converter' ? '<span class="result-intent">Comparison guide</span>' : ''}
+        </div>
         <strong class="result-title">${esc(item.title)}</strong>
         <p class="result-desc">${esc(item.description)}</p>
-        <span class="result-cta">Read guide →</span>
+        <span class="result-cta">${esc(cta)} →</span>
       </a>
     `;
   }
@@ -131,41 +168,81 @@ import BaseLayout from '@layouts/BaseLayout.astro';
   function renderProductCard(item: ProductItem): string {
     const label = PILLAR_LABELS[item.pillar] ?? item.pillar;
     return `
-      <div class="result-card result-card--product" role="listitem">
-        <span class="result-badge result-badge--${esc(item.pillar)}">${label}</span>
+      <a
+        class="result-card result-card--product"
+        href="${esc(item.href)}"
+        role="listitem"
+        data-track="search_result_click"
+        data-result-href="${esc(item.href)}"
+        data-result-title="${esc(item.name)}"
+        data-result-type="product"
+        data-query="${esc(currentQuery)}"
+      >
+        <div class="result-meta">
+          <span class="result-badge result-badge--product">Product</span>
+          <span class="result-badge result-badge--${esc(item.pillar)}">${label}</span>
+        </div>
         <strong class="result-title">${esc(item.name)}</strong>
         <p class="result-desc">${esc(item.bestFor)}</p>
-        <a
-          class="result-buy-btn"
-          href="${esc(item.amazonUrl)}"
-          rel="sponsored noopener noreferrer"
-          target="_blank"
-          data-affiliate="true"
-          data-track="amazon_outbound_click"
-          data-product-name="${esc(item.name)}"
-        >Buy on Amazon</a>
-      </div>
+        <span class="result-cta">View in shop →</span>
+      </a>
     `;
   }
 
   function applyFilter(results: Fuse.FuseResult<SearchItem>[]): Fuse.FuseResult<SearchItem>[] {
     if (activeFilter === 'all') return results;
     if (activeFilter === 'product') return results.filter((r) => r.item.type === 'product');
-    // 'converter' or 'collector' — filter page items by pageType
+    // 'converter' or 'collector' filters page items by pageType.
     return results.filter(
       (r) => r.item.type === 'page' && r.item.pageType === activeFilter
     );
   }
 
+  function getSearchTitle(item: SearchItem): string {
+    return item.type === 'page' ? item.title : item.name;
+  }
+
+  function rankResult(result: Fuse.FuseResult<SearchItem>, query: string): number {
+    const normalizedQuery = query.toLowerCase();
+    const title = getSearchTitle(result.item).toLowerCase();
+    const exactTitleBonus = title.includes(normalizedQuery) ? -0.18 : 0;
+    const typeBonus =
+      result.item.type === 'page' && result.item.pageType === 'converter'
+        ? -0.08
+        : result.item.type === 'page' && result.item.pageType === 'collector'
+          ? -0.03
+          : result.item.type === 'product'
+            ? 0.02
+            : 0;
+    return (result.score ?? 1) + exactTitleBonus + typeBonus;
+  }
+
+  function sortResults(results: Fuse.FuseResult<SearchItem>[], query: string): Fuse.FuseResult<SearchItem>[] {
+    return [...results].sort((a, b) => rankResult(a, query) - rankResult(b, query));
+  }
+
+  function renderEmptyState(message: string) {
+    resultsEl.innerHTML = `
+      <div class="empty-state" role="status">
+        <strong>${esc(message)}</strong>
+        <p>Try one of the popular paths below, or search for a product category like "crate", "cooling mat", or "tracker".</p>
+      </div>
+    `;
+  }
+
   function renderResults() {
     const filtered = applyFilter(lastResults);
     if (filtered.length === 0 && lastResults.length > 0) {
-      statusEl.textContent = `No ${activeFilter === 'all' ? '' : activeFilter + ' '}results for "${currentQuery}"`;
+      const filterLabel = FILTER_LABELS[activeFilter];
+      statusEl.textContent = '';
+      renderEmptyState(`No ${filterLabel === 'all' ? '' : filterLabel + ' '}results for "${currentQuery}"`);
+      return;
+    }
+    if (filtered.length === 0) {
       resultsEl.innerHTML = '';
       return;
     }
-    if (filtered.length === 0) return;
-    const label = activeFilter === 'all' ? '' : ` ${activeFilter}`;
+    const label = activeFilter === 'all' ? '' : ` ${FILTER_LABELS[activeFilter]}`;
     statusEl.textContent = `${filtered.length}${label} result${filtered.length === 1 ? '' : 's'} for "${currentQuery}"`;
     resultsEl.innerHTML = filtered
       .map(({ item }) => (item.type === 'page' ? renderPageCard(item) : renderProductCard(item)))
@@ -179,13 +256,13 @@ import BaseLayout from '@layouts/BaseLayout.astro';
     if (trimmed.length < 2) {
       lastResults = [];
       resultsEl.innerHTML = '';
-      statusEl.textContent = '';
+      statusEl.textContent = 'Type at least 2 characters to search.';
       return;
     }
-    lastResults = fuse.search(trimmed, { limit: 48 });
+    lastResults = sortResults(fuse.search(trimmed, { limit: 48 }), trimmed);
     if (lastResults.length === 0) {
-      statusEl.textContent = `No results for "${trimmed}"`;
-      resultsEl.innerHTML = '';
+      statusEl.textContent = '';
+      renderEmptyState(`No results for "${trimmed}"`);
       return;
     }
     renderResults();
@@ -209,12 +286,22 @@ import BaseLayout from '@layouts/BaseLayout.astro';
   // Hydrate from ?q= param on load
   const initialQuery = new URLSearchParams(window.location.search).get('q') ?? '';
 
-  loadIndex().then(() => {
-    if (initialQuery) {
-      input.value = initialQuery;
-      runSearch(initialQuery);
-    }
-  });
+  statusEl.textContent = 'Loading search...';
+
+  loadIndex()
+    .then(() => {
+      if (initialQuery) {
+        input.value = initialQuery;
+        runSearch(initialQuery);
+      } else {
+        statusEl.textContent = 'Type at least 2 characters to search.';
+      }
+    })
+    .catch(() => {
+      statusEl.textContent = '';
+      input.disabled = true;
+      renderEmptyState('Search is temporarily unavailable.');
+    });
 
   let debounceTimer: ReturnType<typeof setTimeout>;
   input.addEventListener('input', () => {
@@ -233,14 +320,25 @@ import BaseLayout from '@layouts/BaseLayout.astro';
 
 <style>
   .search-page {
-    padding-top: var(--space-3xl);
+    padding-top: var(--space-2xl);
     padding-bottom: var(--space-4xl);
     max-width: 52rem;
   }
 
-  .search-page h1 {
-    font-size: var(--text-4xl);
+  .search-header {
     margin-bottom: var(--space-xl);
+  }
+
+  .search-header h1 {
+    font-size: var(--text-4xl);
+    margin-bottom: var(--space-xs);
+  }
+
+  .search-header p {
+    color: var(--color-text-muted);
+    font-size: var(--text-base);
+    line-height: var(--leading-relaxed);
+    margin: 0;
   }
 
   .search-input-wrap {
@@ -268,11 +366,13 @@ import BaseLayout from '@layouts/BaseLayout.astro';
   .filter-bar {
     display: flex;
     gap: var(--space-sm);
-    flex-wrap: wrap;
+    overflow-x: auto;
+    padding-bottom: 2px;
     margin-bottom: var(--space-lg);
   }
 
   .filter-btn {
+    flex: 0 0 auto;
     padding: 4px 14px;
     font-size: var(--text-sm);
     font-weight: var(--weight-medium);
@@ -304,6 +404,34 @@ import BaseLayout from '@layouts/BaseLayout.astro';
     min-height: 1.25em;
   }
 
+  .suggested-paths {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: var(--space-xs);
+    margin-bottom: var(--space-xl);
+    font-size: var(--text-sm);
+  }
+
+  .suggested-paths span {
+    color: var(--color-text-muted);
+    margin-right: var(--space-xs);
+  }
+
+  .suggested-paths a {
+    color: var(--color-text);
+    text-decoration: none;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-full);
+    padding: 4px 10px;
+    background: var(--color-surface);
+  }
+
+  .suggested-paths a:hover {
+    border-color: var(--color-primary);
+    color: var(--color-primary);
+  }
+
   /* ── Result grid ── */
   .search-results {
     display: grid;
@@ -324,16 +452,29 @@ import BaseLayout from '@layouts/BaseLayout.astro';
     transition: border-color 0.15s, box-shadow 0.15s;
   }
 
-  :global(.result-card--page) {
+  :global(.result-card--product) {
+    background: color-mix(in srgb, var(--color-surface) 92%, var(--color-sand));
+  }
+
+  :global(.result-card--page),
+  :global(.result-card--product) {
     text-decoration: none;
   }
 
-  :global(.result-card--page:hover) {
+  :global(.result-card--page:hover),
+  :global(.result-card--product:hover) {
     border-color: var(--color-primary);
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
   }
 
   /* ── Badges ── */
+  :global(.result-meta) {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: var(--space-xs);
+  }
+
   :global(.result-badge) {
     display: inline-block;
     font-size: var(--text-xs);
@@ -348,6 +489,7 @@ import BaseLayout from '@layouts/BaseLayout.astro';
   :global(.result-badge--converter),
   :global(.result-badge--collector),
   :global(.result-badge--informer) { background: var(--color-bg-alt); color: var(--color-text-muted); }
+  :global(.result-badge--product)  { background: var(--color-charcoal); color: var(--color-sand); }
   :global(.result-badge--attractor) { background: var(--color-sand); color: var(--color-charcoal); }
   :global(.result-badge--cooling)   { background: #ddf0f7; color: #2a6a80; }
   :global(.result-badge--calming)   { background: #e8f0e8; color: #3d6b3a; }
@@ -355,6 +497,11 @@ import BaseLayout from '@layouts/BaseLayout.astro';
   :global(.result-badge--gear)      { background: #ede8f5; color: #4a3a70; }
 
   /* ── Card content ── */
+  :global(.result-intent) {
+    font-size: var(--text-xs);
+    color: var(--color-text-muted);
+  }
+
   :global(.result-title) {
     font-size: var(--text-base);
     font-weight: var(--weight-semibold);
@@ -375,34 +522,37 @@ import BaseLayout from '@layouts/BaseLayout.astro';
     margin-top: var(--space-xs);
   }
 
-  :global(.result-card--page:hover .result-cta) {
+  :global(.result-card--page:hover .result-cta),
+  :global(.result-card--product:hover .result-cta) {
     color: var(--color-link-hover);
   }
 
-  /* ── Amazon buy button ── */
-  :global(.result-buy-btn) {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    margin-top: var(--space-sm);
-    padding: 8px 16px;
+  :global(.empty-state) {
+    border: 1px dashed var(--color-border);
+    border-radius: var(--radius-md);
+    padding: var(--space-xl);
+    background: var(--color-bg-alt);
+  }
+
+  :global(.empty-state strong) {
+    display: block;
+    margin-bottom: var(--space-xs);
+  }
+
+  :global(.empty-state p) {
+    color: var(--color-text-muted);
     font-size: var(--text-sm);
-    font-weight: var(--weight-semibold);
-    font-family: inherit;
-    color: #fff;
-    background: var(--color-terracotta);
-    border-radius: var(--radius-full);
-    text-decoration: none;
-    align-self: flex-start;
-    transition: background 0.12s, transform 0.1s;
+    line-height: 1.5;
+    margin: 0;
   }
 
-  :global(.result-buy-btn::after) {
-    content: '→';
-  }
+  @media (max-width: 560px) {
+    .search-page {
+      padding-top: var(--space-xl);
+    }
 
-  :global(.result-buy-btn:hover) {
-    background: color-mix(in srgb, var(--color-terracotta) 85%, black);
-    transform: translateY(-1px);
+    .search-header h1 {
+      font-size: var(--text-3xl);
+    }
   }
 </style>

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -79,7 +79,7 @@ import BaseLayout from '@layouts/BaseLayout.astro';
         { name: 'category',    weight: 0.10 },
         { name: 'topics',      weight: 0.10 },
       ],
-      threshold: 0.35,
+      threshold: 0.2,
       includeScore: true,
       minMatchCharLength: 2,
     });
@@ -310,7 +310,9 @@ import BaseLayout from '@layouts/BaseLayout.astro';
     gap: var(--space-md);
   }
 
-  .result-card {
+  /* Result cards are injected via innerHTML so Astro's scoped attribute
+     is never added — these rules must be :global to apply. */
+  :global(.result-card) {
     background: var(--color-surface);
     border: 1px solid var(--color-border);
     border-radius: var(--radius-md);
@@ -322,17 +324,17 @@ import BaseLayout from '@layouts/BaseLayout.astro';
     transition: border-color 0.15s, box-shadow 0.15s;
   }
 
-  .result-card--page {
+  :global(.result-card--page) {
     text-decoration: none;
   }
 
-  .result-card--page:hover {
+  :global(.result-card--page:hover) {
     border-color: var(--color-primary);
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
   }
 
   /* ── Badges ── */
-  .result-badge {
+  :global(.result-badge) {
     display: inline-block;
     font-size: var(--text-xs);
     font-weight: var(--weight-semibold);
@@ -343,42 +345,42 @@ import BaseLayout from '@layouts/BaseLayout.astro';
     align-self: flex-start;
   }
 
-  .result-badge--converter,
-  .result-badge--collector,
-  .result-badge--informer { background: var(--color-bg-alt); color: var(--color-text-muted); }
-  .result-badge--attractor { background: var(--color-sand); color: var(--color-charcoal); }
-  .result-badge--cooling   { background: #ddf0f7; color: #2a6a80; }
-  .result-badge--calming   { background: #e8f0e8; color: #3d6b3a; }
-  .result-badge--comfort   { background: #f5ede3; color: #7a4530; }
-  .result-badge--gear      { background: #ede8f5; color: #4a3a70; }
+  :global(.result-badge--converter),
+  :global(.result-badge--collector),
+  :global(.result-badge--informer) { background: var(--color-bg-alt); color: var(--color-text-muted); }
+  :global(.result-badge--attractor) { background: var(--color-sand); color: var(--color-charcoal); }
+  :global(.result-badge--cooling)   { background: #ddf0f7; color: #2a6a80; }
+  :global(.result-badge--calming)   { background: #e8f0e8; color: #3d6b3a; }
+  :global(.result-badge--comfort)   { background: #f5ede3; color: #7a4530; }
+  :global(.result-badge--gear)      { background: #ede8f5; color: #4a3a70; }
 
   /* ── Card content ── */
-  .result-title {
+  :global(.result-title) {
     font-size: var(--text-base);
     font-weight: var(--weight-semibold);
     line-height: 1.3;
   }
 
-  .result-desc {
+  :global(.result-desc) {
     font-size: var(--text-sm);
     color: var(--color-text-muted);
     line-height: 1.5;
     margin: 0;
   }
 
-  .result-cta {
+  :global(.result-cta) {
     font-size: var(--text-sm);
     font-weight: var(--weight-medium);
     color: var(--color-link);
     margin-top: var(--space-xs);
   }
 
-  .result-card--page:hover .result-cta {
+  :global(.result-card--page:hover .result-cta) {
     color: var(--color-link-hover);
   }
 
   /* ── Amazon buy button ── */
-  .result-buy-btn {
+  :global(.result-buy-btn) {
     display: inline-flex;
     align-items: center;
     gap: 6px;
@@ -395,11 +397,11 @@ import BaseLayout from '@layouts/BaseLayout.astro';
     transition: background 0.12s, transform 0.1s;
   }
 
-  .result-buy-btn::after {
+  :global(.result-buy-btn::after) {
     content: '→';
   }
 
-  .result-buy-btn:hover {
+  :global(.result-buy-btn:hover) {
     background: color-mix(in srgb, var(--color-terracotta) 85%, black);
     transform: translateY(-1px);
   }

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -14,10 +14,16 @@ import BaseLayout from '@layouts/BaseLayout.astro';
       <input
         id="search-input"
         type="search"
-        placeholder="Try 'cooling mat', 'anxious dog', 'crate'…"
+        placeholder="Try 'cooling mat', 'anxious dog', 'GPS tracker'…"
         autocomplete="off"
         aria-label="Search Chill-Dogs"
       />
+    </div>
+    <div class="filter-bar" id="filter-bar" role="group" aria-label="Filter results">
+      <button class="filter-btn active" data-filter="all">All</button>
+      <button class="filter-btn" data-filter="converter">Guides</button>
+      <button class="filter-btn" data-filter="collector">Hubs</button>
+      <button class="filter-btn" data-filter="product">Products</button>
     </div>
     <div id="search-status" class="search-status" aria-live="polite"></div>
     <div id="search-results" class="search-results" role="list"></div>
@@ -26,6 +32,7 @@ import BaseLayout from '@layouts/BaseLayout.astro';
 
 <script>
   import Fuse from 'fuse.js';
+  import { track } from '@scripts/analytics';
 
   type PageItem = {
     type: 'page';
@@ -47,12 +54,17 @@ import BaseLayout from '@layouts/BaseLayout.astro';
   };
 
   type SearchItem = PageItem | ProductItem;
+  type FilterKey = 'all' | 'converter' | 'collector' | 'product';
 
   const input = document.getElementById('search-input') as HTMLInputElement;
   const resultsEl = document.getElementById('search-results') as HTMLDivElement;
   const statusEl = document.getElementById('search-status') as HTMLDivElement;
+  const filterBar = document.getElementById('filter-bar') as HTMLDivElement;
 
   let fuse: Fuse<SearchItem> | null = null;
+  let lastResults: Fuse.FuseResult<SearchItem>[] = [];
+  let activeFilter: FilterKey = 'all';
+  let currentQuery = '';
 
   async function loadIndex() {
     const res = await fetch('/search-index.json');
@@ -98,7 +110,16 @@ import BaseLayout from '@layouts/BaseLayout.astro';
   function renderPageCard(item: PageItem): string {
     const label = PAGE_TYPE_LABELS[item.pageType] ?? item.pageType;
     return `
-      <a class="result-card result-card--page" href="${esc(item.href)}" role="listitem">
+      <a
+        class="result-card result-card--page"
+        href="${esc(item.href)}"
+        role="listitem"
+        data-track="search_result_click"
+        data-result-href="${esc(item.href)}"
+        data-result-title="${esc(item.title)}"
+        data-result-type="page"
+        data-query="${esc(currentQuery)}"
+      >
         <span class="result-badge result-badge--${esc(item.pageType)}">${label}</span>
         <strong class="result-title">${esc(item.title)}</strong>
         <p class="result-desc">${esc(item.description)}</p>
@@ -120,30 +141,70 @@ import BaseLayout from '@layouts/BaseLayout.astro';
           rel="sponsored noopener noreferrer"
           target="_blank"
           data-affiliate="true"
-        >Buy on Amazon →</a>
+          data-track="amazon_outbound_click"
+          data-product-name="${esc(item.name)}"
+        >Buy on Amazon</a>
       </div>
     `;
   }
 
+  function applyFilter(results: Fuse.FuseResult<SearchItem>[]): Fuse.FuseResult<SearchItem>[] {
+    if (activeFilter === 'all') return results;
+    if (activeFilter === 'product') return results.filter((r) => r.item.type === 'product');
+    // 'converter' or 'collector' — filter page items by pageType
+    return results.filter(
+      (r) => r.item.type === 'page' && r.item.pageType === activeFilter
+    );
+  }
+
+  function renderResults() {
+    const filtered = applyFilter(lastResults);
+    if (filtered.length === 0 && lastResults.length > 0) {
+      statusEl.textContent = `No ${activeFilter === 'all' ? '' : activeFilter + ' '}results for "${currentQuery}"`;
+      resultsEl.innerHTML = '';
+      return;
+    }
+    if (filtered.length === 0) return;
+    const label = activeFilter === 'all' ? '' : ` ${activeFilter}`;
+    statusEl.textContent = `${filtered.length}${label} result${filtered.length === 1 ? '' : 's'} for "${currentQuery}"`;
+    resultsEl.innerHTML = filtered
+      .map(({ item }) => (item.type === 'page' ? renderPageCard(item) : renderProductCard(item)))
+      .join('');
+  }
+
   function runSearch(query: string) {
     if (!fuse) return;
+    currentQuery = query;
     const trimmed = query.trim();
     if (trimmed.length < 2) {
+      lastResults = [];
       resultsEl.innerHTML = '';
       statusEl.textContent = '';
       return;
     }
-    const results = fuse.search(trimmed, { limit: 24 });
-    if (results.length === 0) {
+    lastResults = fuse.search(trimmed, { limit: 48 });
+    if (lastResults.length === 0) {
       statusEl.textContent = `No results for "${trimmed}"`;
       resultsEl.innerHTML = '';
       return;
     }
-    statusEl.textContent = `${results.length} result${results.length === 1 ? '' : 's'} for "${trimmed}"`;
-    resultsEl.innerHTML = results
-      .map(({ item }) => (item.type === 'page' ? renderPageCard(item) : renderProductCard(item)))
-      .join('');
+    renderResults();
+    track('search_query', {
+      query: trimmed,
+      result_count: lastResults.length,
+      filter: activeFilter,
+    });
   }
+
+  // Filter buttons
+  filterBar.addEventListener('click', (e) => {
+    const btn = (e.target as HTMLElement).closest<HTMLButtonElement>('.filter-btn');
+    if (!btn) return;
+    filterBar.querySelectorAll('.filter-btn').forEach((b) => b.classList.remove('active'));
+    btn.classList.add('active');
+    activeFilter = btn.dataset.filter as FilterKey;
+    if (lastResults.length > 0) renderResults();
+  });
 
   // Hydrate from ?q= param on load
   const initialQuery = new URLSearchParams(window.location.search).get('q') ?? '';
@@ -183,7 +244,7 @@ import BaseLayout from '@layouts/BaseLayout.astro';
   }
 
   .search-input-wrap {
-    margin-bottom: var(--space-lg);
+    margin-bottom: var(--space-md);
   }
 
   #search-input {
@@ -203,6 +264,39 @@ import BaseLayout from '@layouts/BaseLayout.astro';
     border-color: var(--color-primary);
   }
 
+  /* ── Filter bar ── */
+  .filter-bar {
+    display: flex;
+    gap: var(--space-sm);
+    flex-wrap: wrap;
+    margin-bottom: var(--space-lg);
+  }
+
+  .filter-btn {
+    padding: 4px 14px;
+    font-size: var(--text-sm);
+    font-weight: var(--weight-medium);
+    font-family: inherit;
+    border: 1.5px solid var(--color-border);
+    border-radius: var(--radius-full);
+    background: var(--color-surface);
+    color: var(--color-text-muted);
+    cursor: pointer;
+    transition: border-color 0.12s, color 0.12s, background 0.12s;
+  }
+
+  .filter-btn:hover {
+    border-color: var(--color-primary);
+    color: var(--color-text);
+  }
+
+  .filter-btn.active {
+    border-color: var(--color-primary);
+    background: var(--color-primary);
+    color: #fff;
+  }
+
+  /* ── Status ── */
   .search-status {
     font-size: var(--text-sm);
     color: var(--color-text-muted);
@@ -210,6 +304,7 @@ import BaseLayout from '@layouts/BaseLayout.astro';
     min-height: 1.25em;
   }
 
+  /* ── Result grid ── */
   .search-results {
     display: grid;
     gap: var(--space-md);
@@ -236,6 +331,7 @@ import BaseLayout from '@layouts/BaseLayout.astro';
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
   }
 
+  /* ── Badges ── */
   .result-badge {
     display: inline-block;
     font-size: var(--text-xs);
@@ -256,6 +352,7 @@ import BaseLayout from '@layouts/BaseLayout.astro';
   .result-badge--comfort   { background: #f5ede3; color: #7a4530; }
   .result-badge--gear      { background: #ede8f5; color: #4a3a70; }
 
+  /* ── Card content ── */
   .result-title {
     font-size: var(--text-base);
     font-weight: var(--weight-semibold);
@@ -280,18 +377,30 @@ import BaseLayout from '@layouts/BaseLayout.astro';
     color: var(--color-link-hover);
   }
 
+  /* ── Amazon buy button ── */
   .result-buy-btn {
-    display: inline-block;
-    margin-top: var(--space-xs);
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    margin-top: var(--space-sm);
+    padding: 8px 16px;
     font-size: var(--text-sm);
     font-weight: var(--weight-semibold);
-    color: var(--color-link);
+    font-family: inherit;
+    color: #fff;
+    background: var(--color-terracotta);
+    border-radius: var(--radius-full);
     text-decoration: none;
     align-self: flex-start;
+    transition: background 0.12s, transform 0.1s;
+  }
+
+  .result-buy-btn::after {
+    content: '→';
   }
 
   .result-buy-btn:hover {
-    color: var(--color-link-hover);
-    text-decoration: underline;
+    background: color-mix(in srgb, var(--color-terracotta) 85%, black);
+    transform: translateY(-1px);
   }
 </style>

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -1,0 +1,297 @@
+---
+import BaseLayout from '@layouts/BaseLayout.astro';
+---
+
+<BaseLayout
+  title="Search Chill-Dogs"
+  ogTitle="Search Chill-Dogs — Find Dog Gear & Guides"
+  description="Search our full catalog of dog cooling gear, calming aids, beds, crates, and GPS trackers — plus guides and articles to help you choose."
+  noindex={true}
+>
+  <section class="search-page container">
+    <h1>Search</h1>
+    <div class="search-input-wrap">
+      <input
+        id="search-input"
+        type="search"
+        placeholder="Try 'cooling mat', 'anxious dog', 'crate'…"
+        autocomplete="off"
+        aria-label="Search Chill-Dogs"
+      />
+    </div>
+    <div id="search-status" class="search-status" aria-live="polite"></div>
+    <div id="search-results" class="search-results" role="list"></div>
+  </section>
+</BaseLayout>
+
+<script>
+  import Fuse from 'fuse.js';
+
+  type PageItem = {
+    type: 'page';
+    title: string;
+    description: string;
+    pageType: string;
+    href: string;
+    topics: string[];
+  };
+
+  type ProductItem = {
+    type: 'product';
+    name: string;
+    pillar: string;
+    category: string;
+    bestFor: string;
+    bullets: string;
+    amazonUrl: string;
+  };
+
+  type SearchItem = PageItem | ProductItem;
+
+  const input = document.getElementById('search-input') as HTMLInputElement;
+  const resultsEl = document.getElementById('search-results') as HTMLDivElement;
+  const statusEl = document.getElementById('search-status') as HTMLDivElement;
+
+  let fuse: Fuse<SearchItem> | null = null;
+
+  async function loadIndex() {
+    const res = await fetch('/search-index.json');
+    const items: SearchItem[] = await res.json();
+    fuse = new Fuse(items, {
+      keys: [
+        { name: 'title',       weight: 0.40 },
+        { name: 'name',        weight: 0.40 },
+        { name: 'description', weight: 0.25 },
+        { name: 'bestFor',     weight: 0.25 },
+        { name: 'bullets',     weight: 0.15 },
+        { name: 'category',    weight: 0.10 },
+        { name: 'topics',      weight: 0.10 },
+      ],
+      threshold: 0.35,
+      includeScore: true,
+      minMatchCharLength: 2,
+    });
+  }
+
+  const PAGE_TYPE_LABELS: Record<string, string> = {
+    converter: 'Guide',
+    collector: 'Hub',
+    attractor: 'Home',
+    informer:  'Info',
+  };
+
+  const PILLAR_LABELS: Record<string, string> = {
+    cooling: 'Cooling',
+    calming: 'Calming',
+    comfort: 'Comfort',
+    gear:    'Gear',
+  };
+
+  function esc(str: string): string {
+    return str
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+  function renderPageCard(item: PageItem): string {
+    const label = PAGE_TYPE_LABELS[item.pageType] ?? item.pageType;
+    return `
+      <a class="result-card result-card--page" href="${esc(item.href)}" role="listitem">
+        <span class="result-badge result-badge--${esc(item.pageType)}">${label}</span>
+        <strong class="result-title">${esc(item.title)}</strong>
+        <p class="result-desc">${esc(item.description)}</p>
+        <span class="result-cta">Read guide →</span>
+      </a>
+    `;
+  }
+
+  function renderProductCard(item: ProductItem): string {
+    const label = PILLAR_LABELS[item.pillar] ?? item.pillar;
+    return `
+      <div class="result-card result-card--product" role="listitem">
+        <span class="result-badge result-badge--${esc(item.pillar)}">${label}</span>
+        <strong class="result-title">${esc(item.name)}</strong>
+        <p class="result-desc">${esc(item.bestFor)}</p>
+        <a
+          class="result-buy-btn"
+          href="${esc(item.amazonUrl)}"
+          rel="sponsored noopener noreferrer"
+          target="_blank"
+          data-affiliate="true"
+        >Buy on Amazon →</a>
+      </div>
+    `;
+  }
+
+  function runSearch(query: string) {
+    if (!fuse) return;
+    const trimmed = query.trim();
+    if (trimmed.length < 2) {
+      resultsEl.innerHTML = '';
+      statusEl.textContent = '';
+      return;
+    }
+    const results = fuse.search(trimmed, { limit: 24 });
+    if (results.length === 0) {
+      statusEl.textContent = `No results for "${trimmed}"`;
+      resultsEl.innerHTML = '';
+      return;
+    }
+    statusEl.textContent = `${results.length} result${results.length === 1 ? '' : 's'} for "${trimmed}"`;
+    resultsEl.innerHTML = results
+      .map(({ item }) => (item.type === 'page' ? renderPageCard(item) : renderProductCard(item)))
+      .join('');
+  }
+
+  // Hydrate from ?q= param on load
+  const initialQuery = new URLSearchParams(window.location.search).get('q') ?? '';
+
+  loadIndex().then(() => {
+    if (initialQuery) {
+      input.value = initialQuery;
+      runSearch(initialQuery);
+    }
+  });
+
+  let debounceTimer: ReturnType<typeof setTimeout>;
+  input.addEventListener('input', () => {
+    clearTimeout(debounceTimer);
+    const q = input.value;
+    const url = new URL(window.location.href);
+    if (q.trim()) {
+      url.searchParams.set('q', q);
+    } else {
+      url.searchParams.delete('q');
+    }
+    window.history.replaceState(null, '', url);
+    debounceTimer = setTimeout(() => runSearch(q), 150);
+  });
+</script>
+
+<style>
+  .search-page {
+    padding-top: var(--space-3xl);
+    padding-bottom: var(--space-4xl);
+    max-width: 52rem;
+  }
+
+  .search-page h1 {
+    font-size: var(--text-4xl);
+    margin-bottom: var(--space-xl);
+  }
+
+  .search-input-wrap {
+    margin-bottom: var(--space-lg);
+  }
+
+  #search-input {
+    width: 100%;
+    padding: var(--space-md) var(--space-lg);
+    font-size: var(--text-lg);
+    font-family: inherit;
+    border: 2px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    background: var(--color-surface);
+    color: var(--color-text);
+    outline: none;
+    transition: border-color 0.15s;
+  }
+
+  #search-input:focus {
+    border-color: var(--color-primary);
+  }
+
+  .search-status {
+    font-size: var(--text-sm);
+    color: var(--color-text-muted);
+    margin-bottom: var(--space-lg);
+    min-height: 1.25em;
+  }
+
+  .search-results {
+    display: grid;
+    gap: var(--space-md);
+  }
+
+  .result-card {
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    padding: var(--space-lg);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-sm);
+    color: var(--color-text);
+    transition: border-color 0.15s, box-shadow 0.15s;
+  }
+
+  .result-card--page {
+    text-decoration: none;
+  }
+
+  .result-card--page:hover {
+    border-color: var(--color-primary);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+  }
+
+  .result-badge {
+    display: inline-block;
+    font-size: var(--text-xs);
+    font-weight: var(--weight-semibold);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    padding: 2px 8px;
+    border-radius: var(--radius-full);
+    align-self: flex-start;
+  }
+
+  .result-badge--converter,
+  .result-badge--collector,
+  .result-badge--informer { background: var(--color-bg-alt); color: var(--color-text-muted); }
+  .result-badge--attractor { background: var(--color-sand); color: var(--color-charcoal); }
+  .result-badge--cooling   { background: #ddf0f7; color: #2a6a80; }
+  .result-badge--calming   { background: #e8f0e8; color: #3d6b3a; }
+  .result-badge--comfort   { background: #f5ede3; color: #7a4530; }
+  .result-badge--gear      { background: #ede8f5; color: #4a3a70; }
+
+  .result-title {
+    font-size: var(--text-base);
+    font-weight: var(--weight-semibold);
+    line-height: 1.3;
+  }
+
+  .result-desc {
+    font-size: var(--text-sm);
+    color: var(--color-text-muted);
+    line-height: 1.5;
+    margin: 0;
+  }
+
+  .result-cta {
+    font-size: var(--text-sm);
+    font-weight: var(--weight-medium);
+    color: var(--color-link);
+    margin-top: var(--space-xs);
+  }
+
+  .result-card--page:hover .result-cta {
+    color: var(--color-link-hover);
+  }
+
+  .result-buy-btn {
+    display: inline-block;
+    margin-top: var(--space-xs);
+    font-size: var(--text-sm);
+    font-weight: var(--weight-semibold);
+    color: var(--color-link);
+    text-decoration: none;
+    align-self: flex-start;
+  }
+
+  .result-buy-btn:hover {
+    color: var(--color-link-hover);
+    text-decoration: underline;
+  }
+</style>

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -57,6 +57,7 @@ const suggestedSearchPaths = [
     pageType: string;
     href: string;
     topics: string[];
+    productNames: string[];
   };
 
   type ProductItem = {
@@ -95,13 +96,14 @@ const suggestedSearchPaths = [
     const items: SearchItem[] = await res.json();
     fuse = new Fuse(items, {
       keys: [
-        { name: 'title',       weight: 0.40 },
-        { name: 'name',        weight: 0.40 },
-        { name: 'description', weight: 0.25 },
-        { name: 'bestFor',     weight: 0.25 },
-        { name: 'bullets',     weight: 0.15 },
-        { name: 'category',    weight: 0.10 },
-        { name: 'topics',      weight: 0.10 },
+        { name: 'title',        weight: 0.40 },
+        { name: 'name',         weight: 0.40 },
+        { name: 'description',  weight: 0.25 },
+        { name: 'bestFor',      weight: 0.25 },
+        { name: 'bullets',      weight: 0.15 },
+        { name: 'productNames', weight: 0.15 },
+        { name: 'category',     weight: 0.10 },
+        { name: 'topics',       weight: 0.10 },
       ],
       threshold: 0.2,
       includeScore: true,


### PR DESCRIPTION
Adds a /search/ page backed by a prerendered /search-index.json endpoint.
The index aggregates all non-noindex sitemap pages plus the full product
catalog (125+ products) so users can search content guides and individual
products, each with an affiliate buy link.

- src/pages/search-index.json.ts — Astro API endpoint; merges pages
  (getCompleteSitemapPages) and products (productCatalogItems) into a
  flat JSON array at build time
- src/pages/search.astro — informer page (noindex); Fuse.js runs in the
  client, debounced input, ?q= URL param for shareable links, renders
  page cards (with guide links) and product cards (with Amazon buy links
  carrying data-affiliate="true" for analytics)
- src/components/Header.astro — magnifying-glass SVG icon added to nav
- src/data/routes.ts — ROUTES.search = '/search/'
- src/data/content-sitemap.ts — search page registered (noindex)
- src/__tests__/search.test.ts — validates product catalog shape
- src/__tests__/site-smoke.test.ts — exempts search/ from JSON-LD check

https://claude.ai/code/session_017G1ABMZaB71KKZyz98GQf9