### PR TITLE
Feature six homepage article cards

### DIFF
--- a/docs/system-definition.yaml
+++ b/docs/system-definition.yaml
@@ -8,7 +8,7 @@
 
 site_system:
   status: "active"
-  as_of: "2026-06-02"
+  as_of: "2026-06-03"
   owner: "chill-dogs"
   purpose: "Define the website as a modular conversion system and keep implementation aligned."
 
@@ -53,8 +53,9 @@ site_system:
       notes: >
         Home page includes a dusty rose color block introducing the Comfort & Rest collector
         with tagline "Settle in." — positioned between HomepageHero and the start-prompt section.
-        The latest/guide lists include How to Crate Train Your Dog to connect informational
-        crate intent with the new crate converter path.
+        The From the Guide section features the six newest article collectors with OG-image
+        cards, including How to Crate Train Your Dog to connect informational crate intent
+        with the new crate converter path.
         The Browse Picks list is temporarily broad enough to include Best Lick Mats for Dogs
         and Best Travel Crates for Road Trips until converter routing below the article section
         gets a fuller refactor.

--- a/src/__tests__/homepage-articles.test.ts
+++ b/src/__tests__/homepage-articles.test.ts
@@ -59,15 +59,19 @@ describe('homepage article feed', () => {
       createArticle('/travel/how-to-fly-with-a-dog/', '2026-04-10', explicitImage),
       createArticle('/calming/crate-training-for-dogs/', '2026-04-09'),
       createArticle('/safety/what-to-do-if-your-dog-runs-away/', '2026-04-03'),
+      createArticle('/comforting/how-much-do-dogs-sleep/', '2026-03-24'),
+      createArticle('/cooling/keep-dog-cool-in-car/', '2026-03-20'),
     ]);
 
     expect(feed.featuredArticles.map((article) => article.href)).toEqual([
       '/calming/dog-fireworks-anxiety-checklist/',
       '/travel/how-to-fly-with-a-dog/',
       '/calming/crate-training-for-dogs/',
+      '/safety/what-to-do-if-your-dog-runs-away/',
+      '/comforting/how-much-do-dogs-sleep/',
+      '/cooling/keep-dog-cool-in-car/',
     ]);
     expect(feed.moreArticles.map((article) => article.href)).toEqual([
-      '/safety/what-to-do-if-your-dog-runs-away/',
       '/cooling/how-hot-is-too-hot-for-dogs/',
     ]);
     expect(feed.latestGuides.map((article) => article.href)).toEqual([
@@ -75,12 +79,15 @@ describe('homepage article feed', () => {
       '/travel/how-to-fly-with-a-dog/',
       '/calming/crate-training-for-dogs/',
       '/safety/what-to-do-if-your-dog-runs-away/',
+      '/comforting/how-much-do-dogs-sleep/',
+      '/cooling/keep-dog-cool-in-car/',
       '/cooling/how-hot-is-too-hot-for-dogs/',
     ]);
 
     expect(feed.featuredArticles[0]?.image).toBe('/og/calming-dog-fireworks-anxiety-checklist.jpg');
     expect(feed.featuredArticles[1]?.image).toBe('/_assets/custom-og.jpg');
-    expect(feed.moreArticles[0]?.image).toBe('/og/safety-what-to-do-if-your-dog-runs-away.jpg');
+    expect(feed.featuredArticles[3]?.image).toBe('/og/safety-what-to-do-if-your-dog-runs-away.jpg');
+    expect(feed.moreArticles[0]?.image).toBe('/og/cooling-how-hot-is-too-hot-for-dogs.jpg');
   });
 
   it('maps a single article into homepage card data', () => {

--- a/src/components/modules/HomepageBody.astro
+++ b/src/components/modules/HomepageBody.astro
@@ -229,11 +229,11 @@ const shopCards = [
     border-top: 1px solid var(--color-border);
   }
 
-  /* Featured 3-up with OG images */
+  /* Featured article cards with OG images */
   .featured-grid {
     display: grid;
     grid-template-columns: repeat(3, 1fr);
-    gap: var(--space-lg);
+    gap: var(--space-xl) var(--space-lg);
     margin-bottom: var(--space-2xl);
   }
 

--- a/src/utils/homepage-articles.ts
+++ b/src/utils/homepage-articles.ts
@@ -84,7 +84,7 @@ export function getHomepageConverters(limit = 15): HomepageConverterCard[] {
 
 export function buildHomepageArticleFeed(
   entries: CollectionEntry<'articles'>[],
-  featuredCount = 3
+  featuredCount = 6
 ): HomepageArticleFeed {
   const sortedArticles = entries
     .slice()


### PR DESCRIPTION
## Summary
- feature six newest homepage articles with OG-image cards
- keep remaining articles in the compact list
- update homepage feed test coverage and system definition notes

## Tests
- bun run test
- pre-commit hook: bun run test && vitest run src/__tests__/site-smoke.test.ts