### PR TITLE
[codex] Apply pillar theme consistency

### DIFF
--- a/docs/system-definition.yaml
+++ b/docs/system-definition.yaml
@@ -365,6 +365,14 @@ site_system:
       - "/calming/"
       - "/comforting/"
       - "/about/"
+    pillar_theme_contract:
+      source: "src/data/pillar-themes.ts"
+      rule: "Every page whose URL path starts with /cooling/, /calming/, or /comforting/ inherits its pillar theme in BaseLayout."
+      active_state: "Top-nav active and hover colors use the resolved pillar accent via --color-nav-accent."
+      themes:
+        cooling: "cooling blue for links, buttons, hover states, and soft accents on /cooling/*"
+        calming: "calming green for links, buttons, hover states, and soft accents on /calming/*"
+        comfort: "dusty rose for links, buttons, hover states, and soft accents on /comforting/*; do not use sky blue or terracotta as the Comforting authority"
 
   footer:
     sections:

--- a/src/__tests__/pillar-themes.test.ts
+++ b/src/__tests__/pillar-themes.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { pillarThemes, resolvePillarThemeFromPath } from '../data/pillar-themes';
+
+describe('pillar themes', () => {
+  it('resolves pillar root paths', () => {
+    expect(resolvePillarThemeFromPath('/cooling/')?.key).toBe('cooling');
+    expect(resolvePillarThemeFromPath('/calming/')?.key).toBe('calming');
+    expect(resolvePillarThemeFromPath('/comforting/')?.key).toBe('comfort');
+  });
+
+  it('resolves nested pillar paths', () => {
+    expect(resolvePillarThemeFromPath('/cooling/cooling-mats/')?.key).toBe('cooling');
+    expect(resolvePillarThemeFromPath('/calming/cbd-for-dogs/')?.key).toBe('calming');
+    expect(resolvePillarThemeFromPath('/comforting/best-anxiety-dog-crates/')?.key).toBe('comfort');
+  });
+
+  it('normalizes paths without trailing slashes', () => {
+    expect(resolvePillarThemeFromPath('/cooling/cooling-mats')?.key).toBe('cooling');
+    expect(resolvePillarThemeFromPath('/calming')?.key).toBe('calming');
+    expect(resolvePillarThemeFromPath('/comforting')?.key).toBe('comfort');
+  });
+
+  it('does not resolve unrelated paths', () => {
+    expect(resolvePillarThemeFromPath('/')).toBeUndefined();
+    expect(resolvePillarThemeFromPath('/gear/best-dog-gps-trackers/')).toBeUndefined();
+    expect(resolvePillarThemeFromPath('/shop/')).toBeUndefined();
+  });
+
+  it('keeps comfort on dusty rose instead of sky blue or terracotta', () => {
+    expect(pillarThemes.comfort.accent).toBe('hsl(345, 38%, 38%)');
+    expect(pillarThemes.comfort.link).toBe('#8c4a52');
+  });
+});

--- a/src/__tests__/site-smoke.test.ts
+++ b/src/__tests__/site-smoke.test.ts
@@ -172,6 +172,35 @@ describe('site smoke tests', () => {
     expect(coolingConverterCards[0]?.querySelector('img')).toBeNull();
   });
 
