### PR TITLE
Add How We Use AI transparency page

### DIFF
--- a/docs/system-definition.yaml
+++ b/docs/system-definition.yaml
@@ -321,6 +321,7 @@ site_system:
         - "/privacy-policy/"
         - "/terms/"
         - "/affiliate-disclosure/"
+        - "/how-we-use-ai/"
         - "/subscribe/"
         - "/subscribe/thanks/"
         - "/subscribe/confirmed/"

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -27,6 +27,7 @@ const legalLinks = [
   { href: ROUTES.privacyPolicy, label: 'Privacy Policy' },
   { href: ROUTES.terms, label: 'Terms of Use' },
   { href: ROUTES.affiliateDisclosure, label: 'Affiliate Disclosure' },
+  { href: ROUTES.howWeUseAi, label: 'How We Use AI' },
 ];
 
 function normalizePath(pathname: string): string {
@@ -49,6 +50,7 @@ const informerPaths = new Set<string>([
   ROUTES.privacyPolicy,
   ROUTES.terms,
   ROUTES.affiliateDisclosure,
+  ROUTES.howWeUseAi,
   ROUTES.subscribeThanks,
   ROUTES.subscribeConfirmed,
   '/content-sitemap/',

--- a/src/data/content-sitemap.ts
+++ b/src/data/content-sitemap.ts
@@ -594,6 +594,14 @@ export const staticSitemapSections: SitemapSection[] = [
         pageType: 'informer',
       }),
       createSitemapPage({
+        baseTitle: 'How We Use AI',
+        ogTitle: 'How Chill-Dogs Uses AI | Our Research Process',
+        description:
+          'Chill-Dogs uses AI to accelerate research and content structure. Humans verify all claims, edit the voice, and curate every product recommendation.',
+        href: ROUTES.howWeUseAi,
+        pageType: 'informer',
+      }),
+      createSitemapPage({
         baseTitle: 'Privacy Policy',
         description: 'Privacy policy for Chill-Dogs. Learn how we handle your data.',
         href: ROUTES.privacyPolicy,

--- a/src/data/routes.ts
+++ b/src/data/routes.ts
@@ -46,6 +46,7 @@ export const ROUTES = {
   shop: '/shop/',
   search: '/search/',
   affiliateDisclosure: '/affiliate-disclosure/',
+  howWeUseAi: '/how-we-use-ai/',
   privacyPolicy: '/privacy-policy/',
   terms: '/terms/',
   shelterCharities: '/shelter-dog-charities/',

--- a/src/pages/how-we-use-ai.astro
+++ b/src/pages/how-we-use-ai.astro
@@ -1,0 +1,66 @@
+---
+import { ROUTES } from '@data/routes';
+import BaseLayout from '@layouts/BaseLayout.astro';
+---
+
+<BaseLayout
+  title="How We Use AI"
+  ogTitle="How Chill-Dogs Uses AI | Our Research Process"
+  description="Chill-Dogs uses AI to accelerate research and content structure. Humans verify all claims, edit the voice, and curate every product recommendation."
+>
+  <section class="legal container">
+    <div class="prose">
+      <h1>How We Use AI</h1>
+
+      <p>
+        We use AI tools as part of how we research and build chill-dogs.com. This page explains what that means in practice.
+      </p>
+
+      <h2>Research and structure</h2>
+
+      <p>
+        When we're developing an article — say, how hot is too hot for a dog, or how to manage car anxiety — we use AI to accelerate the research phase. That means pulling together what's known on a topic, identifying the questions real dog owners are actually asking, and sketching a structure that covers the subject thoroughly.
+      </p>
+      <p>
+        AI helps us move faster and catch gaps we might otherwise miss. It doesn't replace knowing what matters to dog owners, or which sources are worth citing.
+      </p>
+
+      <h2>Where humans stay in the loop</h2>
+
+      <p>Every article goes through human editorial review before it's published. Specifically:</p>
+      <ul>
+        <li><strong>Source verification.</strong> Any statistic or claim that references a named organization — AKC, AAHA, ASPCA — gets checked against the actual source. We don't publish figures we haven't confirmed.</li>
+        <li><strong>Tone and voice.</strong> AI drafts tend toward generic. We edit for the measured, practical voice this site is built around.</li>
+        <li><strong>Product curation.</strong> Decisions about which products appear on converter pages are made by us, not generated. We research categories, compare options, and make judgment calls about what's worth recommending.</li>
+        <li><strong>Final edit.</strong> Every article is edited in depth before it goes live — structure, accuracy, tone, and flow. AI output is a starting point, not a finished product. Nothing publishes without that pass.</li>
+      </ul>
+
+      <h2>What AI doesn't do here</h2>
+
+      <p>
+        AI doesn't write our affiliate disclosures, set our editorial standards, or decide what this site is for. It doesn't select products, verify veterinary claims, or make calls about what's safe to recommend to dog owners. Those decisions stay with us.
+      </p>
+
+      <h2>Why we're telling you this</h2>
+
+      <p>
+        Because you're trusting us with a practical question about your dog, and you deserve to know how the information was put together. We think AI-assisted research, done carefully with human oversight, produces better content than either approach alone. But the oversight part isn't optional — it's the point.
+      </p>
+      <p>
+        If you have questions about how a specific piece of content was researched, <a href={ROUTES.contact}>contact us</a>.
+      </p>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .legal {
+    padding-top: var(--space-3xl);
+    padding-bottom: var(--space-4xl);
+  }
+
+  .legal h1 {
+    font-size: var(--text-4xl);
+    margin-bottom: var(--space-xl);
+  }
+</style>


### PR DESCRIPTION
Creates /how-we-use-ai/ as an informer page explaining the site's AI-assisted
research process and human editorial oversight. Registers the route, links it
from the footer Legal column, adds it to the sitemap, and updates the system
definition.

https://claude.ai/code/session_01DBetyRC7cVbzjsH8fX8XP9