### PR TITLE
Move the featured guide below the homepage hero's gradient bar

### DIFF
--- a/src/components/modules/HomepageHero.astro
+++ b/src/components/modules/HomepageHero.astro
@@ -11,6 +11,7 @@ interface Props {
 const { featuredArticle } = Astro.props;
 ---
 
+<div class="hp-hero-root" data-hero-root="true">
 <section
   class="hp-hero"
   data-hero-variant="v6"
@@ -70,45 +71,47 @@ const { featuredArticle } = Astro.props;
         </div>
       </div>
     </div>
-    {featuredArticle && (
-      <div class="hp-v6-below">
-        <a
-          href={featuredArticle.href}
-          class="hp-v6-featured"
-          data-home-article="true"
-          data-track="collector_to_converter_click"
-          data-to-page={featuredArticle.href}
-          data-link-position="homepage-hero-featured"
-        >
-          <div class="hp-v6-featured-img-wrap">
-            <img
-              src={typeof featuredArticle.image === 'string' ? featuredArticle.image : featuredArticle.image.src}
-              alt=""
-              class="hp-v6-featured-img"
-              width="600"
-              height="315"
-              loading="eager"
-            />
-          </div>
-          <div class="hp-v6-featured-body">
-            <span class="hp-v6-featured-kicker">Latest guide</span>
-            <span class={`hp-v6-featured-label hp-v6-featured-label--${featuredArticle.color}`}>
-              {featuredArticle.label}
-            </span>
-            <h2 class="hp-v6-featured-title">{featuredArticle.title}</h2>
-            <p class="hp-v6-featured-desc">{featuredArticle.description}</p>
-            <span class="hp-v6-featured-read">
-              Read the latest <span class="hp-v6-featured-arrow" aria-hidden="true">→</span>
-            </span>
-          </div>
-        </a>
-        <a class="hp-v6-viewall" href={ROUTES.articles} data-cta="articles" data-track="hero_click_articles">
-          View all articles <span class="hp-v6-viewall-arrow" aria-hidden="true">→</span>
-        </a>
-      </div>
-    )}
   </div>
 </section>
+
+{featuredArticle && (
+  <div class="hp-v6-below">
+    <a
+      href={featuredArticle.href}
+      class="hp-v6-featured"
+      data-home-article="true"
+      data-track="collector_to_converter_click"
+      data-to-page={featuredArticle.href}
+      data-link-position="homepage-hero-featured"
+    >
+      <div class="hp-v6-featured-img-wrap">
+        <img
+          src={typeof featuredArticle.image === 'string' ? featuredArticle.image : featuredArticle.image.src}
+          alt=""
+          class="hp-v6-featured-img"
+          width="600"
+          height="315"
+          loading="eager"
+        />
+      </div>
+      <div class="hp-v6-featured-body">
+        <span class="hp-v6-featured-kicker">Latest guide</span>
+        <span class={`hp-v6-featured-label hp-v6-featured-label--${featuredArticle.color}`}>
+          {featuredArticle.label}
+        </span>
+        <h2 class="hp-v6-featured-title">{featuredArticle.title}</h2>
+        <p class="hp-v6-featured-desc">{featuredArticle.description}</p>
+        <span class="hp-v6-featured-read">
+          Read the latest <span class="hp-v6-featured-arrow" aria-hidden="true">→</span>
+        </span>
+      </div>
+    </a>
+    <a class="hp-v6-viewall" href={ROUTES.articles} data-cta="articles" data-track="hero_click_articles">
+      View all articles <span class="hp-v6-viewall-arrow" aria-hidden="true">→</span>
+    </a>
+  </div>
+)}
+</div>
 
 <script>
   (function () {
@@ -127,7 +130,11 @@ const { featuredArticle } = Astro.props;
     var hero = document.querySelector('[data-hero-impression="true"]');
     if (!hero) return;
 
-    hero.addEventListener('click', function (e) {
+    // The featured-guide block sits outside the hero section (below the gradient
+    // bar), so delegate CTA clicks from the wrapper that holds both.
+    var heroRoot = document.querySelector('[data-hero-root="true"]') || hero;
+
+    heroRoot.addEventListener('click', function (e) {
       var cta = (e.target as Element).closest('[data-cta]') as HTMLElement | null;
       if (!cta) return;
       trackHeroCtaClick({ cta: cta.dataset.cta!, href: (cta as HTMLAnchorElement).href });

--- a/src/styles/hero.home.base.css
+++ b/src/styles/hero.home.base.css
@@ -203,7 +203,7 @@
   width: 100%;
   max-width: 880px;
   margin: 0 auto;
-  padding: 0 var(--space-lg) var(--space-2xl);
+  padding: var(--space-lg) var(--space-lg) var(--space-2xl);
 }
 
 .hp-v6-featured {


### PR DESCRIPTION
The homepage hero now ends at the gradient rule. It contains only the logo, the tagline, and the four category buttons — the "Latest guide" callout and the view-all link render directly beneath the bar instead of inside the cream hero block.

Separate from the flea/tick release PRs (#282, #283) so it can ship on its own.

## What changed

`.hp-v6-below` moves out of `<section class="hp-hero">` and becomes a sibling. Since the gradient bar is `.hp-hero::after`, leaving the section is what puts the callout below it. The callout markup, classes, and styles are untouched.

Both are wrapped in a new `.hp-hero-root` div purely so click tracking keeps working: the view-all link carries `data-cta="articles"`, and the delegated `hero_cta_click` listener was bound to the hero section it just left. The listener now binds to the wrapper. The `hero_impression` IntersectionObserver still watches the hero section alone, so that metric is unchanged.

## Verified in a real browser

Measured against the built page at 1440px and 390px:

| | Desktop | Mobile |
|---|---|---|
| Gradient bar | 807–815px | ends 1138px |
| Callout top | 815px | 1138px |
| Panes in hero | 4 | 4 |
| Featured card inside hero | no | no |
| Horizontal overflow | none | none |

`bun run build` and `bun run test` pass (219 tests, 28 files).

## Note

The callout now sits on the page background (`#f0f4f6`) rather than the hero cream (`#f5f0e8`), since it is outside the hero block. The featured card itself is white either way, so only the surrounding strip changes. Say the word if you would rather the cream extend below the bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)