### PR TITLE
Fix story-link overflow on mobile by allowing text to wrap

### DIFF
--- a/src/pages/gear/garmin-dog-tracking-collars.astro
+++ b/src/pages/gear/garmin-dog-tracking-collars.astro
@@ -399,7 +399,6 @@ const collectionSchema = {
     font-weight: var(--weight-semibold);
     color: var(--color-primary);
     text-decoration: none;
-    white-space: nowrap;
   }
 
   .story-link:hover {


### PR DESCRIPTION
white-space: nowrap on .story-link prevented the long link text from
wrapping on narrow screens, causing it to bleed outside the container.

https://claude.ai/code/session_015jd1eS7jQth4TSi3ancFbi