### PR TITLE
Add Pinterest follow link to footer

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -100,6 +100,18 @@ const footerCategory = inferCategory(currentPath);
           ))}
         </ul>
       </div>
+      <div class="footer-col">
+        <ul>
+          <li>
+            <a href="https://www.pinterest.com/chilldogs42/" target="_blank" rel="noopener noreferrer" class="pinterest-follow" aria-label="Follow Chill-Dogs on Pinterest">
+              <svg class="pinterest-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                <path fill="#E60023" d="M12 0C5.373 0 0 5.373 0 12c0 5.084 3.163 9.426 7.627 11.174-.105-.949-.2-2.405.042-3.441.218-.937 1.407-5.965 1.407-5.965s-.359-.719-.359-1.782c0-1.668.967-2.914 2.171-2.914 1.023 0 1.518.769 1.518 1.69 0 1.029-.655 2.568-.994 3.995-.283 1.194.599 2.169 1.777 2.169 2.133 0 3.772-2.249 3.772-5.495 0-2.873-2.064-4.882-5.012-4.882-3.414 0-5.418 2.561-5.418 5.207 0 1.031.397 2.138.893 2.738a.36.36 0 0 1 .083.345l-.333 1.36c-.053.22-.174.267-.402.161-1.499-.698-2.436-2.889-2.436-4.649 0-3.785 2.75-7.262 7.929-7.262 4.163 0 7.398 2.967 7.398 6.931 0 4.136-2.607 7.464-6.227 7.464-1.216 0-2.359-.632-2.75-1.378l-.748 2.853c-.271 1.043-1.002 2.35-1.492 3.146C9.57 23.812 10.763 24 12 24c6.627 0 12-5.373 12-12S18.627 0 12 0z"/>
+              </svg>
+              Follow us on Pinterest
+            </a>
+          </li>
+        </ul>
+      </div>
     </div>
 
     {shouldShowSignup && (
@@ -113,15 +125,6 @@ const footerCategory = inferCategory(currentPath);
         />
       </div>
     )}
-
-    <div class="footer-social">
-      <a href="https://www.pinterest.com/chilldogs42/" target="_blank" rel="noopener noreferrer" class="pinterest-follow" aria-label="Follow Chill-Dogs on Pinterest">
-        <svg class="pinterest-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-          <path fill="#E60023" d="M12 0C5.373 0 0 5.373 0 12c0 5.084 3.163 9.426 7.627 11.174-.105-.949-.2-2.405.042-3.441.218-.937 1.407-5.965 1.407-5.965s-.359-.719-.359-1.782c0-1.668.967-2.914 2.171-2.914 1.023 0 1.518.769 1.518 1.69 0 1.029-.655 2.568-.994 3.995-.283 1.194.599 2.169 1.777 2.169 2.133 0 3.772-2.249 3.772-5.495 0-2.873-2.064-4.882-5.012-4.882-3.414 0-5.418 2.561-5.418 5.207 0 1.031.397 2.138.893 2.738a.36.36 0 0 1 .083.345l-.333 1.36c-.053.22-.174.267-.402.161-1.499-.698-2.436-2.889-2.436-4.649 0-3.785 2.75-7.262 7.929-7.262 4.163 0 7.398 2.967 7.398 6.931 0 4.136-2.607 7.464-6.227 7.464-1.216 0-2.359-.632-2.75-1.378l-.748 2.853c-.271 1.043-1.002 2.35-1.492 3.146C9.57 23.812 10.763 24 12 24c6.627 0 12-5.373 12-12S18.627 0 12 0z"/>
-        </svg>
-        Follow us on Pinterest
-      </a>
-    </div>
 
     <div class="footer-affiliates">
       <div class="footer-affiliate-block">
@@ -175,7 +178,7 @@ const footerCategory = inferCategory(currentPath);
 
   .footer-grid {
     display: grid;
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(4, 1fr);
     gap: var(--space-2xl);
     margin-bottom: var(--space-2xl);
   }
