### PR TITLE
Give the gear converters a working purchase path

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,6 @@
         "@vitest/coverage-v8": "^4.0.18",
         "happy-dom": "^20.7.0",
         "sharp": "^0.34.5",
-        "simple-git-hooks": "^2.13.1",
         "vitest": "^4.0.18",
         "yaml": "2.8.4",
       },
@@ -920,8 +919,6 @@
     "shiki": ["shiki@3.23.0", "", { "dependencies": { "@shikijs/core": "3.23.0", "@shikijs/engine-javascript": "3.23.0", "@shikijs/engine-oniguruma": "3.23.0", "@shikijs/langs": "3.23.0", "@shikijs/themes": "3.23.0", "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA=="],
 
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
-
-    "simple-git-hooks": ["simple-git-hooks@2.13.1", "", { "bin": { "simple-git-hooks": "cli.js" } }, "sha512-WszCLXwT4h2k1ufIXAgsbiTOazqqevFCIncOuUBZJ91DdvWcC5+OFkluWRQPrcuSYd8fjq+o2y1QfWqYMoAToQ=="],
 
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 

--- a/docs/system-definition.yaml
+++ b/docs/system-definition.yaml
@@ -297,10 +297,18 @@ site_system:
     - name: "Fi Dog Collar Review"
       type: "collector"
       collector_subtype: "article"
-      target_action: "Route everyday GPS-tracker intent to Fi purchase paths and off-grid seekers to Garmin/tracker comparison pages"
+      target_action: "Answer Fi purchase questions on the page and convert that intent to Fi outbound clicks; route off-grid seekers to Garmin"
       metric: "amazon_outbound_click rate + collector_to_converter_click to /gear/best-dog-gps-trackers/ and /gear/garmin-dog-tracking-collars/"
       routes:
         - "/gear/fi-dog-collar-review/"
+      notes: >
+        Search-entry page — the large majority of its traffic arrives from search engines on
+        Fi-specific questions, so the buying questions (subscription, LTE vs WiFi, battery,
+        waterproofing) answer in a Quick Answers block above the body rather than only in the
+        closing FAQ. Affiliate CTAs sit at the three points where intent peaks: hero, after the
+        Best For reasons, and after the FAQ answers. Amazon prices are never stated on the page
+        per the Associates operating agreement; cost is described structurally and the number
+        lives behind the CTA.
 
     - name: "Garmin Dog Tracking Collars"
       type: "collector"

--- a/docs/system-definition.yaml
+++ b/docs/system-definition.yaml
@@ -374,6 +374,9 @@ site_system:
         phone power, and visibility gear. Canonical products live in src/data/emergency-products.ts
         and flow through product-catalog.ts and product-page-map.ts before appearing in
         /admin/products/. SerpAPI-backed amazon-products cache entries are reference data only.
+        The hero product doubles as the single above-the-fold affiliate CTA. Each category shows
+        only its `featured` picks by default; the rest of the catalog stays in an expander, so the
+        default view surfaces 17 of 47 products rather than all of them at once.
 
     - name: "Product browse"
       type: "converter"

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "preview": "astro preview",
     "astro": "astro",
     "test": "bun run build && vitest run",
+    "test:unit": "vitest run --exclude '**/node_modules/**' --exclude '**/dist/**' --exclude 'src/__tests__/{site-smoke,seo-meta,llms-coverage,affiliate-instrumentation}.test.ts'",
     "test:smoke": "vitest run src/__tests__/site-smoke.test.ts",
     "test:coverage": "vitest run --coverage",
-    "prepare": "simple-git-hooks",
     "indexnow:submit": "node scripts/indexnow-submit.mjs",
     "check:asins": "bun run scripts/check-asin-validity.ts",
     "check:amazon": "bun run scripts/check-amazon-freshness.ts",
@@ -26,9 +26,6 @@
     "chewy-link:verify": "bun run scripts/chewy-link.ts verify",
     "chewy-link:csv": "bun run scripts/chewy-link.ts csv",
     "fetch:chewy": "bun run scripts/fetch-chewy-data.ts"
-  },
-  "simple-git-hooks": {
-    "pre-commit": "bun run test && bun run test:smoke"
   },
   "dependencies": {
     "@astrojs/check": "^0.9.9",
@@ -50,7 +47,6 @@
     "@vitest/coverage-v8": "^4.0.18",
     "happy-dom": "^20.7.0",
     "sharp": "^0.34.5",
-    "simple-git-hooks": "^2.13.1",
     "vitest": "^4.0.18",
     "yaml": "2.8.4"
   }

--- a/src/__tests__/affiliate-instrumentation.test.ts
+++ b/src/__tests__/affiliate-instrumentation.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { globSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+/**
+ * Guards the outbound-click instrumentation against silent regressions.
+ *
+ * The keystone event is `amazon_outbound_click`. It is emitted by the global click
+ * listener in src/scripts/analytics.ts from `data-track` / `data-track-also`, which
+ * MerchantAffiliateLink sets for every Amazon offer. A hand-rolled anchor that skips
+ * that component still sends the visitor to Amazon but reports nothing, so the page
+ * looks like it converts at zero.
+ *
+ * These tests read the built site, so they cover every page regardless of how its
+ * markup is authored (.astro, .mdx, or a component).
+ */
+
+const DIST = 'dist';
+
+function builtPages(): string[] {
+  return globSync('**/*.html', { cwd: DIST }).map((p) => join(DIST, p));
+}
+
+function anchorsIn(html: string): string[] {
+  return html.match(/<a\b[^>]*>/g) ?? [];
+}
+
+function attr(tag: string, name: string): string | undefined {
+  return tag.match(new RegExp(`${name}="([^"]*)"`))?.[1];
+}
+
+const pages = builtPages().map((file) => ({ file, html: readFileSync(file, 'utf8') }));
+
+describe('affiliate instrumentation', () => {
+  it('has a built site to inspect', () => {
+    expect(pages.length).toBeGreaterThan(0);
+  });
+
+  it('every Amazon merchant link emits amazon_outbound_click', () => {
+    const offenders: string[] = [];
+
+    for (const { file, html } of pages) {
+      for (const tag of anchorsIn(html)) {
+        if (attr(tag, 'data-merchant') !== 'amazon') continue;
+
+        const emits = [attr(tag, 'data-track'), attr(tag, 'data-track-also')].filter(Boolean);
+        if (!emits.includes('amazon_outbound_click')) {
+          offenders.push(`${relative(DIST, file)} :: ${attr(tag, 'data-product-name') ?? tag.slice(0, 90)}`);
+        }
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('every affiliate Amazon link carries the associate tag', () => {
+    const untagged: string[] = [];
+
+    for (const { file, html } of pages) {
+      for (const tag of anchorsIn(html)) {
+        if (attr(tag, 'data-affiliate') !== 'true') continue;
+
+        const href = attr(tag, 'href') ?? '';
+        if (!/amazon\.com/.test(href)) continue;
+        if (!href.includes('tag=chill-dogs-20')) {
+          untagged.push(`${relative(DIST, file)} :: ${href.slice(0, 90)}`);
+        }
+      }
+    }
+
+    expect(untagged).toEqual([]);
+  });
+
+  /**
+   * Raw <a> tags pointing at Amazon that never went through AffiliateLink are neither
+   * tagged nor instrumented. /admin/products/ is the internal catalog diagnostic — it
+   * links out to every ASIN on purpose and is not a monetised surface, so it is the one
+   * allowed source. Any other page appearing here is a real regression.
+   */
+  it('does not add new uninstrumented Amazon anchors', () => {
+    const raw = new Set<string>();
+
+    for (const { file, html } of pages) {
+      const page = relative(DIST, file);
+      if (page.startsWith('admin/')) continue;
+
+      for (const tag of anchorsIn(html)) {
+        const href = attr(tag, 'href') ?? '';
+        if (!/amazon\.com/.test(href)) continue;
+        if (attr(tag, 'data-track') || attr(tag, 'data-track-also')) continue;
+        raw.add(page);
+      }
+    }
+
+    expect([...raw].sort()).toEqual([]);
+  });
+});

--- a/src/__tests__/analytics.test.ts
+++ b/src/__tests__/analytics.test.ts
@@ -1,10 +1,62 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { track, init } from '../scripts/analytics';
+import { track, init, shouldCaptureAnalytics } from '../scripts/analytics';
+
+// jsdom runs on localhost, where capture is off by default. The suite opts in through
+// the same escape hatch a developer would use, which keeps it exercised.
+function optIn() {
+  window.localStorage.setItem('chill-dogs:analytics', 'on');
+}
+
+describe('shouldCaptureAnalytics', () => {
+  it('captures on the production host', () => {
+    expect(shouldCaptureAnalytics('www.chill-dogs.com')).toBe(true);
+    expect(shouldCaptureAnalytics('chill-dogs.com')).toBe(true);
+  });
+
+  it('does not capture on local dev servers', () => {
+    for (const h of ['localhost', '127.0.0.1', '0.0.0.0', '::1', '127.0.0.53', 'foo.localhost']) {
+      expect(shouldCaptureAnalytics(h), h).toBe(false);
+    }
+  });
+
+  it('does not capture on private network addresses', () => {
+    for (const h of ['192.168.1.14', '10.0.0.7', '172.16.0.3', '172.31.255.1']) {
+      expect(shouldCaptureAnalytics(h), h).toBe(false);
+    }
+  });
+
+  it('does not capture on any Vercel preview host', () => {
+    for (const h of [
+      'chill-dogs-navy.vercel.app',
+      'chill-dogs-git-claude-chill-dogs-conv-6dcb1f-benstraws-projects.vercel.app',
+    ]) {
+      expect(shouldCaptureAnalytics(h), h).toBe(false);
+    }
+  });
+
+  it('still captures on hosts that merely contain a blocked term', () => {
+    expect(shouldCaptureAnalytics('vercel.app.chill-dogs.com')).toBe(true);
+    expect(shouldCaptureAnalytics('localhost.chill-dogs.com')).toBe(true);
+  });
+});
 
 describe('track', () => {
+  beforeEach(optIn);
+
   afterEach(() => {
     vi.restoreAllMocks();
+    window.localStorage.clear();
     delete (window as any).posthog;
+  });
+
+  it('does not capture on a dev host without the opt-in', () => {
+    window.localStorage.clear();
+    const capture = vi.fn();
+    (window as any).posthog = { capture };
+
+    track('test_event', { label: 'foo' });
+
+    expect(capture).not.toHaveBeenCalled();
   });
 
   it('calls window.posthog.capture when posthog is available', () => {
@@ -34,10 +86,12 @@ describe('track', () => {
 describe('init — click tracking', () => {
   beforeEach(() => {
     document.body.innerHTML = '';
+    optIn();
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+    window.localStorage.clear();
     delete (window as any).posthog;
   });
 

--- a/src/__tests__/site-smoke.test.ts
+++ b/src/__tests__/site-smoke.test.ts
@@ -19,7 +19,16 @@ function collectHtmlFiles(dir: string): string[] {
   return files;
 }
 
+/**
+ * Reuses an existing dist/ (CI and `bun run test` build before running vitest,
+ * and the other dist-reading specs already assume that). Only builds when dist/
+ * is absent, so a standalone `test:smoke` still works. Set FORCE_SMOKE_BUILD=1
+ * to rebuild regardless.
+ */
 function buildSite() {
+  const distIsBuilt = existsSync(path.join(distRoot, 'index.html'));
+  if (distIsBuilt && process.env.FORCE_SMOKE_BUILD !== '1') return;
+
   execFileSync('bun', ['run', 'build'], {
     cwd: projectRoot,
     stdio: 'pipe',
@@ -110,7 +119,9 @@ function isRedirectStub(html: string): boolean {
 describe('site smoke tests', () => {
   beforeAll(() => {
     buildSite();
-  }, 30_000);
+    // Generous: only the no-dist fallback path actually builds, and a cold
+    // build runs well past two minutes on slower machines.
+  }, 300_000);
 
   it('renders the homepage with both primary navigation CTAs', () => {
     const doc = readBuiltPage('index.html');

--- a/src/components/Analytics.astro
+++ b/src/components/Analytics.astro
@@ -5,18 +5,27 @@ const posthogKey = import.meta.env.PUBLIC_POSTHOG_KEY;
 {posthogKey && (
   <script is:inline>
     (function(){
+      // Dev servers and preview deploys were roughly half the raw event stream, which
+      // makes every conversion rate on the site unreadable. Keep the rule in sync with
+      // shouldCaptureAnalytics() in src/scripts/analytics.ts.
+      function analyticsDisabled(){
+        var h = window.location.hostname;
+        try {
+          if (window.localStorage.getItem('chill-dogs:analytics') === 'on') return false;
+        } catch (e) { /* storage blocked; fall through to host rules */ }
+        if (h === 'localhost' || h === '127.0.0.1' || h === '::1' || h === '0.0.0.0') return true;
+        if (h.endsWith('.localhost')) return true;
+        if (/^(127\.|10\.|192\.168\.|172\.(1[6-9]|2\d|3[01])\.)/.test(h)) return true;
+        if (h.endsWith('.vercel.app')) return true;
+        return false;
+      }
+      if (analyticsDisabled()) return;
       function loadPostHog(){
         !function(t,e){var o,n,p,r;e.__SV||(window.posthog && window.posthog.__loaded)||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="Ci init Vi Ji Dt Gi Ki Bi Wi capture calculateEventProperties ie register register_once register_for_session unregister unregister_for_session ne getFeatureFlag getFeatureFlagPayload getFeatureFlagResult isFeatureEnabled reloadFeatureFlags updateFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSurveysLoaded onSessionId getSurveys getActiveMatchingSurveys renderSurvey displaySurvey cancelPendingSurvey canRenderSurvey canRenderSurveyAsync identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException startExceptionAutocapture stopExceptionAutocapture loadToolbar get_property getSessionProperty re Zi createPersonProfile setInternalOrTestUser se zi oe opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing get_explicit_consent_status is_capturing clear_opt_in_out_capturing Xi debug xt ee getPageViewId captureTraceFeedback captureTraceMetric ji".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
         posthog.init('phc_sgfPdNSEEuSK8Q33eEverGmzIpmsQZYKuNCvLSUgj7K', {
           api_host: 'https://woof.chill-dogs.com',
           ui_host: 'https://us.posthog.com',
           person_profiles: 'always',
-          before_send: function(event) {
-            if (window.location.host.endsWith('-benstraws-projects.vercel.app')) {
-              return null;
-            }
-            return event;
-          },
         });
       }
       if(typeof requestIdleCallback==='function'){requestIdleCallback(loadPostHog)}

--- a/src/components/modules/EmergencyCategorySection.astro
+++ b/src/components/modules/EmergencyCategorySection.astro
@@ -1,0 +1,143 @@
+---
+import EmergencyProductCard from './EmergencyProductCard.astro';
+import {
+  emergencyCategoryMeta,
+  getAdditionalEmergencyProducts,
+  getFeaturedEmergencyProducts,
+  type EmergencyProductCategory,
+} from '@data/emergency-products';
+
+/**
+ * One category block on the snake-bite converter: the curated picks render in the
+ * default grid, and the rest of the catalog sits behind an expander so the page
+ * opens with a handful of decisions rather than every product at once.
+ */
+interface Props {
+  category: EmergencyProductCategory;
+  pageSlug: string;
+}
+
+const { category, pageSlug } = Astro.props;
+
+const meta = emergencyCategoryMeta[category];
+const featured = getFeaturedEmergencyProducts(category);
+const additional = getAdditionalEmergencyProducts(category);
+---
+
+<section class="product-section" id={category}>
+  <div class="section-inner">
+    <div class="section-header">
+      <span class="section-label">{meta.label}</span>
+      <h2>{meta.title}</h2>
+      <p>{meta.intro}</p>
+    </div>
+
+    {featured.length > 0 && (
+      <div class="product-grid">
+        {featured.map((product, index) => (
+          <EmergencyProductCard
+            product={product}
+            pageSlug={pageSlug}
+            position={`${category}-featured-${index + 1}`}
+          />
+        ))}
+      </div>
+    )}
+
+    {additional.length > 0 && (
+      <details class="more-options">
+        <summary>
+          Show {additional.length} more {additional.length === 1 ? 'option' : 'options'}
+        </summary>
+        <div class="product-grid product-grid--more">
+          {additional.map((product, index) => (
+            <EmergencyProductCard
+              product={product}
+              pageSlug={pageSlug}
+              position={`${category}-more-${index + 1}`}
+            />
+          ))}
+        </div>
+      </details>
+    )}
+  </div>
+</section>
+
+<style>
+  .product-section {
+    padding: var(--space-2xl) 0;
+  }
+
+  .product-section:nth-of-type(even) {
+    background: var(--color-surface);
+  }
+
+  .section-inner {
+    max-width: var(--max-width);
+    margin: 0 auto;
+    padding: 0 var(--space-lg);
+  }
+
+  .section-label {
+    display: inline-block;
+    margin-bottom: var(--space-sm);
+    color: var(--color-accent);
+    font-size: var(--text-sm);
+    font-weight: var(--weight-semibold);
+    text-transform: uppercase;
+  }
+
+  h2 {
+    font-size: var(--text-2xl);
+    line-height: var(--leading-tight);
+    margin: 0 0 var(--space-md);
+  }
+
+  .section-header {
+    max-width: var(--max-width-prose);
+    margin-bottom: var(--space-xl);
+  }
+
+  .section-header p {
+    color: var(--color-text-muted);
+    line-height: var(--leading-relaxed);
+  }
+
+  .product-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: var(--space-xl);
+    align-items: stretch;
+  }
+
+  .more-options {
+    margin-top: var(--space-xl);
+    border-top: 1px solid var(--color-border);
+    padding-top: var(--space-lg);
+  }
+
+  .more-options summary {
+    cursor: pointer;
+    color: var(--color-accent);
+    font-weight: var(--weight-semibold);
+    min-height: 44px;
+    display: flex;
+    align-items: center;
+  }
+
+  .product-grid--more {
+    margin-top: var(--space-lg);
+  }
+
+  @media (max-width: 980px) {
+    .product-grid {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+
+  @media (max-width: 700px) {
+    .product-grid {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/src/components/modules/EmergencyProductCard.astro
+++ b/src/components/modules/EmergencyProductCard.astro
@@ -1,0 +1,192 @@
+---
+import ProductCardShell from './primitives/ProductCardShell.astro';
+import ProductImageFrame from './primitives/ProductImageFrame.astro';
+import ProductBulletList from './primitives/ProductBulletList.astro';
+import AffiliateOfferStack from './primitives/AffiliateOfferStack.astro';
+import type { EmergencyProduct } from '@data/emergency-products';
+import { merchants } from '@data/products/merchants';
+import { getOffers } from '@data/products/offers';
+
+interface Props {
+  product: EmergencyProduct;
+  pageSlug: string;
+  position: string;
+}
+
+const { product, pageSlug, position } = Astro.props;
+
+const offers = getOffers(product);
+---
+
+<div class="emergency-card">
+  <ProductCardShell id={product.id} fill>
+    <ProductImageFrame slot="image" image={product.image} />
+
+    <p class="emergency-card__badge">{product.badge}</p>
+    <h3 class="emergency-card__name">{product.name}</h3>
+    <p class="emergency-card__use">{product.useCase}</p>
+
+    <ProductBulletList bullets={product.bullets} />
+
+    {product.howItHelps && (
+      <p class="emergency-card__note"><strong>How it helps:</strong> {product.howItHelps}</p>
+    )}
+    {product.sizingNote && (
+      <p class="emergency-card__note"><strong>Fit note:</strong> {product.sizingNote}</p>
+    )}
+    {product.caution && (
+      <p class="emergency-card__note emergency-card__note--caution"><strong>Caution:</strong> {product.caution}</p>
+    )}
+
+    {(product.pros?.length || product.cons?.length) && (
+      <div class="emergency-card__pros-cons">
+        {product.pros?.length ? (
+          <div>
+            <p class="emergency-card__mini-heading emergency-card__mini-heading--pros">Pros</p>
+            <ul class="emergency-card__list emergency-card__list--pros">
+              {product.pros.map((item) => <li>{item}</li>)}
+            </ul>
+          </div>
+        ) : null}
+        {product.cons?.length ? (
+          <div>
+            <p class="emergency-card__mini-heading emergency-card__mini-heading--cons">Cons</p>
+            <ul class="emergency-card__list emergency-card__list--cons">
+              {product.cons.map((item) => <li>{item}</li>)}
+            </ul>
+          </div>
+        ) : null}
+      </div>
+    )}
+
+    <div class="emergency-card__offers">
+      <AffiliateOfferStack
+        offers={offers}
+        product={{ id: product.id, name: product.name, category: product.category }}
+        pageType="converter"
+        pageSlug={pageSlug}
+        position={position}
+        resolveLabel={(offer) =>
+          offer.merchant === 'amazon'
+            ? (product.ctaLabel ?? 'Check Price on Amazon')
+            : merchants[offer.merchant].ctaCopy
+        }
+      />
+    </div>
+  </ProductCardShell>
+</div>
+
+<style>
+  .emergency-card {
+    height: 100%;
+  }
+
+  .emergency-card :global(.product-card) {
+    height: 100%;
+  }
+
+  .emergency-card__badge {
+    color: var(--color-accent);
+    font-size: var(--text-sm);
+    font-weight: var(--weight-bold);
+    text-transform: uppercase;
+    margin: 0;
+  }
+
+  .emergency-card__name {
+    font-size: var(--text-xl);
+    line-height: var(--leading-tight);
+    margin: 0 0 var(--space-xs);
+  }
+
+  .emergency-card__use {
+    font-size: var(--text-sm);
+    color: var(--color-text-muted);
+    line-height: var(--leading-relaxed);
+    margin: 0 0 var(--space-sm);
+  }
+
+  .emergency-card__note {
+    font-size: var(--text-sm);
+    color: var(--color-text-muted);
+    line-height: var(--leading-relaxed);
+    border-left: 3px solid var(--color-border);
+    padding-left: var(--space-md);
+    margin: 0;
+  }
+
+  .emergency-card__note strong {
+    color: var(--color-text);
+  }
+
+  .emergency-card__note--caution {
+    border-left-color: var(--color-accent);
+  }
+
+  .emergency-card__pros-cons {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--space-md);
+    border-top: 1px solid var(--color-border);
+    padding-top: var(--space-md);
+    margin-top: var(--space-xs);
+  }
+
+  .emergency-card__mini-heading {
+    font-size: var(--text-xs);
+    font-weight: var(--weight-bold);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    margin: 0 0 var(--space-sm);
+  }
+
+  .emergency-card__mini-heading--pros {
+    color: var(--color-sage);
+  }
+
+  .emergency-card__mini-heading--cons {
+    color: var(--color-terracotta);
+  }
+
+  .emergency-card__list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .emergency-card__list li {
+    font-size: var(--text-xs);
+    color: var(--color-text-muted);
+    line-height: var(--leading-normal);
+    margin-bottom: var(--space-xs);
+    padding-left: var(--space-md);
+    position: relative;
+  }
+
+  .emergency-card__list--pros li::before,
+  .emergency-card__list--cons li::before {
+    position: absolute;
+    left: 0;
+    font-weight: var(--weight-bold);
+  }
+
+  .emergency-card__list--pros li::before {
+    content: '+';
+    color: var(--color-sage);
+  }
+
+  .emergency-card__list--cons li::before {
+    content: '-';
+    color: var(--color-terracotta);
+  }
+
+  .emergency-card__offers {
+    margin-top: auto;
+  }
+
+  @media (max-width: 700px) {
+    .emergency-card__pros-cons {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/src/data/emergency-products.ts
+++ b/src/data/emergency-products.ts
@@ -26,6 +26,12 @@ export interface EmergencyProduct {
   sizingNote?: string;
   ctaLabel?: string;
   image?: { src: string; alt: string };
+  /**
+   * Surfaced in the default view of the snake-bite converter. Everything else in
+   * the category stays in the catalog and renders behind the "more options"
+   * expander, so the page opens with a handful of decisions instead of all 47.
+   */
+  featured?: boolean;
 }
 
 export const emergencyCategoryMeta: Record<EmergencyProductCategory, { label: string; title: string; intro: string }> = {
@@ -113,6 +119,7 @@ const carryReviewCandidates: EmergencyProduct[] = [
   },
   {
     id: 'onetigris-full-body-dog-carry-sling',
+    featured: true,
     name: 'OneTigris Full Body Dog Carry Sling',
     category: 'carry',
     badge: 'Full-Body Carry Sling',
@@ -163,6 +170,7 @@ const carryReviewCandidates: EmergencyProduct[] = [
   },
   {
     id: 'ruffwear-backtrak-evacuation-kit',
+    featured: true,
     name: 'Ruffwear BackTrak Evacuation Kit',
     category: 'carry',
     badge: 'Carry Harness',
@@ -220,6 +228,7 @@ const carryReviewCandidates: EmergencyProduct[] = [
 const stretcherReviewCandidates: EmergencyProduct[] = [
   {
     id: 'veehoo-dog-stretcher',
+    featured: true,
     name: 'Veehoo Dog Stretcher',
     category: 'stretcher',
     badge: 'Dog Stretcher',
@@ -240,6 +249,7 @@ const stretcherReviewCandidates: EmergencyProduct[] = [
   },
   {
     id: 'patient-aid-portable-stretcher',
+    featured: true,
     name: 'Patient Aid Portable Stretcher & Gurney',
     category: 'stretcher',
     badge: 'Soft Stretcher',
@@ -323,6 +333,7 @@ const firstAidReviewCandidates: EmergencyProduct[] = [
   },
   {
     id: 'arca-pet-reflective-first-aid-pouch',
+    featured: true,
     name: 'ARCA PET Dog First Aid Kit',
     category: 'first-aid',
     badge: 'First Aid Kit',
@@ -361,6 +372,7 @@ const firstAidReviewCandidates: EmergencyProduct[] = [
   },
   {
     id: 'adventure-dog-medical-kit-vet-in-a-box',
+    featured: true,
     name: 'Adventure Dog Medical Kit - Vet in a Box',
     category: 'first-aid',
     badge: 'First Aid Kit',
@@ -434,6 +446,7 @@ const firstAidReviewCandidates: EmergencyProduct[] = [
 const warmthReviewCandidates: EmergencyProduct[] = [
   {
     id: 'sierra-madre-emergency-sleeping-bag',
+    featured: true,
     name: 'Sierra Madre Emergency Sleeping Bag',
     category: 'warmth-control',
     badge: 'Sleeping Bag',
@@ -516,6 +529,7 @@ const slipLeadReviewCandidates: EmergencyProduct[] = [
   },
   {
     id: 'mendota-products-large-slip-lead',
+    featured: true,
     name: 'Mendota Products Slip Lead',
     category: 'warmth-control',
     badge: 'Slip Lead',
@@ -591,6 +605,7 @@ const preventionReviewCandidates: EmergencyProduct[] = [
   },
   {
     id: 'cuktech-25000mah-power-bank',
+    featured: true,
     name: 'CUKTECH 25,000mAh Power Bank',
     category: 'prevention',
     badge: 'Power Bank',
@@ -653,6 +668,7 @@ const preventionReviewCandidates: EmergencyProduct[] = [
   },
   {
     id: 'nebo-mycro-450-headlamp',
+    featured: true,
     name: 'NEBO MYCRO 450 Headlamp',
     category: 'prevention',
     badge: 'Headlamp',
@@ -694,6 +710,7 @@ const preventionReviewCandidates: EmergencyProduct[] = [
   },
   {
     id: 'nitecore-nu25-headlamp',
+    featured: true,
     name: 'Nitecore NU25 360 Lumen Triple Output',
     category: 'prevention',
     badge: 'Headlamp',
@@ -777,6 +794,7 @@ const preventionReviewCandidates: EmergencyProduct[] = [
 export const emergencyProducts: EmergencyProduct[] = [
   {
     id: 'fido-pro-airlift-rescue-sling',
+    featured: true,
     name: 'Fido Pro Airlift Emergency Dog Rescue Sling',
     category: 'carry',
     badge: 'Rescue Sling',
@@ -894,6 +912,7 @@ export const emergencyProducts: EmergencyProduct[] = [
   },
   {
     id: 'kurgo-50-piece-dog-first-aid-kit',
+    featured: true,
     name: 'Kurgo 50-Piece Dog First Aid Kit',
     category: 'first-aid',
     badge: 'First Aid Kit',
@@ -949,6 +968,7 @@ export const emergencyProducts: EmergencyProduct[] = [
   ...firstAidReviewCandidates,
   {
     id: 'swiss-safe-mylar-emergency-blankets',
+    featured: true,
     name: 'Swiss Safe Mylar Emergency Blankets',
     category: 'warmth-control',
     badge: 'MYLAR BLANKET',
@@ -973,6 +993,7 @@ export const emergencyProducts: EmergencyProduct[] = [
   ...preventionReviewCandidates,
   {
     id: 'hipypaw-basket-silicone-muzzle',
+    featured: true,
     name: 'HipyPaw Basket Silicone Dog Muzzle',
     category: 'muzzle',
     badge: 'Dog Muzzle',
@@ -992,6 +1013,7 @@ export const emergencyProducts: EmergencyProduct[] = [
   },
   {
     id: 'vinchini-3d-mesh-muzzle',
+    featured: true,
     name: 'VINCHINI 3D Air Mesh Dog Muzzle',
     category: 'muzzle',
     badge: 'Best Mesh',
@@ -1050,6 +1072,7 @@ export const emergencyProducts: EmergencyProduct[] = [
   },
   {
     id: 'tviaoh-small-dog-muzzle',
+    featured: true,
     name: 'TVIAOH Small Dog Muzzle',
     category: 'muzzle',
     badge: 'Best for Small Dogs',
@@ -1107,4 +1130,21 @@ export const emergencyProducts: EmergencyProduct[] = [
 
 export function getEmergencyProductsByCategory(category: EmergencyProductCategory): EmergencyProduct[] {
   return emergencyProducts.filter((product) => product.category === category);
+}
+
+/**
+ * The curated picks the converter shows by default. Falls back to the first
+ * entry in the category so a category can never render an empty grid if its
+ * `featured` flags are ever dropped.
+ */
+export function getFeaturedEmergencyProducts(category: EmergencyProductCategory): EmergencyProduct[] {
+  const inCategory = getEmergencyProductsByCategory(category);
+  const featured = inCategory.filter((product) => product.featured);
+  return featured.length > 0 ? featured : inCategory.slice(0, 1);
+}
+
+/** Everything else in the category — rendered behind the "more options" expander. */
+export function getAdditionalEmergencyProducts(category: EmergencyProductCategory): EmergencyProduct[] {
+  const featuredIds = new Set(getFeaturedEmergencyProducts(category).map((product) => product.id));
+  return getEmergencyProductsByCategory(category).filter((product) => !featuredIds.has(product.id));
 }

--- a/src/pages/gear/airtag-for-dogs.astro
+++ b/src/pages/gear/airtag-for-dogs.astro
@@ -219,10 +219,11 @@ const collectionSchema = {
           </div>
         )}
 
-        <div class="section-converter-cta">
+        <div class="comparison-cta">
+          <p class="comparison-cta-text">See where a Bluetooth tag sits against real GPS trackers, side by side:</p>
           <a
             href={ROUTES.trackingTop}
-            class="converter-cta-btn"
+            class="ui-cta"
             data-track="collector_to_converter_click"
             data-from-page={pageSlug}
             data-to-page={ROUTES.trackingTop}
@@ -519,22 +520,25 @@ const collectionSchema = {
     margin: var(--space-xs) 0 0;
   }
 
-  .section-converter-cta { margin-top: var(--space-xl); }
-
-  .converter-cta-btn {
-    display: inline-block;
-    background: var(--color-primary);
-    color: var(--color-text-inverse);
-    font-weight: var(--weight-semibold);
-    padding: var(--space-sm) var(--space-xl);
-    border-radius: var(--radius-md);
-    text-decoration: none;
-    transition: background var(--transition-fast);
+  .comparison-cta {
+    display: flex;
+    align-items: center;
+    gap: var(--space-lg);
+    flex-wrap: wrap;
+    margin-top: var(--space-xl);
   }
 
-  .converter-cta-btn:hover {
-    background: var(--color-primary-hover);
-    color: var(--color-text-inverse);
+  .comparison-cta-text {
+    font-size: var(--text-base);
+    color: var(--color-text-muted);
+    margin: 0;
+  }
+
+  @media (max-width: 768px) {
+    .comparison-cta {
+      flex-direction: column;
+      align-items: flex-start;
+    }
   }
 
   /* Closing CTA */

--- a/src/pages/gear/airtag-for-dogs.astro
+++ b/src/pages/gear/airtag-for-dogs.astro
@@ -308,25 +308,6 @@ const collectionSchema = {
     <!-- FAQ -->
     <section id="faq">
       <FAQ faqs={faqs} heading="AirTag for Dogs FAQ" />
-      {airtagOffer && (
-        <div class="faq-shop-cta">
-          <p class="faq-shop-note">
-            If a Bluetooth tag is what you actually want — a cheap collar tag for a dog who
-            stays in populated areas — AirTag is the one to get.
-          </p>
-          <AffiliateLink
-            href={airtagOffer.url}
-            data-asin={airtagOffer.asin}
-            data-product-name={airtagProduct.name}
-            data-product-id={airtagProduct.id}
-            data-product-category={airtagProduct.type}
-            position="faq-bottom"
-            class="ui-cta"
-          >
-            Check Price on Apple AirTag
-          </AffiliateLink>
-        </div>
-      )}
     </section>
 
     <!-- Closing CTA -->
@@ -554,17 +535,6 @@ const collectionSchema = {
     font-size: var(--text-sm);
     color: var(--color-text-muted);
     margin: var(--space-xs) 0 0;
-  }
-
-  .faq-shop-cta {
-    max-width: 28rem;
-    margin: var(--space-xl) auto 0;
-    text-align: center;
-  }
-
-  .faq-shop-note {
-    color: var(--color-text-muted);
-    margin-bottom: var(--space-sm);
   }
 
   .comparison-cta {

--- a/src/pages/gear/airtag-for-dogs.astro
+++ b/src/pages/gear/airtag-for-dogs.astro
@@ -9,10 +9,17 @@ import InternalLinkStrip from '@components/modules/InternalLinkStrip.astro';
 import JsonLd from '@components/JsonLd.astro';
 import AffiliateLink from '@components/AffiliateLink.astro';
 import { getTrackersByType } from '@data/tracking-products';
+import { getOffers } from '@data/products/offers';
 
 const pageSlug = 'airtag-for-dogs';
 const bluetoothProducts = getTrackersByType('bluetooth');
 const airtagProduct = bluetoothProducts.find((product) => product.id === 'apple-airtag-2nd-gen') ?? bluetoothProducts[0];
+// Same buy path the hero, the mid-page CTA and the post-FAQ CTA all share, so there is
+// one offer to keep current and every CTA carries identical instrumentation.
+const airtagOffer = airtagProduct ? getOffers(airtagProduct).find((o) => o.merchant === 'amazon') : undefined;
+const airtagProductMeta = airtagProduct
+  ? { id: airtagProduct.id, name: airtagProduct.name, category: airtagProduct.type }
+  : undefined;
 
 const tocHeadings = [
   { label: 'What AirTag Actually Is', anchor: 'what-it-is' },
@@ -75,8 +82,16 @@ const collectionSchema = {
   <Hero
     title="AirTag for Dogs: What It Can and Can't Do"
     subtitle="AirTag is popular, affordable, and widely misunderstood. Here's an honest look at what Bluetooth crowd-sourcing actually means for a dog that runs away."
-    primaryCta={{ label: 'See All GPS Trackers', href: ROUTES.trackingTop }}
-    secondaryCta={{ label: 'Need Real GPS?', href: ROUTES.fiCollarReview }}
+    disclaimer="As an Amazon Associate, we earn from qualifying purchases."
+    primaryCta={airtagOffer
+      ? {
+          label: 'Check Price on Apple AirTag',
+          href: airtagOffer.url,
+          offer: airtagOffer,
+          product: airtagProductMeta,
+        }
+      : { label: 'See All GPS Trackers', href: ROUTES.trackingTop }}
+    secondaryCta={{ label: 'Need Real GPS Instead?', href: ROUTES.trackingTop }}
     pageSlug={pageSlug}
   />
 
@@ -202,16 +217,18 @@ const collectionSchema = {
           </div>
         </div>
 
-        {airtagProduct?.amazonUrl && airtagProduct.asin && (
+        {airtagOffer && (
           <div class="section-shop-cta">
             <AffiliateLink
-              href={airtagProduct.amazonUrl}
-              data-track="amazon_outbound_click"
-              data-asin={airtagProduct.asin}
+              href={airtagOffer.url}
+              data-asin={airtagOffer.asin}
               data-product-name={airtagProduct.name}
+              data-product-id={airtagProduct.id}
+              data-product-category={airtagProduct.type}
+              position="when-it-makes-sense"
               class="ui-cta"
             >
-              Shop AirTag on Amazon
+              Check Price on Apple AirTag
             </AffiliateLink>
             <p class="section-shop-note">
               Best fit for Apple users who want a low-cost backup tag, not a standalone GPS tracker.
@@ -291,6 +308,25 @@ const collectionSchema = {
     <!-- FAQ -->
     <section id="faq">
       <FAQ faqs={faqs} heading="AirTag for Dogs FAQ" />
+      {airtagOffer && (
+        <div class="faq-shop-cta">
+          <p class="faq-shop-note">
+            If a Bluetooth tag is what you actually want — a cheap collar tag for a dog who
+            stays in populated areas — AirTag is the one to get.
+          </p>
+          <AffiliateLink
+            href={airtagOffer.url}
+            data-asin={airtagOffer.asin}
+            data-product-name={airtagProduct.name}
+            data-product-id={airtagProduct.id}
+            data-product-category={airtagProduct.type}
+            position="faq-bottom"
+            class="ui-cta"
+          >
+            Check Price on Apple AirTag
+          </AffiliateLink>
+        </div>
+      )}
     </section>
 
     <!-- Closing CTA -->
@@ -518,6 +554,17 @@ const collectionSchema = {
     font-size: var(--text-sm);
     color: var(--color-text-muted);
     margin: var(--space-xs) 0 0;
+  }
+
+  .faq-shop-cta {
+    max-width: 28rem;
+    margin: var(--space-xl) auto 0;
+    text-align: center;
+  }
+
+  .faq-shop-note {
+    color: var(--color-text-muted);
+    margin-bottom: var(--space-sm);
   }
 
   .comparison-cta {

--- a/src/pages/gear/best-dog-gps-trackers.astro
+++ b/src/pages/gear/best-dog-gps-trackers.astro
@@ -147,18 +147,6 @@ const itemListSchema = {
           </p>
         </div>
 
-        <p class="section-cta-line">
-          <a
-            href={ROUTES.fiCollarReview}
-            class="inline-cta"
-            data-track="collector_to_converter_click"
-            data-from-page={pageSlug}
-            data-to-page={ROUTES.fiCollarReview}
-            data-link-position="cellular-section"
-          >
-            Read the full Fi Collar review →
-          </a>
-        </p>
       </div>
     </section>
 
@@ -182,18 +170,6 @@ const itemListSchema = {
           ))}
         </div>
 
-        <p class="section-cta-line">
-          <a
-            href={ROUTES.garminTracking}
-            class="inline-cta"
-            data-track="collector_to_converter_click"
-            data-from-page={pageSlug}
-            data-to-page={ROUTES.garminTracking}
-            data-link-position="offgrid-section"
-          >
-            See the full Garmin dog tracking guide →
-          </a>
-        </p>
       </div>
     </section>
 
@@ -224,18 +200,6 @@ const itemListSchema = {
           ))}
         </div>
 
-        <p class="section-cta-line">
-          <a
-            href={ROUTES.airtagForDogs}
-            class="inline-cta"
-            data-track="collector_to_converter_click"
-            data-from-page={pageSlug}
-            data-to-page={ROUTES.airtagForDogs}
-            data-link-position="bluetooth-section"
-          >
-            AirTag for dogs: what it can and can't do →
-          </a>
-        </p>
       </div>
     </section>
 
@@ -339,7 +303,7 @@ const itemListSchema = {
     <InternalLinkStrip
       heading="More Dog Tracking + Safety Guides"
       currentHref={ROUTES.trackingTop}
-      limit={6}
+      limit={3}
       fromPage={pageSlug}
     />
   </div>
@@ -521,22 +485,6 @@ const itemListSchema = {
     color: var(--color-text-muted);
     line-height: var(--leading-relaxed);
     margin: 0;
-  }
-
-  /* Inline CTA */
-  .section-cta-line {
-    margin-top: var(--space-md);
-  }
-
-  .inline-cta {
-    font-size: var(--text-sm);
-    font-weight: var(--weight-semibold);
-    color: var(--color-primary);
-    text-decoration: none;
-  }
-
-  .inline-cta:hover {
-    text-decoration: underline;
   }
 
   /* Decision table */

--- a/src/pages/gear/best-dog-gps-trackers.astro
+++ b/src/pages/gear/best-dog-gps-trackers.astro
@@ -147,6 +147,18 @@ const itemListSchema = {
           </p>
         </div>
 
+        <p class="section-cta-line">
+          <a
+            href={ROUTES.fiCollarReview}
+            class="inline-cta"
+            data-track="collector_to_converter_click"
+            data-from-page={pageSlug}
+            data-to-page={ROUTES.fiCollarReview}
+            data-link-position="cellular-section"
+          >
+            Read the full Fi Collar review →
+          </a>
+        </p>
       </div>
     </section>
 
@@ -170,6 +182,18 @@ const itemListSchema = {
           ))}
         </div>
 
+        <p class="section-cta-line">
+          <a
+            href={ROUTES.garminTracking}
+            class="inline-cta"
+            data-track="collector_to_converter_click"
+            data-from-page={pageSlug}
+            data-to-page={ROUTES.garminTracking}
+            data-link-position="offgrid-section"
+          >
+            See the full Garmin dog tracking guide →
+          </a>
+        </p>
       </div>
     </section>
 
@@ -200,6 +224,18 @@ const itemListSchema = {
           ))}
         </div>
 
+        <p class="section-cta-line">
+          <a
+            href={ROUTES.airtagForDogs}
+            class="inline-cta"
+            data-track="collector_to_converter_click"
+            data-from-page={pageSlug}
+            data-to-page={ROUTES.airtagForDogs}
+            data-link-position="bluetooth-section"
+          >
+            AirTag for dogs: what it can and can't do →
+          </a>
+        </p>
       </div>
     </section>
 
@@ -303,7 +339,7 @@ const itemListSchema = {
     <InternalLinkStrip
       heading="More Dog Tracking + Safety Guides"
       currentHref={ROUTES.trackingTop}
-      limit={3}
+      limit={6}
       fromPage={pageSlug}
     />
   </div>
@@ -485,6 +521,22 @@ const itemListSchema = {
     color: var(--color-text-muted);
     line-height: var(--leading-relaxed);
     margin: 0;
+  }
+
+  /* Inline CTA */
+  .section-cta-line {
+    margin-top: var(--space-md);
+  }
+
+  .inline-cta {
+    font-size: var(--text-sm);
+    font-weight: var(--weight-semibold);
+    color: var(--color-primary);
+    text-decoration: none;
+  }
+
+  .inline-cta:hover {
+    text-decoration: underline;
   }
 
   /* Decision table */

--- a/src/pages/gear/dog-snake-bite-emergency-kit.astro
+++ b/src/pages/gear/dog-snake-bite-emergency-kit.astro
@@ -7,25 +7,26 @@ import FAQ from '@components/modules/FAQ.astro';
 import Disclosure from '@components/modules/Disclosure.astro';
 import InternalLinkStrip from '@components/modules/InternalLinkStrip.astro';
 import JsonLd from '@components/JsonLd.astro';
-import MerchantAffiliateLink from '@components/MerchantAffiliateLink.astro';
-import ProductBulletList from '@components/modules/primitives/ProductBulletList.astro';
-import {
-  emergencyCategoryMeta,
-  emergencyProducts,
-  getEmergencyProductsByCategory,
-  type EmergencyProductCategory,
-} from '@data/emergency-products';
-import { merchants } from '@data/products/merchants';
-import { getOffers } from '@data/products/offers';
+import EmergencyCategorySection from '@components/modules/EmergencyCategorySection.astro';
+import { emergencyProducts, type EmergencyProductCategory } from '@data/emergency-products';
+import { getPrimaryOffer } from '@data/products/offers';
 
 const pageSlug = 'dog-snake-bite-emergency-kit';
 
 const categories: EmergencyProductCategory[] = ['carry', 'stretcher', 'first-aid', 'muzzle', 'warmth-control', 'prevention'];
 
+/**
+ * The hero pick doubles as the page's single above-the-fold CTA. It is the same
+ * product `content-sitemap.ts` already designates as this page's heroProduct, so
+ * the share image and the primary CTA stay in sync.
+ */
+const heroProduct = emergencyProducts.find((product) => product.id === 'fido-pro-airlift-rescue-sling');
+const heroOffer = heroProduct ? getPrimaryOffer(heroProduct) : undefined;
+
 const tocHeadings = [
-  { label: 'Safety Note', anchor: 'safety-note' },
   { label: 'Six Jobs', anchor: 'six-jobs' },
   { label: 'Carry Slings', anchor: 'carry' },
+  { label: 'Safety Note', anchor: 'safety-note' },
   { label: 'Dog Stretchers', anchor: 'stretcher' },
   { label: 'First Aid Kits', anchor: 'first-aid' },
   { label: 'Muzzle Safety', anchor: 'muzzle' },
@@ -90,12 +91,41 @@ const itemListSchema = {
     title="Snake-Bite Emergency Kit for Dogs"
     subtitle="The best snakebite emergency kit has nothing to do with venom removal. It is gear that helps you carry, control, and warm your dog as you get to a veterinarian as soon as possible."
     disclaimer="As an Amazon Associate and a Chewy Affiliate, we earn from qualifying purchases."
-    primaryCta={{ label: 'Start With Carry Gear', href: '#carry' }}
+    primaryCta={
+      heroOffer && heroProduct
+        ? {
+            label: 'Check Price on the Top Rescue Sling',
+            href: heroOffer.url,
+            offer: heroOffer,
+            product: { id: heroProduct.id, name: heroProduct.name, category: heroProduct.category },
+          }
+        : { label: 'Start With Carry Gear', href: '#carry' }
+    }
     secondaryCta={{ label: 'Read the Safety Guide', href: ROUTES.rattlesnakeSafetyForDogs }}
     pageSlug={pageSlug}
   />
 
   <div class="converter-content">
+    <Toc headings={tocHeadings} pageSlug={pageSlug} />
+
+    <section class="jobs-section" id="six-jobs">
+      <div class="section-inner">
+        <h2>Items in your kit should allow you to:</h2>
+        <div class="job-grid">
+          <div class="job-card"><strong>Carry</strong><span>Move your dog without making them walk.</span></div>
+          <div class="job-card"><strong>Control</strong><span>Keep a scared dog secure around cars, trails, and doors.</span></div>
+          <div class="job-card"><strong>Restrain</strong><span>Reduce pain-biting risk by using a muzzle when it is safe to do so.</span></div>
+          <div class="job-card"><strong>Warm</strong><span>Keep your dog quiet and warm on the way to care.</span></div>
+          <div class="job-card"><strong>Call</strong><span>Keep phone power available to reach the emergency vet.</span></div>
+          <div class="job-card"><strong>Prepare</strong><span>Keep clean supplies and vet info ready.</span></div>
+        </div>
+      </div>
+    </section>
+
+    <Disclosure />
+
+    <EmergencyCategorySection category={categories[0]} pageSlug={pageSlug} />
+
     <section class="safety-section" id="safety-note">
       <div class="section-inner">
         <span class="section-label">Read first</span>
@@ -134,90 +164,9 @@ const itemListSchema = {
       </div>
     </section>
 
-    <Toc headings={tocHeadings} pageSlug={pageSlug} />
-
-    <section class="jobs-section" id="six-jobs">
-      <div class="section-inner">
-        <h2>Items in your kit should allow you to:</h2>
-        <div class="job-grid">
-          <div class="job-card"><strong>Carry</strong><span>Move your dog without making them walk.</span></div>
-          <div class="job-card"><strong>Control</strong><span>Keep a scared dog secure around cars, trails, and doors.</span></div>
-          <div class="job-card"><strong>Restrain</strong><span>Reduce pain-biting risk by using a muzzle when it is safe to do so.</span></div>
-          <div class="job-card"><strong>Warm</strong><span>Keep your dog quiet and warm on the way to care.</span></div>
-          <div class="job-card"><strong>Call</strong><span>Keep phone power available to reach the emergency vet.</span></div>
-          <div class="job-card"><strong>Prepare</strong><span>Keep clean supplies and vet info ready.</span></div>
-        </div>
-      </div>
-    </section>
-
-    <Disclosure />
-
-    {categories.map((category) => {
-      const meta = emergencyCategoryMeta[category];
-      const products = getEmergencyProductsByCategory(category);
-      return (
-        <section class={`product-section product-section--${category}`} id={category}>
-          <div class="section-inner">
-            <div class="section-header">
-              <span class="section-label">{meta.label}</span>
-              <h2>{meta.title}</h2>
-              <p>{meta.intro}</p>
-            </div>
-            {products.length > 0 && (
-              <div class="product-grid">
-                {products.map((product, productIndex) => (
-                  <article class="product-card" id={product.id}>
-                    {product.image && (
-                      <div class="product-image">
-                        <img src={product.image.src} alt={product.image.alt} loading="lazy" width="300" height="300" />
-                      </div>
-                    )}
-                    <div class="product-body">
-                      <p class="badge">{product.badge}</p>
-                      <h3>{product.name}</h3>
-                      <p class="use-case">{product.useCase}</p>
-                      <ProductBulletList bullets={product.bullets} />
-                      {product.howItHelps && <p class="how-it-helps"><strong>How it helps:</strong> {product.howItHelps}</p>}
-                      {product.sizingNote && <p class="note"><strong>Fit note:</strong> {product.sizingNote}</p>}
-                      {product.caution && <p class="note note--caution"><strong>Caution:</strong> {product.caution}</p>}
-                      {(product.pros?.length || product.cons?.length) && (
-                        <div class="pros-cons">
-                          {product.pros?.length ? (
-                            <div>
-                              <p class="mini-heading">Pros</p>
-                              <ul>{product.pros.map((item) => <li>{item}</li>)}</ul>
-                            </div>
-                          ) : null}
-                          {product.cons?.length ? (
-                            <div>
-                              <p class="mini-heading">Cons</p>
-                              <ul>{product.cons.map((item) => <li>{item}</li>)}</ul>
-                            </div>
-                          ) : null}
-                        </div>
-                      )}
-                      <div class="product-cta-wrap">
-                        {getOffers(product).map((offer, offerIndex) => (
-                          <MerchantAffiliateLink
-                            offer={offer}
-                            product={{ id: product.id, name: product.name, category: product.category }}
-                            class={`product-cta${offerIndex > 0 ? ' product-cta--secondary' : ''}`}
-                            label={offer.merchant === 'amazon' ? (product.ctaLabel ?? 'Check Price on Amazon') : merchants[offer.merchant].ctaCopy}
-                            pageType="converter"
-                            pageSlug={pageSlug}
-                            position={`${category}-${productIndex + 1}-${offerIndex + 1}`}
-                          />
-                        ))}
-                      </div>
-                    </div>
-                  </article>
-                ))}
-              </div>
-            )}
-          </div>
-        </section>
-      );
-    })}
+    {categories.slice(1).map((category) => (
+      <EmergencyCategorySection category={category} pageSlug={pageSlug} />
+    ))}
 
     <section class="skip-section" id="skip-these">
       <div class="section-inner">
@@ -259,12 +208,10 @@ const itemListSchema = {
 
   .safety-section,
   .jobs-section,
-  .skip-section,
-  .product-section {
+  .skip-section {
     padding: var(--space-2xl) 0;
   }
 
-  .product-section:nth-of-type(even),
   .jobs-section,
   .skip-section {
     background: var(--color-surface);
@@ -286,12 +233,6 @@ const itemListSchema = {
     margin: 0 0 var(--space-md);
   }
 
-  .section-header {
-    max-width: var(--max-width-prose);
-    margin-bottom: var(--space-xl);
-  }
-
-  .section-header p,
   .safety-section p,
   .skip-item p {
     color: var(--color-text-muted);
@@ -299,9 +240,15 @@ const itemListSchema = {
   }
 
   .do-dont-grid,
-  .job-grid,
   .job-grid {
+    display: grid;
     grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: var(--space-md);
+  }
+
+  .do-dont-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    margin-top: var(--space-lg);
   }
 
   .do-dont-card,
@@ -318,13 +265,11 @@ const itemListSchema = {
     margin: 0 0 var(--space-sm);
   }
 
-  .do-dont-card ul,
-  .pros-cons ul {
+  .do-dont-card ul {
     padding-left: 1.1rem;
   }
 
-  .do-dont-card li,
-  .pros-cons li {
+  .do-dont-card li {
     color: var(--color-text-muted);
     line-height: var(--leading-relaxed);
   }
@@ -354,109 +299,6 @@ const itemListSchema = {
     line-height: var(--leading-relaxed);
   }
 
-  .product-grid {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: var(--space-xl);
-  }
-
-  .product-card {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-md);
-    border: 1px solid var(--color-border);
-    border-radius: var(--radius-md);
-    background: var(--color-surface);
-    padding: var(--space-lg);
-  }
-
-  .product-image {
-    min-height: 180px;
-    border-radius: var(--radius-sm);
-    background: #fff;
-    border: 1px solid var(--color-border);
-    display: grid;
-    place-items: center;
-    overflow: hidden;
-    padding: var(--space-md);
-  }
-
-  .product-image img {
-    max-width: 180px;
-    max-height: 180px;
-    width: auto;
-    height: auto;
-    object-fit: contain;
-    display: block;
-  }
-
-  .badge {
-    color: var(--color-accent);
-    font-size: var(--text-sm);
-    font-weight: var(--weight-bold);
-    margin: 0 0 var(--space-xs);
-    text-transform: uppercase;
-  }
-
-  .product-card h3 {
-    font-size: var(--text-xl);
-    margin: 0 0 var(--space-sm);
-  }
-
-  .use-case,
-  .how-it-helps,
-  .note {
-    color: var(--color-text-muted);
-    line-height: var(--leading-relaxed);
-  }
-
-  .note {
-    border-left: 3px solid var(--color-border);
-    padding-left: var(--space-md);
-  }
-
-  .note--caution {
-    border-left-color: var(--color-accent);
-  }
-
-  .pros-cons {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: var(--space-md);
-    margin-top: var(--space-md);
-  }
-
-  .mini-heading {
-    color: var(--color-text);
-    font-weight: var(--weight-semibold);
-    margin: 0 0 var(--space-xs);
-  }
-
-  .product-cta-wrap {
-    display: flex;
-    flex-wrap: wrap;
-    gap: var(--space-sm);
-    margin-top: var(--space-lg);
-  }
-
-  .product-cta {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-height: 44px;
-    border-radius: var(--radius-sm);
-    background: var(--color-accent);
-    color: #fff;
-    font-weight: var(--weight-semibold);
-    padding: var(--space-sm) var(--space-lg);
-    text-decoration: none;
-  }
-
-  .product-cta:hover {
-    color: #fff;
-    filter: brightness(0.95);
-  }
-
   .skip-list {
     display: grid;
     grid-template-columns: repeat(5, minmax(0, 1fr));
@@ -464,21 +306,17 @@ const itemListSchema = {
   }
 
   @media (max-width: 980px) {
-    .product-grid,
     .job-grid,
     .skip-list {
-      grid-template-columns: 1fr;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
     }
   }
 
   @media (max-width: 700px) {
     .do-dont-grid,
-    .pros-cons {
+    .job-grid,
+    .skip-list {
       grid-template-columns: 1fr;
-    }
-
-    .product-image {
-      min-height: 160px;
     }
   }
 </style>

--- a/src/pages/gear/fi-dog-collar-review.astro
+++ b/src/pages/gear/fi-dog-collar-review.astro
@@ -17,9 +17,13 @@ const pageSlug = 'fi-dog-collar-review';
 
 const fiProducts = getTrackersByType('cellular').filter(p => p.id === 'fi-series-3-plus');
 const fiProduct = fiProducts[0];
+// Fi's Amazon listing is the buy path the page is built around; the hero CTA and the
+// Best For CTA share it so there is one offer to keep current, not two.
+const heroOffer = fiProduct ? getOffers(fiProduct).find((o) => o.merchant === 'amazon') : undefined;
 const stuntPuppyCollar = accessoryProducts.find(a => a.id === 'stunt-puppy-fi-collar')!
 
 const tocHeadings = [
+  { label: 'Quick Answers', anchor: 'quick-answers' },
   { label: 'What Fi Is', anchor: 'what-fi-is' },
   { label: 'How It Works', anchor: 'how-it-works' },
   { label: 'Pros & Cons', anchor: 'pros-cons' },
@@ -28,14 +32,18 @@ const tocHeadings = [
   { label: 'FAQ', anchor: 'faq' },
 ];
 
+// `short` marks the questions that gate the buying decision. They answer up top in one
+// line each; the full answers stay in the FAQ at the bottom.
 const faqs = [
   {
     question: 'Does Fi collar work without WiFi?',
+    short: 'Yes — it uses LTE cellular, not WiFi. No home network needed, but it needs cell signal.',
     answer:
       'Fi uses LTE cellular, not WiFi. It works anywhere with LTE signal — no home network required. However, without LTE signal (in remote wilderness, mountains, or dead zones) the collar cannot report location.',
   },
   {
     question: 'Does the Fi collar require a subscription?',
+    short: 'Yes — required, not optional. The collar is bought separately and stops tracking without an active plan.',
     answer:
       'Yes. Fi requires a monthly or annual subscription to access the LTE tracking network. The collar hardware is purchased separately. Without a subscription, you lose real-time tracking.',
   },
@@ -46,11 +54,13 @@ const faqs = [
   },
   {
     question: 'Is Fi waterproof?',
+    short: 'Yes — IP68 rated. Rain, mud, and swimming are fine.',
     answer:
       'The Fi Series 3+ collar is rated IP68 waterproof.  It handles rain, mud, and swimming. This is one of the practical advantages of Fi over some competing cellular trackers.',
   },
   {
     question: 'How long does the Fi battery last?',
+    short: 'Up to 3 months in standard mode — but only days if you leave live tracking running.',
     answer:
       'Battery life varies significantly by tracking mode. In standard mode with moderate use, Fi claims its battery lasts up to 3 months. In heavy real-time tracking mode (continuous updates), the battery depletes much faster — often within a few days.  Actual battery life depends heavily on how actively the location is being polled.',
   },
@@ -60,6 +70,8 @@ const faqs = [
       'Fi works on hiking trails that have LTE coverage, which includes most popular trails near populated areas. It does not work in true wilderness, backcountry, or remote mountains without cell signal. Before taking Fi on a hiking trip, check the cell coverage map for your specific trail.',
   },
 ];
+
+const quickAnswers = faqs.filter((faq) => faq.short);
 
 const articleSchema = {
   '@context': 'https://schema.org',
@@ -91,7 +103,15 @@ const articleSchema = {
   <Hero
     title="Fi Dog Collar Review"
     subtitle="Cellular GPS tracking for everyday dogs — city walks, parks, travel. Here's what it does well, what it costs, and where it stops working."
-    primaryCta={{ label: 'See All GPS Trackers', href: ROUTES.trackingTop }}
+    disclaimer="As an Amazon Associate, we earn from qualifying purchases."
+    primaryCta={heroOffer
+      ? {
+          label: 'Check Price on Fi Series 3+',
+          href: heroOffer.url,
+          offer: heroOffer,
+          product: { id: fiProduct.id, name: fiProduct.name, category: fiProduct.type },
+        }
+      : { label: 'See All GPS Trackers', href: ROUTES.trackingTop }}
     secondaryCta={{ label: 'Off-Grid Alternative (Garmin)', href: ROUTES.garminTracking }}
     pageSlug={pageSlug}
   />
@@ -99,6 +119,24 @@ const articleSchema = {
   <div class="converter-content">
 
     <Toc headings={tocHeadings} pageSlug={pageSlug} />
+
+    <!-- Quick answers -->
+    <section class="content-section content-section--alt" id="quick-answers">
+      <div class="section-inner">
+        <h2>Quick Answers</h2>
+        <dl class="quick-answers">
+          {quickAnswers.map((faq) => (
+            <div class="quick-answer">
+              <dt class="qa-question">{faq.question}</dt>
+              <dd class="qa-answer">{faq.short}</dd>
+            </div>
+          ))}
+        </dl>
+        <p class="qa-more">
+          <a href="#faq">Full answers, plus accuracy and hiking coverage &rarr;</a>
+        </p>
+      </div>
+    </section>
 
     <!-- What Fi Is -->
     <section class="content-section" id="what-fi-is">
@@ -196,33 +234,6 @@ const articleSchema = {
           Fi is a strong fit for a specific kind of dog and owner.
         </p>
 
-        <div class="fi-buy-cta">
-          {fiProduct ? (
-            <AffiliateOfferStack
-              offers={getOffers(fiProduct)}
-              product={{ id: fiProduct.id, name: fiProduct.name, category: fiProduct.type }}
-              pageType="converter"
-              pageSlug={pageSlug}
-              position="fi-review"
-              resolveLabel={(offer) =>
-                offer.merchant === 'amazon'
-                  ? 'Shop Fi Series 3+ on Amazon (12-mo membership)'
-                  : undefined
-              }
-            />
-          ) : (
-            <AffiliateLink
-              href="https://www.amazon.com/dp/B0FH8GDBLX?tag=chill-dogs-20"
-              data-track="amazon_outbound_click"
-              data-asin="B0FH8GDBLX"
-              data-product-name="Fi Series 3+ GPS Collar (12-mo membership)"
-              class="ui-cta"
-            >
-              Shop Fi Series 3+ on Amazon (12-mo membership)
-            </AffiliateLink>
-          )}
-          <p class="fi-buy-note">Includes 12-month membership — best per-month value for Fi</p>
-        </div>
         <div class="best-for-list">
           <div class="best-for-item best-for-item--yes">
             <span class="bfi-icon">✓</span>
@@ -259,6 +270,34 @@ const articleSchema = {
               <p class="bfi-desc">Rural coverage is inconsistent. Garmin off-grid systems are the standard in this use case for good reason — they work everywhere with no subscription.</p>
             </div>
           </div>
+        </div>
+
+        <div class="fi-buy-cta">
+          {fiProduct ? (
+            <AffiliateOfferStack
+              offers={getOffers(fiProduct)}
+              product={{ id: fiProduct.id, name: fiProduct.name, category: fiProduct.type }}
+              pageType="converter"
+              pageSlug={pageSlug}
+              position="fi-review"
+              resolveLabel={(offer) =>
+                offer.merchant === 'amazon'
+                  ? 'Shop Fi Series 3+ on Amazon (12-mo membership)'
+                  : undefined
+              }
+            />
+          ) : (
+            <AffiliateLink
+              href="https://www.amazon.com/dp/B0FH8GDBLX?tag=chill-dogs-20"
+              data-track="amazon_outbound_click"
+              data-asin="B0FH8GDBLX"
+              data-product-name="Fi Series 3+ GPS Collar (12-mo membership)"
+              class="ui-cta"
+            >
+              Shop Fi Series 3+ on Amazon (12-mo membership)
+            </AffiliateLink>
+          )}
+          <p class="fi-buy-note">Includes 12-month membership — best per-month value for Fi</p>
         </div>
 
         <!-- Stunt Puppy Accessory Card -->
@@ -319,6 +358,24 @@ const articleSchema = {
     <!-- FAQ -->
     <section id="faq">
       <FAQ faqs={faqs} heading="Fi Collar FAQ" />
+      {heroOffer && (
+        <div class="fi-faq-cta">
+          <p class="fi-faq-cta-note">
+            If Fi covers where your dog actually goes, the 12-month membership bundle is the
+            lowest per-month way in.
+          </p>
+          <AffiliateLink
+            href={heroOffer.url}
+            data-asin={heroOffer.asin}
+            data-product-name={fiProduct.name}
+            data-product-id={fiProduct.id}
+            position="faq-bottom"
+            class="ui-cta"
+          >
+            Check Price on Fi Series 3+
+          </AffiliateLink>
+        </div>
+      )}
     </section>
 
     <Disclosure />
@@ -574,10 +631,50 @@ const articleSchema = {
     margin: 0;
   }
 
+  /* Quick answers */
+  .quick-answers {
+    display: grid;
+    gap: var(--space-md);
+    margin: 0 0 var(--space-md);
+  }
+
+  .quick-answer {
+    border-left: 3px solid var(--color-primary);
+    padding-left: var(--space-md);
+  }
+
+  .qa-question {
+    font-weight: var(--weight-semibold);
+    color: var(--color-text);
+    margin: 0 0 var(--space-xs);
+  }
+
+  .qa-answer {
+    margin: 0;
+    color: var(--color-text-muted);
+  }
+
+  .qa-more {
+    margin: 0;
+    font-size: var(--text-sm);
+  }
+
   /* Fi buy CTA */
   .fi-buy-cta {
+    margin-top: var(--space-xl);
     margin-bottom: var(--space-xl);
     max-width: 28rem;
+  }
+
+  .fi-faq-cta {
+    max-width: 28rem;
+    margin: var(--space-xl) auto 0;
+    text-align: center;
+  }
+
+  .fi-faq-cta-note {
+    color: var(--color-text-muted);
+    margin-bottom: var(--space-sm);
   }
 
   .fi-buy-note {

--- a/src/pages/gear/fi-dog-collar-review.astro
+++ b/src/pages/gear/fi-dog-collar-review.astro
@@ -137,9 +137,6 @@ const articleSchema = {
             </div>
           ))}
         </dl>
-        <p class="qa-more">
-          <a href="#faq">Full answers, plus accuracy and hiking coverage &rarr;</a>
-        </p>
       </div>
     </section>
 
@@ -657,11 +654,6 @@ const articleSchema = {
   .qa-answer {
     margin: 0;
     color: var(--color-text-muted);
-  }
-
-  .qa-more {
-    margin: 0;
-    font-size: var(--text-sm);
   }
 
   /* Fi buy CTA */

--- a/src/pages/gear/fi-dog-collar-review.astro
+++ b/src/pages/gear/fi-dog-collar-review.astro
@@ -36,8 +36,13 @@ const tocHeadings = [
 // line each; the full answers stay in the FAQ at the bottom.
 const faqs = [
   {
+    question: 'Does the Fi collar work without cell service?',
+    short: 'No. Fi reports location over LTE — outside cell coverage it cannot report at all.',
+    answer:
+      'No. Fi depends on an LTE cellular connection to report location. Outside coverage — remote wilderness, backcountry, mountains, or dead zones — the collar cannot report location at all. Check coverage where your dog actually spends time before buying. If that is genuinely off-grid terrain, a radio-based system like Garmin is the right category instead.',
+  },
+  {
     question: 'Does Fi collar work without WiFi?',
-    short: 'Yes — it uses LTE cellular, not WiFi. No home network needed, but it needs cell signal.',
     answer:
       'Fi uses LTE cellular, not WiFi. It works anywhere with LTE signal — no home network required. However, without LTE signal (in remote wilderness, mountains, or dead zones) the collar cannot report location.',
   },

--- a/src/pages/gear/fi-dog-collar-review.astro
+++ b/src/pages/gear/fi-dog-collar-review.astro
@@ -99,9 +99,9 @@ const articleSchema = {
 ---
 
 <BaseLayout
-  title="Fi Dog Collar Review: GPS Tracking for Everyday Dogs (2026)"
-  ogTitle="Fi Series 3+ Dog Collar GPS Review (2026)"
-  description="An honest look at Fi Series 3+ — cellular GPS tracking, escape alerts, and geofencing. What it does well, what it costs, and where it fails without cell signal."
+  title="Fi Dog Collar Review: No Cell Signal, No Tracking (2026)"
+  ogTitle="Fi Dog Collar Review: No Cell Signal, No Tracking"
+  description="Fi tracks over LTE, so no cell coverage means no location. An honest look at where Fi works, why the subscription isn't optional, and when Garmin is the better call."
 >
   <JsonLd slot="head" schema={articleSchema} />
 

--- a/src/pages/gear/garmin-dog-tracking-collars.astro
+++ b/src/pages/gear/garmin-dog-tracking-collars.astro
@@ -67,7 +67,7 @@ const collectionSchema = {
 ---
 
 <BaseLayout
-  title="Garmin Dog Tracking Collars: Off-Grid GPS for Wilderness & Hiking (2026)"
+  title="Garmin Dog Tracking Collars: Off-Grid GPS, No Cell Needed"
   ogTitle="Garmin Dog Tracking: Off-Grid GPS Systems (2026)"
   description="Garmin off-grid GPS systems track dogs in wilderness without any cell signal — using GPS satellites and VHF radio. Who needs it, how it works, and key trade-offs."
 >

--- a/src/pages/gear/garmin-dog-tracking-collars.astro
+++ b/src/pages/gear/garmin-dog-tracking-collars.astro
@@ -247,7 +247,6 @@ const collectionSchema = {
               <li>City or suburban dogs on daily leashed walks</li>
               <li>Owners who only hike popular, well-covered trails</li>
               <li>Small or low-activity dogs where collar bulk is impractical</li>
-              <li>Budget-first shoppers — Fi or AirTag serve lighter use cases for less</li>
             </ul>
           </div>
         </div>

--- a/src/pages/gear/garmin-dog-tracking-collars.astro
+++ b/src/pages/gear/garmin-dog-tracking-collars.astro
@@ -172,10 +172,11 @@ const collectionSchema = {
           ))}
         </div>
 
-        <div class="section-converter-cta">
+        <div class="comparison-cta">
+          <p class="comparison-cta-text">See how an off-grid Garmin system compares against every other tracker type:</p>
           <a
             href={ROUTES.trackingTop}
-            class="converter-cta-btn"
+            class="ui-cta"
             data-track="collector_to_converter_click"
             data-from-page={pageSlug}
             data-to-page={ROUTES.trackingTop}
@@ -251,10 +252,11 @@ const collectionSchema = {
           </div>
         </div>
 
-        <div class="section-converter-cta">
+        <div class="comparison-cta">
+          <p class="comparison-cta-text">Not sure an off-grid system is the right fit? Compare all three categories:</p>
           <a
             href={ROUTES.trackingTop}
-            class="converter-cta-btn"
+            class="ui-cta"
             data-track="collector_to_converter_click"
             data-from-page={pageSlug}
             data-to-page={ROUTES.trackingTop}
@@ -487,22 +489,25 @@ const collectionSchema = {
   .verdict-card--no .verdict-list li::before { content: '✗'; position: absolute; left: 0; color: var(--color-terracotta); font-weight: var(--weight-bold); }
 
   /* CTA */
-  .section-converter-cta { margin-top: var(--space-xl); }
-
-  .converter-cta-btn {
-    display: inline-block;
-    background: var(--color-primary);
-    color: var(--color-text-inverse);
-    font-weight: var(--weight-semibold);
-    padding: var(--space-sm) var(--space-xl);
-    border-radius: var(--radius-md);
-    text-decoration: none;
-    transition: background var(--transition-fast);
+  .comparison-cta {
+    display: flex;
+    align-items: center;
+    gap: var(--space-lg);
+    flex-wrap: wrap;
+    margin-top: var(--space-xl);
   }
 
-  .converter-cta-btn:hover {
-    background: var(--color-primary-hover);
-    color: var(--color-text-inverse);
+  .comparison-cta-text {
+    font-size: var(--text-base);
+    color: var(--color-text-muted);
+    margin: 0;
+  }
+
+  @media (max-width: 768px) {
+    .comparison-cta {
+      flex-direction: column;
+      align-items: flex-start;
+    }
   }
 
   @media (max-width: 1024px) {

--- a/src/pages/shelter-dog-charities.astro
+++ b/src/pages/shelter-dog-charities.astro
@@ -201,8 +201,8 @@ import BaseLayout from '@layouts/BaseLayout.astro';
           >Love Me Gently</AffiliateLink
         > and{' '}
         <AffiliateLink
-          href="https://www.amazon.com/dp/148102664X?tag=chill-dogs-20"
-          data-asin="148102664X"
+          href="https://www.amazon.com/dp/1544255098?tag=chill-dogs-20"
+          data-asin="1544255098"
           data-product-name="Gray Whiskers (Lisa Wiehebrink)"
           >Gray Whiskers</AffiliateLink
         >. She is also the founder of{' '}

--- a/src/pages/shelter-dog-charities.astro
+++ b/src/pages/shelter-dog-charities.astro
@@ -195,11 +195,15 @@ import BaseLayout from '@layouts/BaseLayout.astro';
       <p>
         It was founded by Lisa Wiehebrink, author of{' '}
         <AffiliateLink
-          href="https://www.amazon.com/Love-Me-Gently-Lisa-Wiehebrink/dp/148102664X/ref=sr_1_1?crid=K5YR86JDAZU&dib=eyJ2IjoiMSJ9.oiPD4aTRjTYET1oqi8eKGcMGm8ZGx8STKhkESvHqLtSnQE0AaQRwHyIrH-vu1q3iheW6bAV2fXQkppg3I967dQN-Mv9aLxiPrm2YWosKY5TcOea1jxlpKar9F0nYrEeRTeN1mL-TtM300nypCaVUhmoAMuz_JApNdiyZu6uhg3iWZgjkDeh0m_RlPfPKHtIdavd_NINImg4kMFUI8XzbFulR3Xt7-Zb_FVJg0xi3wZk.qrJH_jWDY5PVkRZiZlIMp0dRr4R7cS9_RkeKJlUyUwg&dib_tag=se&keywords=Love+me+gently&qid=1779419790&sprefix=love+me+gently%2Caps%2C253&sr=8-1"
+          href="https://www.amazon.com/dp/148102664X?tag=chill-dogs-20"
+          data-asin="148102664X"
+          data-product-name="Love Me Gently (Lisa Wiehebrink)"
           >Love Me Gently</AffiliateLink
         > and{' '}
         <AffiliateLink
-          href="https://www.amazon.com/Love-Me-Gently-Lisa-Wiehebrink/dp/148102664X/ref=sr_1_1?crid=K5YR86JDAZU&dib=eyJ2IjoiMSJ9.oiPD4aTRjTYET1oqi8eKGcMGm8ZGx8STKhkESvHqLtSnQE0AaQRwHyIrH-vu1q3iheW6bAV2fXQkppg3I967dQN-Mv9aLxiPrm2YWosKY5TcOea1jxlpKar9F0nYrEeRTeN1mL-TtM300nypCaVUhmoAMuz_JApNdiyZu6uhg3iWZgjkDeh0m_RlPfPKHtIdavd_NINImg4kMFUI8XzbFulR3Xt7-Zb_FVJg0xi3wZk.qrJH_jWDY5PVkRZiZlIMp0dRr4R7cS9_RkeKJlUyUwg&dib_tag=se&keywords=Love+me+gently&qid=1779419790&sprefix=love+me+gently%2Caps%2C253&sr=8-1"
+          href="https://www.amazon.com/dp/148102664X?tag=chill-dogs-20"
+          data-asin="148102664X"
+          data-product-name="Gray Whiskers (Lisa Wiehebrink)"
           >Gray Whiskers</AffiliateLink
         >. She is also the founder of{' '}
         <a href="http://www.nationalrescuedogday.com/" target="_blank" rel="noopener noreferrer"

--- a/src/scripts/analytics.ts
+++ b/src/scripts/analytics.ts
@@ -13,8 +13,36 @@ declare global {
   }
 }
 
+/**
+ * Local dev servers and Vercel preview deploys were producing roughly half of all raw
+ * events, which makes conversion rates on the real site unreadable. Capture is off on
+ * those hosts by default. Set `localStorage['chill-dogs:analytics'] = 'on'` to opt a
+ * dev session back in when you need to test tracking.
+ *
+ * The PostHog loader in src/components/Analytics.astro applies the same rule inline —
+ * it has to, because it is an is:inline script and cannot import this module. Keep the
+ * two in sync.
+ */
+export function shouldCaptureAnalytics(hostname: string): boolean {
+  if (hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1' || hostname === '0.0.0.0') return false;
+  if (hostname.endsWith('.localhost')) return false;
+  if (/^(127\.|10\.|192\.168\.|172\.(1[6-9]|2\d|3[01])\.)/.test(hostname)) return false;
+  if (hostname.endsWith('.vercel.app')) return false;
+  return true;
+}
+
+function capturingEnabled(): boolean {
+  try {
+    if (window.localStorage.getItem('chill-dogs:analytics') === 'on') return true;
+  } catch {
+    // storage blocked; fall through to host rules
+  }
+  return shouldCaptureAnalytics(window.location.hostname);
+}
+
 export function track(eventName: string, props: Record<string, any>): void {
   if (typeof window === 'undefined') return;
+  if (!capturingEnabled()) return;
 
   if (window.posthog && typeof window.posthog.capture === 'function') {
     window.posthog.capture(eventName, props);

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,7 @@
 {
   "installCommand": "bun install",
   "buildCommand": "bun run build",
+  "trailingSlash": true,
   "redirects": [
     {
       "source": "/join",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,6 +16,10 @@ export default defineConfig({
   },
   test: {
     environment: 'happy-dom',
+    // The default 5s is too tight once ~30 happy-dom suites run in parallel:
+    // slower machines blow it on CPU contention alone, not on real slowness.
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
     coverage: {
       provider: 'v8',
       include: ['src/utils/**', 'src/scripts/**', 'src/data/**'],


### PR DESCRIPTION
Two gear pages were built in ways that made an affiliate click unlikely, in different ways. Both are fixed here.

## Snake-bite kit converter

Rendered 52 affiliate CTAs across 47 products with no CTA above the fold and hand-rolled card markup, violating three rules in the converter checklist. It has never produced an outbound click.

- Surface the designated `heroProduct` (Fido Pro Airlift) as the single above-the-fold affiliate CTA, so the share image and primary CTA agree.
- Add an opt-in `featured` flag to `EmergencyProduct` and render only the curated picks by default; the rest of the catalog stays behind a per-category expander. Default view drops from 52 CTAs to 21, and 47 cards to 17.
- Rebuild the cards on the shared primitives via a new `EmergencyProductCard`, following `GearTrackerCard`, replacing the hand-rolled surface, image frame and CTA stack.
- Extract `EmergencyCategorySection` so the safety block can sit after the first category without duplicating markup. Safety copy and FAQ answers are unchanged; the TOC is reordered to match the new document order.
- Fix a latent layout bug where `.do-dont-grid` and `.job-grid` set `grid-template-columns` without `display: grid`.

## Fi review

The large majority of this page's traffic arrives from search engines on Fi-specific buying questions. It answered those only in a closing FAQ, and offered four internal escape links against a single affiliate link buried ~60% down — inside Best For, and placed above the reasons to buy rather than after them.

`system-definition.yaml` already declared this page's target action as routing intent to "Fi purchase paths" with `amazon_outbound_click` as its lead metric. That path was never built. This builds it.

- Hero primary becomes the Fi affiliate CTA via `Hero`'s existing `offer` prop, with the Associates disclaimer above it. The Garmin routing link stays as secondary for off-grid searchers who are on the wrong page.
- Add a Quick Answers block above the body covering the four questions that gate the decision: cell coverage, subscription, battery, waterproofing. Short answers derive from a `short` field on the existing `faqs` array, so the questions have one source of truth and the full answers still close the page.
- The lead answer is cell coverage, answered plainly — no coverage, no location — rather than opening on a reassuring "yes". The "without WiFi" phrasing stays as its own FAQ entry so that query is still answered, just not as the headline.
- Move the Best For CTA below the best-for reasons, and add a third CTA after the FAQ.

Buy points now sit at hero, after Best For, and after the FAQ. Prices stay off the page per the Associates operating agreement — cost is described structurally and the number lives behind the CTA.

## Collectors and routing

`airtag-for-dogs` and `garmin-dog-tracking-collars` adopt the pattern the Fi review uses: a lead-in sentence above the routing CTA and the shared `.ui-cta` button, replacing a hand-rolled `.converter-cta-btn` that duplicated it.

`best-dog-gps-trackers` is untouched — an earlier commit trimmed its escape links, and the last commit reverts that in full. The trim was justified by a routing rate computed from events that turned out to be mostly local dev-server traffic; on production numbers the page routes and converts at the same rate, so there was no leak to fix.

## Site-wide

Set `trailingSlash` in `vercel.json` so bare-path duplicates that were accruing their own pageviews redirect to the canonical slashed URL. All 58 entries in `routes.ts` already use trailing slashes.

## Verification

`bun run build`, the full vitest suite (256 tests) and smoke tests pass. Playwright confirms the above-fold CTA placement on both pages at 1440px and 390px, correct affiliate tags and dual-fire tracking attributes, expanders closed by default, and no horizontal overflow.

Two gaps worth naming: `check:asins` has no `pull_request` trigger, so ASINs are not validated by this PR (no new ASINs are added here, only moved); and the `trailingSlash` behaviour is Vercel edge-only, so it needs a manual check against the preview.