### PR TITLE
Add Chewy to all affiliate disclosures

### DIFF
--- a/src/components/modules/Disclosure.astro
+++ b/src/components/modules/Disclosure.astro
@@ -11,7 +11,7 @@ const { showSafety = true } = Astro.props;
 <aside class="disc" aria-label="Disclosures">
   <div class="disc-inner">
     <p class="disc-affiliate">
-      <strong>Affiliate Disclosure:</strong> This page contains affiliate links. If you purchase through these links,
+      <strong>Affiliate Disclosure:</strong> This page contains affiliate links to Amazon and Chewy. If you purchase through these links,
       we earn a small commission at no extra cost to you. This supports our ability to research and recommend products.
       <a href={ROUTES.affiliateDisclosure}>Full disclosure</a>.
     </p>

--- a/src/pages/affiliate-disclosure.astro
+++ b/src/pages/affiliate-disclosure.astro
@@ -6,7 +6,7 @@ import BaseLayout from '@layouts/BaseLayout.astro';
 <BaseLayout
   title="Affiliate Disclosure"
   ogTitle="Affiliate Disclosure | How Chill-Dogs Earns Revenue"
-  description="Full affiliate disclosure for Chill-Dogs. We earn commissions from Amazon on qualifying purchases made through links on our site — here's exactly how that works."
+  description="Full affiliate disclosure for Chill-Dogs. We earn commissions from Amazon and Chewy on qualifying purchases made through links on our site."
 >
   <section class="legal container">
     <div class="prose">
@@ -15,10 +15,13 @@ import BaseLayout from '@layouts/BaseLayout.astro';
       <p>
         Chill-Dogs is a participant in the <strong>Amazon Services LLC Associates Program</strong>, an affiliate advertising program designed to provide a means for sites to earn advertising fees by advertising and linking to Amazon.com.
       </p>
+      <p>
+        Chill-Dogs is also a participant in the <strong>Chewy Affiliate Program</strong>, an affiliate advertising program that allows sites to earn commissions by linking to Chewy.com.
+      </p>
 
       <h2>What This Means for You</h2>
       <p>
-        When you click on a product link on our site and make a purchase on Amazon, we may receive a small commission. This comes at <strong>no additional cost to you</strong> — the price you pay is exactly the same whether you use our link or go directly to Amazon.
+        When you click on a product link on our site and make a purchase on Amazon or Chewy, we may receive a small commission. This comes at <strong>no additional cost to you</strong> — the price you pay is exactly the same whether you use our link or go directly to the retailer.
       </p>
 
       <h2>Our Commitment to Honesty</h2>
@@ -38,7 +41,7 @@ import BaseLayout from '@layouts/BaseLayout.astro';
 
       <h2>Identifying Affiliate Links</h2>
       <p>
-        Affiliate links on our site are typically "Check Price on Amazon" or "View on Amazon" buttons. We also include disclosure notices near affiliate content throughout the site.
+        Affiliate links on our site are typically "Check Price on Amazon", "View on Amazon", or "Check Price on Chewy" buttons. We also include disclosure notices near affiliate content throughout the site.
       </p>
 
       <h2>Questions?</h2>

--- a/src/pages/shop/index.astro
+++ b/src/pages/shop/index.astro
@@ -135,7 +135,7 @@ for (const pillar of pillars) {
       </p>
 
       <div class="disclosure">
-        <p>Chill Dogs is a participant in the Amazon Services LLC Associates Program. As an Amazon Associate, we earn from qualifying purchases at no extra cost to you. <a href={ROUTES.affiliateDisclosure}>Full disclosure →</a></p>
+        <p>Chill Dogs is a participant in the Amazon Services LLC Associates Program. As an Amazon Associate, we earn from qualifying purchases at no extra cost to you. Chill Dogs also participates in the Chewy Affiliate Program and earns commissions from qualifying Chewy purchases. <a href={ROUTES.affiliateDisclosure}>Full disclosure →</a></p>
       </div>
     </div>
 

--- a/src/pages/terms.astro
+++ b/src/pages/terms.astro
@@ -20,7 +20,7 @@ import BaseLayout from '@layouts/BaseLayout.astro';
 
       <h2>Affiliate Links</h2>
       <p>
-        This site contains affiliate links to Amazon.com and potentially other retailers. When you click on these links and make a purchase, we may earn a commission. This does not affect the price you pay. See our <a href={ROUTES.affiliateDisclosure}>Affiliate Disclosure</a> for more details.
+        This site contains affiliate links to Amazon.com and Chewy.com. When you click on these links and make a purchase, we may earn a commission. This does not affect the price you pay. See our <a href={ROUTES.affiliateDisclosure}>Affiliate Disclosure</a> for more details.
       </p>
 
       <h2>Intellectual Property</h2>


### PR DESCRIPTION
## Summary
- `Disclosure.astro` (used on all article/converter pages): "affiliate links" → "affiliate links to Amazon and Chewy"
- `affiliate-disclosure.astro`: Added Chewy Affiliate Program paragraph; updated "What This Means for You" and "Identifying Affiliate Links" sections
- `shop/index.astro`: Added Chewy sentence after the Amazon Associates sentence
- `terms.astro`: Replaced "Amazon.com and potentially other retailers" with "Amazon.com and Chewy.com"

Footer was already correct (has separate Amazon and Chewy blocks). `AffiliateDisclosure.astro` is dead code — skipped.

## Test plan
- [x] `bun run build` — 75 pages built, no errors
- [x] `bun run test` — 189/189 passing (caught og:description length violation and fixed it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)