### PR TITLE
Show all homepage articles as OG cards

### DIFF
--- a/docs/system-definition.yaml
+++ b/docs/system-definition.yaml
@@ -53,9 +53,9 @@ site_system:
       notes: >
         Home page includes a dusty rose color block introducing the Comfort & Rest collector
         with tagline "Settle in." — positioned between HomepageHero and the start-prompt section.
-        The From the Guide section features the six newest article collectors with OG-image
-        cards, including How to Crate Train Your Dog to connect informational crate intent
-        with the new crate converter path.
+        The From the Guide section features all current article collectors with OG-image cards,
+        including How to Crate Train Your Dog to connect informational crate intent with the
+        new crate converter path.
         The Browse Picks list is temporarily broad enough to include Best Lick Mats for Dogs
         and Best Travel Crates for Road Trips until converter routing below the article section
         gets a fuller refactor.

--- a/src/__tests__/homepage-articles.test.ts
+++ b/src/__tests__/homepage-articles.test.ts
@@ -70,10 +70,9 @@ describe('homepage article feed', () => {
       '/safety/what-to-do-if-your-dog-runs-away/',
       '/comforting/how-much-do-dogs-sleep/',
       '/cooling/keep-dog-cool-in-car/',
-    ]);
-    expect(feed.moreArticles.map((article) => article.href)).toEqual([
       '/cooling/how-hot-is-too-hot-for-dogs/',
     ]);
+    expect(feed.moreArticles).toEqual([]);
     expect(feed.latestGuides.map((article) => article.href)).toEqual([
       '/calming/dog-fireworks-anxiety-checklist/',
       '/travel/how-to-fly-with-a-dog/',
@@ -87,7 +86,7 @@ describe('homepage article feed', () => {
     expect(feed.featuredArticles[0]?.image).toBe('/og/calming-dog-fireworks-anxiety-checklist.jpg');
     expect(feed.featuredArticles[1]?.image).toBe('/_assets/custom-og.jpg');
     expect(feed.featuredArticles[3]?.image).toBe('/og/safety-what-to-do-if-your-dog-runs-away.jpg');
-    expect(feed.moreArticles[0]?.image).toBe('/og/cooling-how-hot-is-too-hot-for-dogs.jpg');
+    expect(feed.featuredArticles[6]?.image).toBe('/og/cooling-how-hot-is-too-hot-for-dogs.jpg');
   });
 
   it('maps a single article into homepage card data', () => {

--- a/src/components/modules/HomepageBody.astro
+++ b/src/components/modules/HomepageBody.astro
@@ -97,21 +97,23 @@ const shopCards = [
     ))}
   </div>
 
-  <div class="more-grid">
-    {articleFeed.moreArticles.map((article) => (
-      <a
-        href={article.href}
-        class={`more-card more-card--${article.color}`}
-        data-home-article="true"
-        data-track="collector_to_converter_click"
-        data-to-page={article.href}
-        data-link-position="homepage-more-articles"
-      >
-        <h3 class="more-title">{article.title}</h3>
-        <p class="more-desc">{article.description}</p>
-      </a>
-    ))}
-  </div>
+  {articleFeed.moreArticles.length > 0 && (
+    <div class="more-grid">
+      {articleFeed.moreArticles.map((article) => (
+        <a
+          href={article.href}
+          class={`more-card more-card--${article.color}`}
+          data-home-article="true"
+          data-track="collector_to_converter_click"
+          data-to-page={article.href}
+          data-link-position="homepage-more-articles"
+        >
+          <h3 class="more-title">{article.title}</h3>
+          <p class="more-desc">{article.description}</p>
+        </a>
+      ))}
+    </div>
+  )}
 </section>
 
 {/* ── Browse Picks ── */}

--- a/src/utils/homepage-articles.ts
+++ b/src/utils/homepage-articles.ts
@@ -84,7 +84,7 @@ export function getHomepageConverters(limit = 15): HomepageConverterCard[] {
 
 export function buildHomepageArticleFeed(
   entries: CollectionEntry<'articles'>[],
-  featuredCount = 6
+  featuredCount = Number.POSITIVE_INFINITY
 ): HomepageArticleFeed {
   const sortedArticles = entries
     .slice()


### PR DESCRIPTION
## Summary
- render every homepage article with the full OG-image card treatment
- keep the compact article list as an empty-safe fallback only
- update homepage article feed tests and system definition notes

## Tests
- bun run test
- pre-commit hook: bun run test && vitest run src/__tests__/site-smoke.test.ts

## Render check
- built homepage showed 13 article cards for 13 article files, with 0 homepage-more-articles entries