@@ -211,29 +214,15 @@ const footerCategory = inferCategory(currentPath);
     margin-bottom: var(--space-2xl);
   }
 
-  .footer-social {
-    border-top: 1px solid rgba(240, 244, 246, 0.15);
-    padding-block: var(--space-xl);
-    margin-bottom: var(--space-lg);
-  }
-
   .pinterest-follow {
     display: inline-flex;
     align-items: center;
     gap: var(--space-sm);
-    color: rgba(240, 244, 246, 0.85);
-    font-size: var(--text-sm);
-    text-decoration: none;
-    transition: color var(--transition-fast);
-  }
-
-  .pinterest-follow:hover {
-    color: var(--color-text-inverse);
   }
 
   .pinterest-logo {
-    width: 24px;
-    height: 24px;
+    width: 20px;
+    height: 20px;
     flex-shrink: 0;
   }
 

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -114,6 +114,15 @@ const footerCategory = inferCategory(currentPath);
       </div>
     )}
 
+    <div class="footer-social">
+      <a href="https://www.pinterest.com/chilldogs42/" target="_blank" rel="noopener noreferrer" class="pinterest-follow" aria-label="Follow Chill-Dogs on Pinterest">
+        <svg class="pinterest-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+          <path fill="#E60023" d="M12 0C5.373 0 0 5.373 0 12c0 5.084 3.163 9.426 7.627 11.174-.105-.949-.2-2.405.042-3.441.218-.937 1.407-5.965 1.407-5.965s-.359-.719-.359-1.782c0-1.668.967-2.914 2.171-2.914 1.023 0 1.518.769 1.518 1.69 0 1.029-.655 2.568-.994 3.995-.283 1.194.599 2.169 1.777 2.169 2.133 0 3.772-2.249 3.772-5.495 0-2.873-2.064-4.882-5.012-4.882-3.414 0-5.418 2.561-5.418 5.207 0 1.031.397 2.138.893 2.738a.36.36 0 0 1 .083.345l-.333 1.36c-.053.22-.174.267-.402.161-1.499-.698-2.436-2.889-2.436-4.649 0-3.785 2.75-7.262 7.929-7.262 4.163 0 7.398 2.967 7.398 6.931 0 4.136-2.607 7.464-6.227 7.464-1.216 0-2.359-.632-2.75-1.378l-.748 2.853c-.271 1.043-1.002 2.35-1.492 3.146C9.57 23.812 10.763 24 12 24c6.627 0 12-5.373 12-12S18.627 0 12 0z"/>
+        </svg>
+        Follow us on Pinterest
+      </a>
+    </div>
+
     <div class="footer-affiliates">
       <div class="footer-affiliate-block">
         <p>Chill-Dogs is a participant in the Amazon Services LLC Associates Program. As an Amazon Associate, we earn from qualifying purchases.</p>
@@ -200,6 +209,32 @@ const footerCategory = inferCategory(currentPath);
     border-top: 1px solid rgba(240, 244, 246, 0.15);
     padding-block: var(--space-2xl);
     margin-bottom: var(--space-2xl);
+  }
+
+  .footer-social {
+    border-top: 1px solid rgba(240, 244, 246, 0.15);
+    padding-block: var(--space-xl);
+    margin-bottom: var(--space-lg);
+  }
+
+  .pinterest-follow {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-sm);
+    color: rgba(240, 244, 246, 0.85);
+    font-size: var(--text-sm);
+    text-decoration: none;
+    transition: color var(--transition-fast);
+  }
+
+  .pinterest-follow:hover {
+    color: var(--color-text-inverse);
+  }
+
+  .pinterest-logo {
+    width: 24px;
+    height: 24px;
+    flex-shrink: 0;
   }
 
   .footer-affiliates {


### PR DESCRIPTION
Adds a standalone "Follow us on Pinterest" link with the red Pinterest
SVG logo between the email signup and affiliate disclaimer sections.

https://claude.ai/code/session_017EjHhLqU7BbiHaMvSK3WT8