### PR TITLE
Add Rolling Dog Farm to shelter dog charities page

### DIFF
--- a/src/pages/shelter-dog-charities.astro
+++ b/src/pages/shelter-dog-charities.astro
@@ -162,6 +162,13 @@ import BaseLayout from '@layouts/BaseLayout.astro';
       </p>
 
       <h2>Rolling Dog Farm</h2>
+      <img
+        src="https://scontent-lax3-1.xx.fbcdn.net/v/t39.30808-1/310302024_488211616673609_1419817390131643100_n.jpg?stp=dst-jpg_tt6&cstp=mx239x239&ctp=s239x239&_nc_cat=110&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=risndhMryjsQ7kNvwE0eGEd&_nc_oc=AdpuywJ_JwXAjAl3n0wrDNoZIz3VeexALbhR4_Yms_qy7ajjzeZ18laVWG5rn50I5oI&_nc_zt=24&_nc_ht=scontent-lax3-1.xx&_nc_gid=EwAlOofw_i5xjhA4nCgYeQ&_nc_ss=7b289&oh=00_AQAWp501wVAHePyCrwbU5RxvfCgvRp0CxBL7UoMs-i57xw&oe=6A4925E6"
+        alt="Rolling Dog Farm logo"
+        class="charity-logo"
+        loading="lazy"
+        decoding="async"
+      />
       <p>
         Rolling Dog Farm is a 501(c)(3) nonprofit sanctuary in the White Mountains of northern New
         Hampshire for dogs that most shelters struggle to place — blind, blind and deaf, missing a

--- a/src/pages/shelter-dog-charities.astro
+++ b/src/pages/shelter-dog-charities.astro
@@ -161,6 +161,23 @@ import BaseLayout from '@layouts/BaseLayout.astro';
         >.
       </p>
 
+      <h2>Rolling Dog Farm</h2>
+      <p>
+        Rolling Dog Farm is a 501(c)(3) nonprofit sanctuary in the White Mountains of northern New
+        Hampshire for dogs that most shelters struggle to place — blind, blind and deaf, missing a
+        limb, or living with neurological or orthopedic conditions. Founded in 2000 as Rolling Dog
+        Ranch Animal Sanctuary, it was built on the belief that disability is no reason to give up
+        on a dog. The farm takes in animals that are among the least likely to be adopted and among
+        the most vulnerable in traditional shelters, and shows — through the daily lives of the dogs
+        in its care — that with patience and the right support, they can thrive.
+      </p>
+      <p>
+        Learn more at{' '}
+        <a href="https://www.rollingdogfarm.org/" target="_blank" rel="noopener noreferrer"
+          >rollingdogfarm.org</a
+        >.
+      </p>
+
       <h2>Tails That Teach</h2>
       <p>
         Tails That Teach inspires young children to be kind to pets and people. Its primary focus is


### PR DESCRIPTION
Inserts Rolling Dog Farm (rollingdogfarm.org) in alphabetical order between
Reducing Animal Stress and Tails That Teach. Rolling Dog Farm is a 501(c)(3)
sanctuary in New Hampshire that rescues disabled dogs who are blind, deaf,
missing a limb, or living with neurological/orthopedic conditions. Includes the
Rolling Dog Farm logo image above the section description.

Co-Authored-By: Claude