### PR TITLE
Split footer affiliate disclosures into separate Amazon and Chewy blocks

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -114,32 +114,31 @@ const footerCategory = inferCategory(currentPath);
       </div>
     )}
 
-    <div class="footer-disclosure">
-      <p>
-        Chill-Dogs is a participant in the Amazon Services LLC Associates Program.  As an Amazon Associate, we earn from qualifying purchases.
-        Chill-Dogs also participates in the Chewy Affiliate Program and earns commissions from qualifying purchases.
-      </p>
-    </div>
-
-    <div class="footer-affiliate-logos">
-      <a
-        href="https://chewy.sjv.io/c/7067825/2846786/32975"
-        target="_blank"
-        rel="nofollow sponsored noopener"
-        aria-label="Chewy Affiliate Program"
-      >
-        <img
-          src="/images/chewy-logo.png"
-          alt="Chewy Affiliate Program logo"
-          width="848"
-          height="258"
-          loading="lazy"
-          decoding="async"
-        />
-      </a>
-      <AffiliateLink href="https://www.amazon.com/b/?node=2975312011&ref_=PetMainNav_1&pf_rd_r=K8AF5S50SA2Y3BXEX3VR&pf_rd_p=eca06bfa-7025-4421-8855-9e7df7f1f66b&pf_rd_m=A2R2RITDJNW1Q6&pf_rd_s=merchandised-search-4&pf_rd_i=2619533011&tag=chill-dogs-20">
-        <img src="https://images-na.ssl-images-amazon.com/images/G/01//associates/network/revamp/AmazonAssociatesLogo.svg" alt="Amazon Associates logo" loading="lazy" decoding="async" />
-      </AffiliateLink>
+    <div class="footer-affiliates">
+      <div class="footer-affiliate-block">
+        <p>Chill-Dogs is a participant in the Amazon Services LLC Associates Program. As an Amazon Associate, we earn from qualifying purchases.</p>
+        <AffiliateLink href="https://www.amazon.com/b/?node=2975312011&ref_=PetMainNav_1&pf_rd_r=K8AF5S50SA2Y3BXEX3VR&pf_rd_p=eca06bfa-7025-4421-8855-9e7df7f1f66b&pf_rd_m=A2R2RITDJNW1Q6&pf_rd_s=merchandised-search-4&pf_rd_i=2619533011&tag=chill-dogs-20">
+          <img src="https://images-na.ssl-images-amazon.com/images/G/01//associates/network/revamp/AmazonAssociatesLogo.svg" alt="Amazon Associates logo" loading="lazy" decoding="async" />
+        </AffiliateLink>
+      </div>
+      <div class="footer-affiliate-block">
+        <p>Chill-Dogs participates in the Chewy Affiliate Program and earns commissions from qualifying purchases.</p>
+        <a
+          href="https://chewy.sjv.io/c/7067825/2846786/32975"
+          target="_blank"
+          rel="nofollow sponsored noopener"
+          aria-label="Chewy Affiliate Program"
+        >
+          <img
+            src="/images/chewy-logo.png"
+            alt="Chewy logo"
+            width="848"
+            height="258"
+            loading="lazy"
+            decoding="async"
+          />
+        </a>
+      </div>
     </div>
 
     <div class="footer-bottom">
@@ -197,43 +196,44 @@ const footerCategory = inferCategory(currentPath);
     color: var(--color-text-inverse);
   }
 
-  .footer-disclosure {
-    border-top: 1px solid rgba(240, 244, 246, 0.15);
-    padding-top: var(--space-xl);
-    margin-bottom: var(--space-lg);
-  }
-
   .footer-signup {
     border-top: 1px solid rgba(240, 244, 246, 0.15);
     padding-block: var(--space-2xl);
     margin-bottom: var(--space-2xl);
   }
 
-  .footer-disclosure p {
+  .footer-affiliates {
+    border-top: 1px solid rgba(240, 244, 246, 0.15);
+    padding-top: var(--space-xl);
+    margin-bottom: var(--space-lg);
+    display: flex;
+    gap: var(--space-3xl);
+    flex-wrap: wrap;
+  }
+
+  .footer-affiliate-block {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-md);
+  }
+
+  .footer-affiliate-block p {
     font-size: var(--text-xs);
     color: rgba(240, 244, 246, 0.65);
     line-height: var(--leading-relaxed);
-    max-width: 600px;
+    max-width: 280px;
   }
 
-  .footer-affiliate-logos {
-    display: flex;
-    align-items: center;
-    gap: var(--space-lg);
-    flex-wrap: wrap;
-    margin-bottom: var(--space-lg);
-  }
-
-  .footer-affiliate-logos a {
+  .footer-affiliate-block a {
     display: inline-flex;
     align-items: center;
   }
 
-  .footer-affiliate-logos img {
+  .footer-affiliate-block img {
     display: block;
-    height: 36px;
+    height: 32px;
     width: auto;
-    max-width: 180px;
+    max-width: 160px;
     object-fit: contain;
   }
 


### PR DESCRIPTION
## Summary

- Replaces the single combined disclosure paragraph + side-by-side logos with two distinct blocks
- Each block has its own disclosure sentence followed by the linked affiliate logo
- Amazon block first, Chewy block second

## Test plan

- [x] 163/163 tests passing
- [x] Verified visually in dev — both blocks render correctly with correct logos and links

🤖 Generated with [Claude Code](https://claude.com/claude-code)