+  it('applies pillar themes to all pages under pillar URL paths', () => {
+    const cases = [
+      { page: path.join('cooling', 'index.html'), theme: 'cooling' },
+      { page: path.join('cooling', 'cooling-mats', 'index.html'), theme: 'cooling' },
+      { page: path.join('cooling', 'keep-dog-cool-in-car', 'index.html'), theme: 'cooling' },
+      { page: path.join('calming', 'index.html'), theme: 'calming' },
+      { page: path.join('calming', 'best-calming-products-for-anxious-dogs', 'index.html'), theme: 'calming' },
+      { page: path.join('calming', 'cbd-for-dogs', 'index.html'), theme: 'calming' },
+      { page: path.join('comforting', 'index.html'), theme: 'comfort' },
+      { page: path.join('comforting', 'best-anxiety-dog-crates', 'index.html'), theme: 'comfort' },
+      { page: path.join('comforting', 'how-much-do-dogs-sleep', 'index.html'), theme: 'comfort' },
+    ];
+
+    for (const { page, theme } of cases) {
+      const doc = readBuiltPage(page);
+      expect(doc.documentElement.getAttribute('data-pillar-theme')).toBe(theme);
+      expect(doc.documentElement.getAttribute('style')).toContain('--pillar-accent:');
+    }
+  });
+
+  it('marks the active pillar top-nav item with the pillar theme', () => {
+    const comfortDoc = readBuiltPage(path.join('comforting', 'best-anxiety-dog-crates', 'index.html'));
+    const activeNav = comfortDoc.querySelector<HTMLAnchorElement>('.main-nav a[aria-current="page"]');
+
+    expect(comfortDoc.documentElement.getAttribute('data-pillar-theme')).toBe('comfort');
+    expect(comfortDoc.documentElement.getAttribute('style')).toContain('--color-nav-accent: hsl(345, 38%, 38%)');
+    expect(activeNav?.getAttribute('href')).toBe('/comforting/');
+  });
+
   it('renders derived InternalLinkStrip links on migrated pages', () => {
     const cases = [
       {

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -13,6 +13,10 @@ const navItems = [
 const currentPath = Astro.url.pathname;
 const isHome = currentPath === '/' || currentPath.startsWith('/v/');
 const isSearch = currentPath === ROUTES.search;
+
+function isActivePath(href: string) {
+  return currentPath === href || (href !== '/' && currentPath.startsWith(href));
+}
 ---
 
 <header class="site-header">
@@ -28,16 +32,20 @@ const isSearch = currentPath === ROUTES.search;
     </button>
     <nav class="main-nav" aria-label="Main navigation">
       <ul>
-        {navItems.map(({ href, label }) => (
-          <li>
-            <a
-              href={href}
-              class:list={[{ active: currentPath === href || (href !== '/' && currentPath.startsWith(href)) }]}
-            >
-              {label}
-            </a>
-          </li>
-        ))}
+        {navItems.map(({ href, label }) => {
+          const isActive = isActivePath(href);
+          return (
+            <li>
+              <a
+                href={href}
+                class:list={[{ active: isActive }]}
+                aria-current={isActive ? 'page' : undefined}
+              >
+                {label}
+              </a>
+            </li>
+          );
+        })}
         <li>
           <a
             href={ROUTES.search}

--- a/src/components/modules/CalmingConverterPage.astro
+++ b/src/components/modules/CalmingConverterPage.astro
@@ -37,7 +37,7 @@ function quickPickProduct(item: QuickPickItem) {
 }
 ---
 
-<BaseLayout title={config.title} description={config.description} navAccent="var(--color-sage)">
+<BaseLayout title={config.title} description={config.description} pillarTheme="calming">
   {schema && <JsonLd slot="head" schema={schema} />}
 
   <div class="calming-theme">
@@ -285,7 +285,7 @@ function quickPickProduct(item: QuickPickItem) {
   }
 
   .quick-pick-image-placeholder {
-    color: var(--color-sage);
+    color: var(--pillar-accent);
     opacity: 0.5;
   }
 
@@ -307,8 +307,8 @@ function quickPickProduct(item: QuickPickItem) {
     text-align: center;
     margin-top: var(--space-md);
     padding: var(--space-sm) var(--space-md);
-    background: var(--color-sage);
-    color: var(--color-charcoal) !important;
+    background: var(--pillar-accent);
+    color: var(--pillar-accent-text) !important;
     font-weight: var(--weight-semibold);
     font-size: var(--text-sm);
     text-decoration: none;
@@ -322,23 +322,23 @@ function quickPickProduct(item: QuickPickItem) {
   }
 
   .quick-pick-link:hover {
-    background: var(--color-sage-hover);
-    color: var(--color-charcoal) !important;
+    background: var(--pillar-accent-hover);
+    color: var(--pillar-accent-text) !important;
   }
 
   .quick-pick-link--secondary {
     background: transparent;
-    color: var(--color-charcoal) !important;
-    border: 1px solid var(--color-sage);
+    color: var(--pillar-link) !important;
+    border: 1px solid var(--pillar-accent);
   }
 
   .quick-pick-link--secondary:hover {
-    background: color-mix(in srgb, var(--color-sage) 18%, transparent);
-    color: var(--color-charcoal) !important;
+    background: color-mix(in srgb, var(--pillar-accent) 18%, transparent);
+    color: var(--pillar-link) !important;
   }
 
   .quick-pick-link:focus-visible {
-    outline: 2px solid var(--color-sage);
+    outline: 2px solid var(--pillar-accent);
     outline-offset: 2px;
   }
 
@@ -352,46 +352,46 @@ function quickPickProduct(item: QuickPickItem) {
   }
 
   :global(.calming-theme .hero-cta--primary) {
-    background: var(--color-sage);
-    color: var(--color-charcoal);
+    background: var(--pillar-accent);
+    color: var(--pillar-accent-text);
   }
 
   :global(.calming-theme .hero-cta--primary:hover) {
-    background: var(--color-sage-hover);
-    color: var(--color-charcoal);
+    background: var(--pillar-accent-hover);
+    color: var(--pillar-accent-text);
   }
 
   :global(.calming-theme .hero-cta--secondary) {
-    color: var(--color-accent-text);
-    border-color: var(--color-accent-text);
+    color: var(--pillar-link);
+    border-color: var(--pillar-link);
   }
 
   :global(.calming-theme .hero-cta--secondary:hover) {
-    background: var(--color-sage);
-    color: var(--color-charcoal);
+    background: var(--pillar-accent);
+    color: var(--pillar-accent-text);
   }
 
   :global(.calming-theme .ils-link:hover) {
-    background: var(--color-sage);
-    color: var(--color-charcoal);
+    background: var(--pillar-accent);
+    color: var(--pillar-accent-text);
   }
 
   :global(.calming-theme .disc-inner a) {
-    color: var(--color-accent-text);
+    color: var(--pillar-link);
   }
 
   :global(.calming-theme .calm-card-cta) {
-    background: var(--color-sage);
-    color: var(--color-charcoal) !important;
+    background: var(--pillar-accent);
+    color: var(--pillar-accent-text) !important;
   }
 
   :global(.calming-theme .calm-card-cta:hover) {
-    background: var(--color-sage-hover);
-    color: var(--color-charcoal) !important;
+    background: var(--pillar-accent-hover);
+    color: var(--pillar-accent-text) !important;
   }
 
   :global(.calming-theme .calm-card-cta:focus-visible) {
-    outline-color: var(--color-sage);
+    outline-color: var(--pillar-accent);
   }
 
   @media (max-width: 1024px) {

--- a/src/components/modules/CalmingProductCard.astro
+++ b/src/components/modules/CalmingProductCard.astro
@@ -99,7 +99,7 @@ const offers = getOffers(product);
   }
 
   .calm-card-image-placeholder {
-    color: var(--color-sage);
+    color: var(--pillar-link);
     opacity: 0.5;
   }
 
@@ -120,7 +120,7 @@ const offers = getOffers(product);
 
   .calm-card-best-for {
     font-size: var(--text-sm);
-    color: var(--color-accent-text);
+    color: var(--pillar-link);
     margin-bottom: var(--space-md);
     line-height: var(--leading-normal);
   }
@@ -146,7 +146,7 @@ const offers = getOffers(product);
     content: '+';
     position: absolute;
     left: 0;
-    color: var(--color-accent-text);
+    color: var(--pillar-link);
     font-weight: var(--weight-bold);
   }
 
@@ -165,8 +165,8 @@ const offers = getOffers(product);
   :global(.calm-card-cta) {
     display: block;
     text-align: center;
-    background: var(--color-primary);
-    color: var(--color-text-inverse) !important;
+    background: var(--pillar-accent);
+    color: var(--pillar-accent-text) !important;
     font-weight: var(--weight-semibold);
     padding: var(--space-sm) var(--space-lg);
     border-radius: var(--radius-md);
@@ -176,23 +176,23 @@ const offers = getOffers(product);
   }
 
   :global(.calm-card-cta:hover) {
-    background: var(--color-primary-hover);
-    color: var(--color-text-inverse) !important;
+    background: var(--pillar-accent-hover);
+    color: var(--pillar-accent-text) !important;
   }
 
   :global(.calm-card-cta--secondary) {
     background: transparent;
-    color: var(--color-primary) !important;
-    border: 1px solid var(--color-primary);
+    color: var(--pillar-link) !important;
+    border: 1px solid var(--pillar-accent);
   }
 
   :global(.calm-card-cta--secondary:hover) {
-    background: color-mix(in srgb, var(--color-primary) 10%, transparent);
-    color: var(--color-primary) !important;
+    background: color-mix(in srgb, var(--pillar-accent) 10%, transparent);
+    color: var(--pillar-link) !important;
   }
 
   :global(.calm-card-cta:focus-visible) {
-    outline: 2px solid var(--color-primary);
+    outline: 2px solid var(--pillar-accent);
     outline-offset: 2px;
   }
 </style>

--- a/src/components/modules/CollectorBody.astro
+++ b/src/components/modules/CollectorBody.astro
@@ -8,12 +8,11 @@ interface Props {
 }
 
 const { config } = Astro.props;
-const accentColor = config.accent === 'sage' ? 'var(--color-sage)' : config.accent === 'terracotta' ? 'var(--color-terracotta)' : 'var(--color-primary)';
 ---
 
 {config.start && (
   <section class="start-here">
-    <div class="start-here-inner" style={`--collector-accent: ${accentColor}`}>
+    <div class="start-here-inner">
       <span class="start-here-label">Start here</span>
       <h2>
         <a
@@ -52,7 +51,6 @@ const accentColor = config.accent === 'sage' ? 'var(--color-sage)' : config.acce
           data-category={card.dataCategory}
           data-card-type={card.cardType}
           data-link-position="section"
-          style={`--collector-accent: ${accentColor}`}
         >
           {card.image && (
             <span class="cat-card-media" aria-hidden="true">
@@ -84,7 +82,7 @@ const accentColor = config.accent === 'sage' ? 'var(--color-sage)' : config.acce
 
   .start-here-inner {
     background: var(--color-surface);
-    border: 2px solid var(--collector-accent);
+    border: 2px solid var(--pillar-accent);
     border-radius: var(--radius-lg);
     padding: var(--space-xl);
     text-align: center;
@@ -96,7 +94,7 @@ const accentColor = config.accent === 'sage' ? 'var(--color-sage)' : config.acce
     font-weight: var(--weight-bold);
     text-transform: uppercase;
     letter-spacing: 0.05em;
-    color: var(--collector-accent);
+    color: var(--pillar-link);
     margin-bottom: var(--space-sm);
   }
 
@@ -111,7 +109,7 @@ const accentColor = config.accent === 'sage' ? 'var(--color-sage)' : config.acce
   }
 
   .start-here-inner h2 a:hover {
-    color: var(--collector-accent);
+    color: var(--pillar-link);
   }
 
   .start-here-inner p {
@@ -173,7 +171,7 @@ const accentColor = config.accent === 'sage' ? 'var(--color-sage)' : config.acce
   .cat-card-media {
     display: block;
     aspect-ratio: 16 / 9;
-    background: color-mix(in srgb, var(--collector-accent) 12%, var(--color-surface));
+    background: color-mix(in srgb, var(--pillar-accent) 12%, var(--color-surface));
     border-bottom: 1px solid var(--color-border);
     overflow: hidden;
   }
@@ -186,13 +184,13 @@ const accentColor = config.accent === 'sage' ? 'var(--color-sage)' : config.acce
   }
 
   .cat-card--guide {
-    border: 1px solid color-mix(in srgb, var(--collector-accent) 35%, var(--color-border));
+    border: 1px solid color-mix(in srgb, var(--pillar-accent) 35%, var(--color-border));
   }
 
   .cat-card--guide .cat-card-body {
     background: linear-gradient(
       180deg,
-      color-mix(in srgb, var(--collector-accent) 8%, var(--color-surface)) 0%,
+      color-mix(in srgb, var(--pillar-accent) 8%, var(--color-surface)) 0%,
       var(--color-surface) 55%
     );
   }
@@ -200,8 +198,8 @@ const accentColor = config.accent === 'sage' ? 'var(--color-sage)' : config.acce
   .cat-card-badge {
     align-self: flex-start;
     border-radius: 999px;
-    background: color-mix(in srgb, var(--collector-accent) 15%, var(--color-surface));
-    color: var(--collector-accent);
+    background: color-mix(in srgb, var(--pillar-accent) 15%, var(--color-surface));
+    color: var(--pillar-link);
     font-size: var(--text-xs);
     font-weight: var(--weight-bold);
     letter-spacing: 0.05em;
@@ -228,7 +226,7 @@ const accentColor = config.accent === 'sage' ? 'var(--color-sage)' : config.acce
   .cat-card-link {
     font-size: var(--text-sm);
     font-weight: var(--weight-semibold);
-    color: var(--collector-accent);
+    color: var(--pillar-link);
   }
 
   .cat-card:hover .cat-card-link {
@@ -242,6 +240,6 @@ const accentColor = config.accent === 'sage' ? 'var(--color-sage)' : config.acce
   }
 
   :global(.disc-inner a) {
-    color: var(--collector-accent);
+    color: var(--pillar-link);
   }
 </style>

--- a/src/components/modules/RelaxationConverterPage.astro
+++ b/src/components/modules/RelaxationConverterPage.astro
@@ -36,7 +36,7 @@ function quickPickProduct(item: QuickPickItem) {
 }
 ---
 
-<BaseLayout title={config.title} ogTitle={config.ogTitle} description={config.description} navAccent="var(--color-sky)">
+<BaseLayout title={config.title} ogTitle={config.ogTitle} description={config.description} pillarTheme="comfort">
   {schema && <JsonLd slot="head" schema={schema} />}
 
   <div class="relaxation-theme">
@@ -273,7 +273,7 @@ function quickPickProduct(item: QuickPickItem) {
   }
 
   .quick-pick-image-placeholder {
-    color: var(--color-sky);
+    color: var(--pillar-accent);
     opacity: 0.5;
   }
 
@@ -295,8 +295,8 @@ function quickPickProduct(item: QuickPickItem) {
     text-align: center;
     margin-top: var(--space-md);
     padding: var(--space-sm) var(--space-md);
-    background: var(--color-sky);
-    color: var(--color-charcoal) !important;
+    background: var(--pillar-accent);
+    color: var(--pillar-accent-text) !important;
     font-weight: var(--weight-semibold);
     font-size: var(--text-sm);
     text-decoration: none;
@@ -310,23 +310,23 @@ function quickPickProduct(item: QuickPickItem) {
   }
 
   .quick-pick-link:hover {
-    background: var(--color-sky-hover);
-    color: var(--color-charcoal) !important;
+    background: var(--pillar-accent-hover);
+    color: var(--pillar-accent-text) !important;
   }
 
   .quick-pick-link--secondary {
     background: transparent;
-    color: var(--color-charcoal) !important;
-    border: 1px solid var(--color-sky);
+    color: var(--pillar-link) !important;
+    border: 1px solid var(--pillar-accent);
   }
 
   .quick-pick-link--secondary:hover {
-    background: color-mix(in srgb, var(--color-sky) 16%, transparent);
-    color: var(--color-charcoal) !important;
+    background: color-mix(in srgb, var(--pillar-accent) 16%, transparent);
+    color: var(--pillar-link) !important;
   }
 
   .quick-pick-link:focus-visible {
-    outline: 2px solid var(--color-sky);
+    outline: 2px solid var(--pillar-accent);
     outline-offset: 2px;
   }
 
@@ -340,32 +340,32 @@ function quickPickProduct(item: QuickPickItem) {
   }
 
   :global(.relaxation-theme .hero-cta--primary) {
-    background: var(--color-sky);
-    color: var(--color-charcoal);
+    background: var(--pillar-accent);
+    color: var(--pillar-accent-text);
   }
 
   :global(.relaxation-theme .hero-cta--primary:hover) {
-    background: var(--color-sky-hover);
-    color: var(--color-charcoal);
+    background: var(--pillar-accent-hover);
+    color: var(--pillar-accent-text);
   }
 
   :global(.relaxation-theme .hero-cta--secondary) {
-    color: var(--color-sky);
-    border-color: var(--color-sky);
+    color: var(--pillar-link);
+    border-color: var(--pillar-link);
   }
 
   :global(.relaxation-theme .hero-cta--secondary:hover) {
-    background: var(--color-sky);
-    color: var(--color-charcoal);
+    background: var(--pillar-accent);
+    color: var(--pillar-accent-text);
   }
 
   :global(.relaxation-theme .ils-link:hover) {
-    background: var(--color-sky);
-    color: var(--color-charcoal);
+    background: var(--pillar-accent);
+    color: var(--pillar-accent-text);
   }
 
   :global(.relaxation-theme .disc-inner a) {
-    color: var(--color-sky);
+    color: var(--pillar-link);
   }
 
   @media (max-width: 1024px) {

--- a/src/components/modules/RelaxationProductCard.astro
+++ b/src/components/modules/RelaxationProductCard.astro
@@ -98,7 +98,7 @@ const offers = getOffers(product);
   }
 
   .rx-card-image-placeholder {
-    color: var(--color-sky);
+    color: var(--pillar-link);
     opacity: 0.5;
   }
 
@@ -119,7 +119,7 @@ const offers = getOffers(product);
 
   .rx-card-best-for {
     font-size: var(--text-sm);
-    color: var(--color-accent-text);
+    color: var(--pillar-link);
     margin-bottom: var(--space-md);
     line-height: var(--leading-normal);
   }
@@ -145,7 +145,7 @@ const offers = getOffers(product);
     content: '+';
     position: absolute;
     left: 0;
-    color: var(--color-sky);
+    color: var(--pillar-link);
     font-weight: var(--weight-bold);
   }
 
@@ -164,8 +164,8 @@ const offers = getOffers(product);
   :global(.rx-card-cta) {
     display: block;
     text-align: center;
-    background: var(--color-sky);
-    color: var(--color-charcoal) !important;
+    background: var(--pillar-accent);
+    color: var(--pillar-accent-text) !important;
     font-weight: var(--weight-semibold);
     padding: var(--space-sm) var(--space-lg);
     border-radius: var(--radius-md);
@@ -175,23 +175,23 @@ const offers = getOffers(product);
   }
 
   :global(.rx-card-cta:hover) {
-    background: var(--color-sky-hover);
-    color: var(--color-charcoal) !important;
+    background: var(--pillar-accent-hover);
+    color: var(--pillar-accent-text) !important;
   }
 
   :global(.rx-card-cta--secondary) {
     background: transparent;
-    color: var(--color-charcoal) !important;
-    border: 1px solid var(--color-sky);
+    color: var(--pillar-link) !important;
+    border: 1px solid var(--pillar-accent);
   }
 
   :global(.rx-card-cta--secondary:hover) {
-    background: color-mix(in srgb, var(--color-sky) 16%, transparent);
-    color: var(--color-charcoal) !important;
+    background: color-mix(in srgb, var(--pillar-accent) 16%, transparent);
+    color: var(--pillar-link) !important;
   }
 
   :global(.rx-card-cta:focus-visible) {
-    outline: 2px solid var(--color-sky);
+    outline: 2px solid var(--pillar-accent);
     outline-offset: 2px;
   }
 </style>

--- a/src/components/modules/SectionCollectorPage.astro
+++ b/src/components/modules/SectionCollectorPage.astro
@@ -17,7 +17,7 @@ const { definition, body, schema } = await getSectionCollectorPageData(collector
   title={definition.title}
   ogTitle={definition.ogTitle}
   description={definition.description}
-  navAccent={definition.navAccent}
+  pillarTheme={definition.accent}
 >
   <JsonLd slot="head" schema={schema} />
   <HeroExperiment

--- a/src/data/pillar-themes.ts
+++ b/src/data/pillar-themes.ts
@@ -1,0 +1,66 @@
+export type PillarThemeKey = 'cooling' | 'calming' | 'comfort';
+
+export interface PillarTheme {
+  key: PillarThemeKey;
+  pathPrefix: string;
+  accent: string;
+  accentHover: string;
+  accentText: string;
+  link: string;
+  linkHover: string;
+  softBackground: string;
+}
+
+export const pillarThemes: Record<PillarThemeKey, PillarTheme> = {
+  cooling: {
+    key: 'cooling',
+    pathPrefix: '/cooling/',
+    accent: 'hsl(200, 80%, 28%)',
+    accentHover: 'hsl(200, 80%, 22%)',
+    accentText: '#ffffff',
+    link: '#1c4a5e',
+    linkHover: '#143747',
+    softBackground: 'hsl(195, 70%, 96%)',
+  },
+  calming: {
+    key: 'calming',
+    pathPrefix: '/calming/',
+    accent: 'hsl(155, 50%, 26%)',
+    accentHover: 'hsl(155, 52%, 20%)',
+    accentText: '#ffffff',
+    link: '#2f5b3d',
+    linkHover: '#21432d',
+    softBackground: 'hsl(150, 30%, 96%)',
+  },
+  comfort: {
+    key: 'comfort',
+    pathPrefix: '/comforting/',
+    accent: 'hsl(345, 38%, 38%)',
+    accentHover: 'hsl(345, 40%, 30%)',
+    accentText: '#ffffff',
+    link: '#8c4a52',
+    linkHover: '#6f343d',
+    softBackground: 'hsl(345, 40%, 97%)',
+  },
+};
+
+export function resolvePillarThemeFromPath(pathname: string): PillarTheme | undefined {
+  const normalizedPath = pathname.endsWith('/') ? pathname : `${pathname}/`;
+  return Object.values(pillarThemes).find((theme) => normalizedPath.startsWith(theme.pathPrefix));
+}
+
+export function pillarThemeStyle(theme: PillarTheme): string {
+  return [
+    `--pillar-accent: ${theme.accent}`,
+    `--pillar-accent-hover: ${theme.accentHover}`,
+    `--pillar-accent-text: ${theme.accentText}`,
+    `--pillar-link: ${theme.link}`,
+    `--pillar-link-hover: ${theme.linkHover}`,
+    `--pillar-soft-bg: ${theme.softBackground}`,
+    `--color-nav-accent: ${theme.accent}`,
+    `--color-link: ${theme.link}`,
+    `--color-link-hover: ${theme.linkHover}`,
+    `--color-primary: ${theme.accent}`,
+    `--color-primary-hover: ${theme.accentHover}`,
+  ].join('; ');
+}

--- a/src/data/section-collectors.ts
+++ b/src/data/section-collectors.ts
@@ -1,4 +1,5 @@
 import type { SitemapPage, SitemapSection, SitemapTopic } from './content-sitemap';
+import type { PillarThemeKey } from './pillar-themes';
 import { ROUTES } from './routes';
 
 export interface CollectorCard {
@@ -21,7 +22,7 @@ export interface CollectorSection {
 
 export interface CollectorBodyConfig {
   fromPage: string;
-  accent: 'primary' | 'sage' | 'terracotta';
+  accent: PillarThemeKey;
   start?: {
     href: string;
     title: string;
@@ -98,7 +99,7 @@ export const sectionCollectorDefinitions: Record<SectionCollectorKey, SectionCol
     key: 'cooling',
     href: ROUTES.coolingHub,
     fromPage: 'cooling-collector',
-    accent: 'primary',
+    accent: 'cooling',
     title: 'Cooling Relief',
     ogTitle: 'Cooling Products for Dogs | Mats, Vests & Bandanas',
     schemaName: 'Cooling Relief for Dogs',
@@ -167,8 +168,7 @@ export const sectionCollectorDefinitions: Record<SectionCollectorKey, SectionCol
     key: 'calming',
     href: ROUTES.calmingHub,
     fromPage: 'calming-collector',
-    accent: 'sage',
-    navAccent: 'var(--color-sage)',
+    accent: 'calming',
     title: 'Calm & Comfort',
     ogTitle: 'Calming Products for Dogs | ThunderShirts, Treats & More',
     schemaName: 'Calming Products for Anxious Dogs',
@@ -252,7 +252,7 @@ export const sectionCollectorDefinitions: Record<SectionCollectorKey, SectionCol
     key: 'comfort',
     href: ROUTES.comfortHub,
     fromPage: 'comfort-collector',
-    accent: 'terracotta',
+    accent: 'comfort',
     title: 'Comfort & Rest',
     ogTitle: 'Dog Beds for Comfort & Rest | Calming & Orthopedic Picks',
     schemaName: 'Comfort & Rest for Dogs',

--- a/src/layouts/ArticleLayout.astro
+++ b/src/layouts/ArticleLayout.astro
@@ -5,6 +5,7 @@ import '@styles/collector-article.css';
 import '@styles/article-components.css';
 import type { ImageMetadata } from 'astro';
 import { resolveAutoOgImagePath, resolveProvidedOgImagePath } from '@utils/og';
+import type { PillarThemeKey } from '@data/pillar-themes';
 
 interface Props {
   title: string;
@@ -13,9 +14,10 @@ interface Props {
   canonicalPath: string;
   ogImage?: string | ImageMetadata;
   navAccent?: string;
+  pillarTheme?: PillarThemeKey;
 }
 
-const { title, description, ogTitle, canonicalPath, ogImage, navAccent } = Astro.props;
+const { title, description, ogTitle, canonicalPath, ogImage, navAccent, pillarTheme } = Astro.props;
 const canonicalUrl = `https://www.chill-dogs.com${canonicalPath}`;
 const resolvedArticleImage = resolveProvidedOgImagePath(ogImage)
   ?? `https://www.chill-dogs.com${resolveAutoOgImagePath({ pathname: canonicalPath }) ?? '/og-default.jpg'}`;
@@ -35,7 +37,7 @@ const articleSchema = {
   },
 };
 ---
-<BaseLayout {title} {description} {ogTitle} canonicalUrl={canonicalUrl} {navAccent}>
+<BaseLayout {title} {description} {ogTitle} canonicalUrl={canonicalUrl} {navAccent} {pillarTheme}>
   <JsonLd slot="head" schema={articleSchema} />
   <slot />
 </BaseLayout>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -14,6 +14,7 @@ import SpeedInsights from '@vercel/speed-insights/astro';
 import type { ImageMetadata } from 'astro';
 import { resolveAutoOgImagePath, resolveProvidedOgImagePath } from '@utils/og';
 import { buildBreadcrumbSchema } from '@utils/breadcrumbs';
+import { pillarThemes, pillarThemeStyle, resolvePillarThemeFromPath, type PillarThemeKey } from '@data/pillar-themes';
 
 interface Props {
   title: string;
@@ -23,6 +24,7 @@ interface Props {
   canonicalUrl?: string;
   noindex?: boolean;
   navAccent?: string;
+  pillarTheme?: PillarThemeKey;
   hideChrome?: boolean;
 }
 
@@ -34,9 +36,17 @@ const {
   canonicalUrl,
   noindex = false,
   navAccent,
+  pillarTheme,
   hideChrome = false,
 } = Astro.props;
 
+const inferredPillarTheme = resolvePillarThemeFromPath(Astro.url.pathname);
+const resolvedPillarTheme = inferredPillarTheme ?? (pillarTheme ? pillarThemes[pillarTheme] : undefined);
+const htmlStyle = resolvedPillarTheme
+  ? pillarThemeStyle(resolvedPillarTheme)
+  : navAccent
+    ? `--color-nav-accent: ${navAccent}`
+    : undefined;
 const siteTitle = title === 'Home'
   ? 'Chill-Dogs — Cooling & Calming Products for Dogs'
   : `${title} | Chill-Dogs`;
@@ -53,7 +63,7 @@ const breadcrumbSchema = !noindex && !isStaging && Astro.site
 ---
 
 <!doctype html>
-<html lang="en" style={navAccent ? `--color-nav-accent: ${navAccent}` : undefined}>
+<html lang="en" data-pillar-theme={resolvedPillarTheme?.key} style={htmlStyle}>
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -21,6 +21,12 @@
   --color-accent: var(--color-sage);
   --color-accent-text: #5e7a5a;
   --color-accent-alt: var(--color-terracotta);
+  --pillar-accent: var(--color-primary);
+  --pillar-accent-hover: var(--color-primary-hover);
+  --pillar-accent-text: var(--color-text-inverse);
+  --pillar-link: var(--color-link);
+  --pillar-link-hover: var(--color-link-hover);
+  --pillar-soft-bg: var(--color-bg-cool);
   --color-surface: #ffffff;
   --color-border: #c5d4dc;
 


### PR DESCRIPTION
## Summary
- Add centralized pillar theme resolution for `/cooling/*`, `/calming/*`, and `/comforting/*` paths.
- Wire BaseLayout, top nav active states, collector cards, and converter CTAs to shared pillar CSS variables.
- Make Comforting use dusty rose as the authoritative pillar color instead of sky blue or terracotta.
- Document the pillar theme contract in `docs/system-definition.yaml`.

## Why
Pillar theme colors were consistent on the pillar landing pages but drifted on nested converter and article paths. The nav active state and CTA/link styling now respect the URL path authority across each pillar.

## Validation
- `bun run test`
- `bun run build`
- pre-commit hook: `bun run test && bun run test:smoke`