### PR TITLE
Make llms.txt dynamic and comprehensive from sitemap inventory

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,15 +3,7 @@ import mdx from '@astrojs/mdx';
 import sitemap from '@astrojs/sitemap';
 import robotsTxt from 'astro-robots-txt';
 
-const EXCLUDED_SITEMAP_FRAGMENTS = [
-  '/draft',
-  '/v/',
-  '/admin/',
-  '/content-sitemap/',
-  '/privacy-policy/',
-  '/terms/',
-  '/subscribe/',
-];
+import { isExcludedFromDiscovery } from './src/data/discovery-exclusions.ts';
 
 export default defineConfig({
   site: 'https://www.chill-dogs.com',
@@ -26,7 +18,7 @@ export default defineConfig({
   integrations: [
     mdx(),
     sitemap({
-      filter: (page) => !EXCLUDED_SITEMAP_FRAGMENTS.some((fragment) => page.includes(fragment)),
+      filter: (page) => !isExcludedFromDiscovery(page),
       serialize: (item) => {
         if (item.url === 'https://www.chill-dogs.com/') {
           item.priority = 1.0;

--- a/docs/ai/engineering/routes-and-sitemap.md
+++ b/docs/ai/engineering/routes-and-sitemap.md
@@ -97,6 +97,25 @@ Do not edit `sitemap-inventory.ts` directly for page registration — edit `cont
 
 ---
 
+## Discovery surfaces: XML sitemap and llms.txt
+
+Both public discovery surfaces derive from the same data. Neither is a curated list.
+
+| Surface | Built by | Source |
+|---|---|---|
+| `sitemap-0.xml` | `@astrojs/sitemap` in `astro.config.mjs` | Every built route, minus the shared exclusions |
+| `llms.txt` | `src/pages/llms.txt.ts` | Complete sitemap inventory, minus `noindex` and the shared exclusions |
+
+**Shared exclusions live in `src/data/discovery-exclusions.ts`.** Both surfaces import `isExcludedFromDiscovery()`, so a fragment added there disappears from both at once. Do not add a second exclusion list.
+
+A page appears in `llms.txt` automatically once it is registered in `content-sitemap.ts` (or is an MDX article with a `canonicalPath`). There is nothing to curate — do not reintroduce a hand-maintained link array in `llms.txt.ts`. Ordering-only nudges for high-intent pages go in `PRIORITY_OVERRIDES`; they move a page within its section and never decide whether it is listed.
+
+`src/__tests__/llms-coverage.test.ts` fails if `llms.txt` omits any indexable sitemap URL, lists a URL absent from the sitemap, or lists a `noindex` page.
+
+Sections in `llms.txt` come from path prefix (`LLMS_SECTION_ORDER` in `src/utils/llms.ts`). When adding a new top-level path prefix, add a matching section rule — otherwise its pages still appear, but under `Core Pages`.
+
+---
+
 ## Related content system
 
 Related links derive from the complete sitemap inventory automatically. Do not add manual related arrays.

--- a/docs/system-definition.yaml
+++ b/docs/system-definition.yaml
@@ -496,6 +496,7 @@ site_system:
     seo_strategy: "collector captures intent; converter monetizes intent; variant routes remain canonicalized and noindex"
     sitemap_inventory: "src/data/sitemap-inventory.ts composes staticSitemapSections with article MDX collection entries at build time; future related-content derivation should use the complete inventory instead of static-only sections. Converter sitemap entries carry pubDate and optional lastUpdated metadata for homepage theme-section converter recency ordering."
     section_collectors: "src/data/section-collectors.ts defines cooling, calming, and comfort collector metadata, topic subsection grouping, topic coverage, priority ordering, dynamic CollectorBody card inventories, and CollectionPage hasPart schema from the complete sitemap inventory."
+    discovery_surfaces: "The XML sitemap (astro.config.mjs) and llms.txt (src/pages/llms.txt.ts) share one exclusion list in src/data/discovery-exclusions.ts. llms.txt is generated from the complete sitemap inventory — every registered page that is not noindex and not excluded is listed, so new pages appear automatically. It is never a hand-curated subset; src/__tests__/llms-coverage.test.ts fails the build if llms.txt and the XML sitemap disagree on any indexable URL."
 
   redirects:
     # Production: vercel.json → redirects array (true HTTP redirect at Vercel edge).

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -27,7 +27,7 @@ Test non-trivial logic in isolation. Skip trivial getters, filters, and pass-thr
 **What we test:**
 
 - `analytics.ts` — PostHog dispatch, graceful degradation without PostHog, event delegation via `closest()`, `data-*` attribute mapping to snake_case props
-- `llms.ts` — path normalization edge cases, `dedupeAndRankLinks` dedup/exclusion behavior, `buildLlmsMarkdown` output structure (maxLinks, section grouping, empty inputs)
+- `llms.ts` — path normalization edge cases, `dedupeAndRankLinks` dedup/exclusion behavior, page-kind ranking, exclusion parity with the shared discovery list, `buildLlmsMarkdown` output structure (uncapped output, maxLinks, section grouping, empty inputs)
 - `og.ts` — headline derivation priority and site-suffix stripping, `clampOgText` boundary behavior (exact limit, no word boundary, normal truncation), CTA defaults and overrides, route eligibility logic
 - `src/scripts/og-gen/**` — product-style OG eligibility by `heroProduct`, committed asset coverage and stale-input manifest checks, route filename derivation, summary fallback, title splitting, cache key/copy behavior, and `heroProduct` validation
 - `breadcrumbs.ts` — already fully covered, no changes needed
@@ -66,6 +66,7 @@ Smoke tests build the site once and verify critical output. They catch integrati
 - 404 and policy pages are noindex
 - Sitemap includes all content routes and excludes variant pages
 - llms.txt includes all sections, key links, and excludes private/variant paths
+- llms.txt and the XML sitemap list exactly the same indexable URLs — llms.txt omits nothing indexable and lists nothing noindex
 
 **What we do NOT test:**
 
@@ -90,7 +91,8 @@ Vitest covers the fast utility/data boundary and the build smoke layer. Keep thi
 | File | Tests | What it covers |
 |---|---|---|
 | `analytics.test.ts` | 6 | PostHog dispatch, degradation, delegation, attr mapping |
-| `llms.test.ts` | 11 | Path normalization, dedup, exclusion, markdown output |
+| `llms.test.ts` | 18 | Path normalization, dedup, exclusion, page-kind ranking, markdown output |
+| `llms-coverage.test.ts` | 6 | llms.txt / XML sitemap alignment across all indexable pages |
 | `og.test.ts` | 8 | Headline derivation, clamping, CTA, eligibility |
 | `product-og.test.ts` | 12 | Hero-product OG eligibility, committed assets and manifest freshness, text helpers, cache behavior, validation |
 | `breadcrumbs.test.ts` | 3 | Schema generation, special labels |

--- a/src/__tests__/llms-coverage.test.ts
+++ b/src/__tests__/llms-coverage.test.ts
@@ -1,0 +1,109 @@
+/**
+ * llms.txt / XML sitemap alignment.
+ *
+ * llms.txt must list every page the XML sitemap exposes that is actually
+ * indexable — no hand-curated subset, no stale omissions. The only permitted
+ * gap is a sitemap URL whose built HTML carries a `noindex` robots directive.
+ *
+ * Requires a completed build in dist/ — run `bun run build` before this test.
+ * These checks run as part of the full test suite via `bun run test`.
+ */
+
+import { readdirSync, readFileSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+const distRoot = path.join(process.cwd(), 'dist');
+
+function readSitemapUrls(): string[] {
+  const files = readdirSync(distRoot).filter(
+    (name) => /^sitemap-\d+\.xml$/.test(name)
+  );
+
+  if (files.length === 0) {
+    throw new Error('No dist/sitemap-*.xml found. Run `bun run build` first.');
+  }
+
+  return files.flatMap((file) => {
+    const xml = readFileSync(path.join(distRoot, file), 'utf8');
+    return Array.from(xml.matchAll(/<loc>([^<]+)<\/loc>/g)).map((match) => match[1]);
+  });
+}
+
+function readLlmsUrls(): string[] {
+  const llmsPath = path.join(distRoot, 'llms.txt');
+
+  if (!existsSync(llmsPath)) {
+    throw new Error('No dist/llms.txt found. Run `bun run build` first.');
+  }
+
+  const body = readFileSync(llmsPath, 'utf8');
+  return Array.from(body.matchAll(/^- \[[^\]]*\]\((https?:\/\/[^)\s]+)\)/gm)).map(
+    (match) => match[1]
+  );
+}
+
+function toPathname(url: string): string {
+  return new URL(url).pathname;
+}
+
+/** True when the built page for this route asks robots not to index it. */
+function isNoindex(pathname: string): boolean {
+  const htmlPath = path.join(distRoot, pathname, 'index.html');
+
+  if (!existsSync(htmlPath)) {
+    return false;
+  }
+
+  const html = readFileSync(htmlPath, 'utf8');
+  const robots = html.match(/<meta[^>]+name="robots"[^>]+content="([^"]*)"/i);
+  return Boolean(robots && /noindex/i.test(robots[1]));
+}
+
+let sitemapPaths: string[];
+let llmsPaths: string[];
+
+beforeAll(() => {
+  sitemapPaths = readSitemapUrls().map(toPathname).sort();
+  llmsPaths = readLlmsUrls().map(toPathname).sort();
+});
+
+describe('llms.txt sitemap coverage', () => {
+  it('emits a non-trivial index', () => {
+    expect(llmsPaths.length).toBeGreaterThan(40);
+  });
+
+  it('lists every indexable page in the XML sitemap', () => {
+    const indexable = sitemapPaths.filter((pathname) => !isNoindex(pathname));
+    const missing = indexable.filter((pathname) => !llmsPaths.includes(pathname));
+
+    expect(missing).toEqual([]);
+  });
+
+  it('lists no page that is absent from the XML sitemap', () => {
+    const extra = llmsPaths.filter((pathname) => !sitemapPaths.includes(pathname));
+
+    expect(extra).toEqual([]);
+  });
+
+  it('lists no noindex page', () => {
+    const noindexed = llmsPaths.filter((pathname) => isNoindex(pathname));
+
+    expect(noindexed).toEqual([]);
+  });
+
+  it('lists every article collector', () => {
+    const articlePaths = sitemapPaths.filter((pathname) => {
+      const htmlPath = path.join(distRoot, pathname, 'index.html');
+      if (!existsSync(htmlPath)) return false;
+      return /"@type"\s*:\s*"(Article|BlogPosting)"/.test(readFileSync(htmlPath, 'utf8'));
+    });
+
+    expect(articlePaths.length).toBeGreaterThan(0);
+    expect(articlePaths.filter((pathname) => !llmsPaths.includes(pathname))).toEqual([]);
+  });
+
+  it('does not repeat a URL', () => {
+    expect(new Set(llmsPaths).size).toBe(llmsPaths.length);
+  });
+});

--- a/src/__tests__/llms.test.ts
+++ b/src/__tests__/llms.test.ts
@@ -4,10 +4,12 @@ import {
   buildLlmsMarkdown,
   dedupeAndRankLinks,
   normalizePath,
+  rankLlmsLink,
   sectionForPath,
   shouldExcludePath,
   toAbsoluteUrl,
 } from '../utils/llms';
+import { EXCLUDED_DISCOVERY_FRAGMENTS } from '../data/discovery-exclusions';
 
 describe('llms utilities', () => {
   it('excludes non-indexable paths', () => {
@@ -18,13 +20,73 @@ describe('llms utilities', () => {
     expect(shouldExcludePath('/cooling/cooling-mats/')).toBe(false);
   });
 
+  it('excludes every path the XML sitemap excludes', () => {
+    for (const fragment of EXCLUDED_DISCOVERY_FRAGMENTS) {
+      expect(shouldExcludePath(`${fragment}example/`)).toBe(true);
+    }
+  });
+
+  it('keeps indexable informer pages that the XML sitemap keeps', () => {
+    expect(shouldExcludePath('/affiliate-disclosure/')).toBe(false);
+    expect(shouldExcludePath('/shelter-dog-charities/')).toBe(false);
+    expect(shouldExcludePath('/shop/')).toBe(false);
+    expect(shouldExcludePath('/articles/')).toBe(false);
+  });
+
   it('groups routes by section mapping', () => {
     expect(sectionForPath('/cooling/cooling-mats/')).toBe('Cooling Guides');
     expect(sectionForPath('/calming/car-anxiety-for-dogs/')).toBe('Calming Guides');
+    expect(sectionForPath('/comforting/best-calming-dog-beds/')).toBe('Comfort & Rest Guides');
+    expect(sectionForPath('/gear/best-dog-gps-trackers/')).toBe('Gear & Tracking Guides');
+    expect(sectionForPath('/safety/rattlesnake-safety-for-dogs/')).toBe('Safety Guides');
     expect(sectionForPath('/travel/dog-road-trip-gear/')).toBe('Travel Guides');
     expect(sectionForPath('/about/')).toBe('About');
     expect(sectionForPath('/contact/')).toBe('About');
+    expect(sectionForPath('/affiliate-disclosure/')).toBe('About');
+    expect(sectionForPath('/shop/')).toBe('Core Pages');
     expect(sectionForPath('/unknown/path/')).toBe('Core Pages');
+  });
+
+  it('ranks section collectors and converters above supporting articles', () => {
+    const sectionCollector = rankLlmsLink({
+      title: 'Cooling Relief',
+      path: '/cooling/',
+      pageKind: 'section-collector',
+    });
+    const converter = rankLlmsLink({
+      title: 'Cooling Mats',
+      path: '/cooling/cooling-mats/',
+      pageKind: 'converter',
+    });
+    const article = rankLlmsLink({
+      title: 'How Hot Is Too Hot',
+      path: '/cooling/how-hot-is-too-hot-for-dogs/',
+      pageKind: 'article-collector',
+    });
+    const informer = rankLlmsLink({
+      title: 'About',
+      path: '/about/',
+      pageKind: 'informer',
+    });
+
+    expect(sectionCollector).toBeGreaterThan(converter);
+    expect(converter).toBeGreaterThan(article);
+    expect(article).toBeGreaterThan(informer);
+  });
+
+  it('lets an explicit priority override the page kind', () => {
+    expect(
+      rankLlmsLink({
+        title: 'Best Cooling Products',
+        path: '/cooling/best-cooling-products-for-dogs/',
+        pageKind: 'converter',
+        explicitPriority: 935,
+      })
+    ).toBe(935);
+  });
+
+  it('keeps home first regardless of page kind', () => {
+    expect(rankLlmsLink({ title: 'Home', path: '/', pageKind: 'attractor' })).toBe(1000);
   });
 
   it('deduplicates by path and keeps highest priority version', () => {
@@ -111,6 +173,53 @@ describe('llms utilities', () => {
     expect(markdown).toContain('# Chill-Dogs');
     expect(markdown).toContain('> Test');
     expect(markdown).not.toContain('## ');
+  });
+
+  it('emits every link when no maxLinks cap is supplied', () => {
+    const links = Array.from({ length: 60 }, (_, index) => ({
+      title: `Page ${index}`,
+      path: `/cooling/page-${index}-guide/`,
+    }));
+
+    const markdown = buildLlmsMarkdown({
+      siteName: 'Chill-Dogs',
+      description: 'Test',
+      baseUrl: 'https://www.chill-dogs.com/',
+      links,
+    });
+
+    expect(markdown.split('\n').filter((line) => line.startsWith('- ['))).toHaveLength(60);
+  });
+
+  it('emits a section for every pillar', () => {
+    const markdown = buildLlmsMarkdown({
+      siteName: 'Chill-Dogs',
+      description: 'Test',
+      baseUrl: 'https://www.chill-dogs.com/',
+      links: [
+        { title: 'Home', path: '/' },
+        { title: 'Cooling', path: '/cooling/' },
+        { title: 'Calming', path: '/calming/' },
+        { title: 'Comfort', path: '/comforting/' },
+        { title: 'Gear', path: '/gear/' },
+        { title: 'Safety', path: '/safety/what-to-do-if-your-dog-runs-away/' },
+        { title: 'Travel', path: '/travel/dog-road-trip-gear/' },
+        { title: 'About', path: '/about/' },
+      ],
+    });
+
+    for (const section of [
+      'Core Pages',
+      'Cooling Guides',
+      'Calming Guides',
+      'Comfort & Rest Guides',
+      'Gear & Tracking Guides',
+      'Safety Guides',
+      'Travel Guides',
+      'About',
+    ]) {
+      expect(markdown).toContain(`## ${section}`);
+    }
   });
 
   it('resolves absolute URLs from base + path', () => {

--- a/src/data/discovery-exclusions.ts
+++ b/src/data/discovery-exclusions.ts
@@ -1,0 +1,20 @@
+/**
+ * Path fragments that keep a route out of every public discovery surface.
+ *
+ * Consumed by the XML sitemap filter (`astro.config.mjs`) and by `llms.txt`
+ * (`src/pages/llms.txt.ts`) so the two surfaces cannot drift apart. Anything
+ * added here disappears from both at once.
+ */
+export const EXCLUDED_DISCOVERY_FRAGMENTS = [
+  '/draft',
+  '/v/',
+  '/admin/',
+  '/content-sitemap/',
+  '/privacy-policy/',
+  '/terms/',
+  '/subscribe/',
+] as const;
+
+export function isExcludedFromDiscovery(pathOrUrl: string): boolean {
+  return EXCLUDED_DISCOVERY_FRAGMENTS.some((fragment) => pathOrUrl.includes(fragment));
+}

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -1,117 +1,57 @@
 import type { APIContext } from 'astro';
-import { buildLlmsMarkdown, type LlmsLink } from '@utils/llms';
+import { buildLlmsMarkdown, normalizePath, type LlmsLink, type LlmsPageKind } from '@utils/llms';
+import type { SitemapPage } from '@data/content-sitemap';
+import { isExcludedFromDiscovery } from '@data/discovery-exclusions';
 import { ROUTES } from '@data/routes';
+import { getCompleteSitemapPages } from '@data/sitemap-inventory';
 
 export const prerender = true;
 
 const SITE_NAME = 'Chill-Dogs';
 const SITE_DESCRIPTION = 'Curated cooling and calming product guides for dogs, focused on practical picks and clear routes to high-intent recommendations.';
-const INTRO = 'This index prioritizes evergreen guides and key conversion pages for fast retrieval by LLM tools and agents.';
+const INTRO = 'This is a complete index of every indexable, publicly discoverable page on the site, grouped by section and ordered so section landing pages and product guides come before supporting articles.';
 
-const STATIC_LINKS: LlmsLink[] = [
-  {
-    title: 'Home',
-    path: ROUTES.home,
-    description: 'Main entry point to cooling and calming recommendation paths.',
-    explicitPriority: 1000,
-  },
-  {
-    title: 'Cooling Collector',
-    path: ROUTES.coolingHub,
-    description: 'Overview of cooling categories and supporting heat-safety guides.',
-    explicitPriority: 960,
-  },
-  {
-    title: 'Calming Collector',
-    path: ROUTES.calmingHub,
-    description: 'Overview of calming categories and high-intent anxiety guides.',
-    explicitPriority: 955,
-  },
-  {
-    title: 'Gear, Travel & Safety Collector',
-    path: ROUTES.gearHub,
-    description: 'Overview of GPS tracking, travel, and safety gear categories and guides.',
-    explicitPriority: 950,
-  },
-  {
-    title: 'Best Cooling Products for Dogs',
-    path: ROUTES.coolingTop,
-    description: 'Top cooling picks across mats, vests, bandanas, and frozen enrichment.',
-    explicitPriority: 940,
-  },
-  {
-    title: 'Best Calming Products for Anxious Dogs',
-    path: ROUTES.calmingTop,
-    description: 'Top calming picks across wraps, chews, lick mats, and snuffle mats.',
-    explicitPriority: 935,
-  },
-  {
-    title: "Rhys's Road Trip Chill Kit",
-    path: ROUTES.roadTrip,
-    description: 'Road-trip setup that combines cooling and calming recommendations.',
-    explicitPriority: 930,
-  },
-  {
-    title: 'Car Cooling for Dogs',
-    path: ROUTES.coolingCar,
-    description: 'Converter page focused on in-car cooling gear and heat-risk reduction.',
-    explicitPriority: 920,
-  },
-  {
-    title: 'Car Anxiety for Dogs',
-    path: ROUTES.calmingCar,
-    description: 'Converter page focused on travel calming aids and routines.',
-    explicitPriority: 915,
-  },
-  {
-    title: 'Cooling Mats',
-    path: ROUTES.coolingMats,
-    description: 'Category converter for cooling mat recommendations.',
-    explicitPriority: 910,
-  },
-  {
-    title: 'Cooling Vests',
-    path: ROUTES.coolingVests,
-    description: 'Category converter for evaporative cooling vest recommendations.',
-    explicitPriority: 905,
-  },
-  {
-    title: 'Cooling Bandanas',
-    path: ROUTES.coolingBandanas,
-    description: 'Category converter for lightweight neck-cooling options.',
-    explicitPriority: 900,
-  },
-  {
-    title: 'Freezable Dog Toys',
-    path: ROUTES.coolingToys,
-    description: 'Category converter for frozen enrichment and cooling play.',
-    explicitPriority: 895,
-  },
-  {
-    title: 'How Hot Is Too Hot for Dogs?',
-    path: ROUTES.coolingSafety,
-    description: 'Heat threshold explainer with routing to cooling products.',
-    explicitPriority: 885,
-  },
-  {
-    title: 'Best ThunderShirt Alternatives for Dogs',
-    path: ROUTES.calmingAlternatives,
-    description: 'Comparison guide for calming options beyond pressure wraps.',
-    explicitPriority: 880,
-  },
-  {
-    title: 'About Chill-Dogs',
-    path: ROUTES.about,
-    description: 'Editorial approach, positioning, and trust context.',
-    explicitPriority: 600,
-  },
-  {
-    title: 'Contact',
-    path: ROUTES.contact,
-    description: 'Direct contact page for editorial or site questions.',
-    explicitPriority: 590,
-  },
-];
+/**
+ * Ordering nudges for the highest-intent pages. These only move a page within
+ * its section — they never decide whether a page appears. Coverage comes from
+ * the sitemap inventory, so a new page is listed the moment it is registered.
+ */
+const PRIORITY_OVERRIDES: Record<string, number> = {
+  [ROUTES.home]: 1000,
+  [ROUTES.shop]: 930,
+  [ROUTES.articles]: 920,
+  [ROUTES.coolingTop]: 935,
+  [ROUTES.calmingTop]: 935,
+  [ROUTES.trackingTop]: 935,
+  [ROUTES.roadTrip]: 935,
+};
+
+function pageKindFor(page: SitemapPage): LlmsPageKind {
+  if (page.pageType === 'collector') {
+    return page.collectorSubtype === 'article' ? 'article-collector' : 'section-collector';
+  }
+
+  return page.pageType;
+}
+
+/**
+ * A page belongs in llms.txt on exactly the terms it belongs in the XML
+ * sitemap: registered in the inventory, indexable, and not sitting behind one
+ * of the shared discovery exclusions.
+ */
+function isPublicAndIndexable(page: SitemapPage): boolean {
+  return !page.noindex && !isExcludedFromDiscovery(normalizePath(page.href));
+}
+
+function toLlmsLink(page: SitemapPage): LlmsLink {
+  return {
+    title: page.baseTitle,
+    path: page.href,
+    description: page.preview.description,
+    pageKind: pageKindFor(page),
+    explicitPriority: PRIORITY_OVERRIDES[normalizePath(page.href)],
+  };
+}
 
 function resolveBaseUrl(context: APIContext): string {
   const envUrl = import.meta.env.PUBLIC_SITE_URL;
@@ -128,14 +68,15 @@ function resolveBaseUrl(context: APIContext): string {
 
 export async function GET(context: APIContext): Promise<Response> {
   const baseUrl = resolveBaseUrl(context);
+  const pages = await getCompleteSitemapPages();
+  const links = pages.filter(isPublicAndIndexable).map(toLlmsLink);
 
   const body = buildLlmsMarkdown({
     siteName: SITE_NAME,
     description: SITE_DESCRIPTION,
     shortParagraph: INTRO,
     baseUrl,
-    links: STATIC_LINKS,
-    maxLinks: 40,
+    links,
   });
 
   return new Response(body, {

--- a/src/utils/llms.ts
+++ b/src/utils/llms.ts
@@ -1,7 +1,23 @@
+import { isExcludedFromDiscovery } from '@data/discovery-exclusions';
+
+/**
+ * How a page earns its place in the ordering. Mirrors the sitemap page types,
+ * splitting collectors into section collectors and article collectors so
+ * section landing pages lead their section and prose guides trail the
+ * converters they support.
+ */
+export type LlmsPageKind =
+  | 'attractor'
+  | 'section-collector'
+  | 'converter'
+  | 'article-collector'
+  | 'informer';
+
 export interface LlmsLink {
   title: string;
   path: string;
   description?: string;
+  pageKind?: LlmsPageKind;
   explicitPriority?: number;
 }
 
@@ -9,21 +25,39 @@ interface RankedLlmsLink extends LlmsLink {
   priority: number;
 }
 
+export const LLMS_SECTION_ORDER = [
+  'Core Pages',
+  'Cooling Guides',
+  'Calming Guides',
+  'Comfort & Rest Guides',
+  'Gear & Tracking Guides',
+  'Safety Guides',
+  'Travel Guides',
+  'About',
+] as const;
+
 const SECTION_RULES: Array<{ prefix: string; section: string }> = [
   { prefix: '/cooling/', section: 'Cooling Guides' },
   { prefix: '/calming/', section: 'Calming Guides' },
+  { prefix: '/comforting/', section: 'Comfort & Rest Guides' },
+  { prefix: '/gear/', section: 'Gear & Tracking Guides' },
+  { prefix: '/safety/', section: 'Safety Guides' },
   { prefix: '/travel/', section: 'Travel Guides' },
   { prefix: '/about/', section: 'About' },
   { prefix: '/contact/', section: 'About' },
+  { prefix: '/affiliate-disclosure/', section: 'About' },
+  { prefix: '/shelter-dog-charities/', section: 'About' },
 ];
 
-const EXCLUDED_EXACT_PATHS = new Set([
-  '/404/',
-  '/content-sitemap/',
-  '/privacy-policy/',
-  '/terms/',
-  '/affiliate-disclosure/',
-]);
+const PAGE_KIND_PRIORITY: Record<LlmsPageKind, number> = {
+  attractor: 960,
+  'section-collector': 940,
+  converter: 900,
+  'article-collector': 860,
+  informer: 500,
+};
+
+const EXCLUDED_EXACT_PATHS = new Set(['/404/']);
 
 export function normalizePath(path: string): string {
   if (!path.startsWith('/')) {
@@ -40,7 +74,7 @@ export function shouldExcludePath(path: string): boolean {
     return true;
   }
 
-  if (normalized.includes('/v/')) {
+  if (isExcludedFromDiscovery(normalized)) {
     return true;
   }
 
@@ -66,6 +100,10 @@ export function rankLlmsLink(link: LlmsLink): number {
 
   if (path === '/') {
     return 1000;
+  }
+
+  if (link.pageKind) {
+    return PAGE_KIND_PRIORITY[link.pageKind];
   }
 
   if (path === '/cooling/' || path === '/calming/') {
@@ -138,7 +176,7 @@ export function buildLlmsMarkdown(options: {
     shortParagraph,
     baseUrl,
     links,
-    maxLinks = 40,
+    maxLinks = Number.POSITIVE_INFINITY,
   } = options;
 
   const selected = dedupeAndRankLinks(links).slice(0, maxLinks);
@@ -151,12 +189,11 @@ export function buildLlmsMarkdown(options: {
     grouped.set(section, sectionLinks);
   }
 
+  // Any section a future SECTION_RULES entry introduces still gets emitted,
+  // appended after the known order rather than silently dropped.
   const sectionOrder = [
-    'Core Pages',
-    'Cooling Guides',
-    'Calming Guides',
-    'Travel Guides',
-    'About',
+    ...LLMS_SECTION_ORDER,
+    ...Array.from(grouped.keys()).filter((section) => !LLMS_SECTION_ORDER.includes(section as never)),
   ];
 
   const lines: string[] = [


### PR DESCRIPTION
## Summary

Converts `llms.txt` from a hand-curated list of 18 high-priority pages to a complete, automatically-generated index of every indexable page on the site. The index is now derived directly from the sitemap inventory, eliminating manual maintenance and ensuring perfect alignment with the XML sitemap.

## Key Changes

- **Dynamic generation**: `llms.txt` now pulls from `getCompleteSitemapPages()` instead of a static `STATIC_LINKS` array, automatically including every new page the moment it's registered in `content-sitemap.ts`
- **Shared exclusions**: Extracted discovery exclusion logic into `src/data/discovery-exclusions.ts` and imported by both `astro.config.mjs` (XML sitemap filter) and `llms.txt.ts`, preventing drift between the two surfaces
- **Page-kind ranking**: Added `LlmsPageKind` type (`attractor`, `section-collector`, `converter`, `article-collector`, `informer`) to rank pages by type within their section, with section collectors and converters leading article-collectors and informers
- **Priority overrides only**: Replaced the full static link array with `PRIORITY_OVERRIDES` — a minimal map for nudging high-intent pages within their section, never deciding whether they appear
- **Comprehensive test coverage**: Added `src/__tests__/llms-coverage.test.ts` to enforce that `llms.txt` lists every indexable sitemap URL, omits every noindex page, and contains no duplicates or extra URLs
- **Documentation**: Updated `docs/ai/engineering/routes-and-sitemap.md` to explain the unified discovery surface architecture and the role of `PRIORITY_OVERRIDES`

## Implementation Details

- `isPublicAndIndexable()` filters pages by `noindex` flag and shared discovery exclusions
- `toLlmsLink()` converts sitemap pages to `LlmsLink` objects, deriving `pageKind` from page type and collector subtype
- `pageKindFor()` splits collectors into section and article variants for proper ranking
- `LLMS_SECTION_ORDER` defines the canonical section order; new sections are appended after known ones
- Removed the `maxLinks: 40` cap — all indexable pages are now emitted
- Test suite validates alignment on every build via `bun run test`

https://claude.ai/code/session_0176CjgH4Su5KDbvshGsgKB3