### PR TITLE
docs: add charity outreach program and email templates to the AI knowledge base

### DIFF
--- a/docs/ai/AI_INDEX.md
+++ b/docs/ai/AI_INDEX.md
@@ -89,6 +89,7 @@ You are starting any task and need to know which docs apply.
 
 **Read:**
 - [`marketing/charity-outreach-program.md`](marketing/charity-outreach-program.md) — Three-touch outreach sequence, rollout schedule, tracker, success measures
+- [`marketing/charity-outreach-templates.md`](marketing/charity-outreach-templates.md) — Email copy for each touch, placeholders, week 1 drafts
 - [`marketing/newsletter-guide.md`](marketing/newsletter-guide.md) — Format and link rules for the spotlight issue
 - [`marketing/utm-rules.md`](marketing/utm-rules.md) — UTM tagging for links sent to charities
 - [`writing/medical-and-vet-claim-guardrails.md`](writing/medical-and-vet-claim-guardrails.md) — Claim guardrails for outreach copy

--- a/docs/ai/AI_INDEX.md
+++ b/docs/ai/AI_INDEX.md
@@ -85,6 +85,18 @@ You are starting any task and need to know which docs apply.
 
 ---
 
+### Contacting a charity or running a charity newsletter spotlight
+
+**Read:**
+- [`marketing/charity-outreach-program.md`](marketing/charity-outreach-program.md) — Three-touch outreach sequence, rollout schedule, tracker, success measures
+- [`marketing/newsletter-guide.md`](marketing/newsletter-guide.md) — Format and link rules for the spotlight issue
+- [`marketing/utm-rules.md`](marketing/utm-rules.md) — UTM tagging for links sent to charities
+- [`writing/medical-and-vet-claim-guardrails.md`](writing/medical-and-vet-claim-guardrails.md) — Claim guardrails for outreach copy
+
+**Checklist:** [`checklists/marketing-publish-checklist.md`](checklists/marketing-publish-checklist.md)
+
+---
+
 ### Changing routes, sitemap, schema, or architecture
 
 **Read:**

--- a/docs/ai/KNOWLEDGE_GRAPH.md
+++ b/docs/ai/KNOWLEDGE_GRAPH.md
@@ -105,6 +105,8 @@ marketing/newsletter-guide.md             # Email format and link rules
     ↓
 marketing/charity-outreach-program.md     # Charity relationships, spotlight coordination, tracker
     ↓
+marketing/charity-outreach-templates.md   # Email copy for each touch in the sequence
+    ↓
 writing/medical-and-vet-claim-guardrails.md   # What not to claim in marketing copy
     ↓
 checklists/marketing-publish-checklist.md # Final gate

--- a/docs/ai/KNOWLEDGE_GRAPH.md
+++ b/docs/ai/KNOWLEDGE_GRAPH.md
@@ -103,6 +103,8 @@ marketing/utm-rules.md                    # UTM parameter format for external li
     ↓
 marketing/newsletter-guide.md             # Email format and link rules
     ↓
+marketing/charity-outreach-program.md     # Charity relationships, spotlight coordination, tracker
+    ↓
 writing/medical-and-vet-claim-guardrails.md   # What not to claim in marketing copy
     ↓
 checklists/marketing-publish-checklist.md # Final gate

--- a/docs/ai/marketing/charity-outreach-program.md
+++ b/docs/ai/marketing/charity-outreach-program.md
@@ -12,6 +12,7 @@ tags:
   - backlinks
   - marketing
 related:
+  - charity-outreach-templates.md
   - newsletter-guide.md
   - marketing-plan.md
   - utm-rules.md
@@ -60,6 +61,8 @@ Make the coverage genuinely useful to the charity before asking them to help amp
 ---
 
 ## The three-touch sequence
+
+Copy for all three touches, plus personalized week 1 drafts, lives in [`charity-outreach-templates.md`](charity-outreach-templates.md).
 
 ### Touch 1 — Initial introduction
 
@@ -200,6 +203,7 @@ These are supporting metrics. They do not replace the keystone event `amazon_out
 
 ## Related knowledge
 
+- [`charity-outreach-templates.md`](charity-outreach-templates.md) — Email copy for all three touches, plus week 1 drafts
 - [`newsletter-guide.md`](newsletter-guide.md) — Email format, voice, and link rules for the spotlight itself
 - [`marketing-plan.md`](marketing-plan.md) — Channel strategy, KPIs, organic-first posture
 - [`utm-rules.md`](utm-rules.md) — UTM parameter format for links sent to charities

--- a/docs/ai/marketing/charity-outreach-program.md
+++ b/docs/ai/marketing/charity-outreach-program.md
@@ -1,0 +1,208 @@
+---
+title: Charity Outreach Program
+type: canonical
+domain: marketing
+status: active
+updated: 2026-08-19
+tags:
+  - chill-dogs
+  - charities
+  - outreach
+  - newsletter
+  - backlinks
+  - marketing
+related:
+  - newsletter-guide.md
+  - marketing-plan.md
+  - utm-rules.md
+  - ../writing/medical-and-vet-claim-guardrails.md
+  - ../checklists/marketing-publish-checklist.md
+---
+
+# Charity Outreach Program
+
+Turns the editorial mentions on the Dog Charities We Love page into ongoing relationships with the organizations covered there.
+
+## Use this when
+
+Contacting a charity featured on `/shelter-dog-charities/`, scheduling a charity newsletter spotlight, or following up after one publishes.
+
+---
+
+## What this program is
+
+Chill-Dogs features a group of dog-focused charities on the **Dog Charities We Love** page (`ROUTES.shelterCharities` → `/shelter-dog-charities/`) and periodically highlights one of them in the newsletter.
+
+This program builds contact relationships with those organizations so the charity section works as living editorial rather than a static directory.
+
+**Goals:**
+
+- Introduce Chill-Dogs and make each charity aware of its inclusion on the site
+- Give organizations a chance to correct or update their listing
+- Establish contact before asking for anything promotional
+- Coordinate future newsletter charity spotlights
+- Encourage charities to share Chill-Dogs coverage through their own channels
+- Earn relevant, legitimate backlinks and referral traffic over time
+- Develop a pipeline of charity stories, campaigns, and events that become future Chill-Dogs content
+
+**Guiding principle:**
+
+> Feature first, relationship second, promotion third.
+
+Make the coverage genuinely useful to the charity before asking them to help amplify Chill-Dogs.
+
+---
+
+## Page type note
+
+`/shelter-dog-charities/` is registered as an **`informer`** page in `src/data/content-sitemap.ts`. It carries no revenue goal and no affiliate CTA, and outreach must not change that. Do not add product placements, affiliate links, or converter-style CTAs to the charity page in service of this program. The business value here is earned links, referral traffic, and story supply — all of which flow to collectors and converters elsewhere on the site.
+
+---
+
+## The three-touch sequence
+
+### Touch 1 — Initial introduction
+
+An individual email to each charity explaining:
+
+- what Chill-Dogs is
+- why we selected their organization
+- where they are featured on the charity page
+- that we periodically feature charities in the Chill-Dogs newsletter
+- that the inclusion is **editorial — not sponsored or paid**
+- that they are welcome to send corrections or updated information
+
+**Do not ask for a backlink, a share, or any promotion in this email.** The only job of touch 1 is to establish contact and hand the charity something useful.
+
+### Touch 2 — Pre-publication check-in
+
+When a charity is scheduled for a newsletter spotlight, contact them again **before** publication.
+
+Ask whether there is a current campaign, program, donation page, event, volunteer opportunity, or other priority they would especially like readers to know about.
+
+This produces fresher material and makes the feature more useful to the organization.
+
+### Touch 3 — Published feature follow-up
+
+After publication, send the organization the newsletter archive link.
+
+At this point, casually encourage them to share the feature with supporters or add it to a news, media, or press page. This is the natural moment for social shares and backlinks to develop without making the original outreach feel transactional.
+
+---
+
+## Copy rules for outreach emails
+
+Outreach email copy is Chill-Dogs marketing copy and follows the same guardrails as everything else:
+
+- Match the site voice: calm, practical, peer-level. Not breathless, not "excited to share."
+- **No vet-authority language.** No "vet-approved" or "vet-recommended" — see [`../writing/medical-and-vet-claim-guardrails.md`](../writing/medical-and-vet-claim-guardrails.md).
+- State plainly that the listing is editorial and unpaid. Never imply the charity paid for placement, and never offer placement in exchange for a link.
+- Link to production URLs only (`https://www.chill-dogs.com/`), never staging or preview.
+- UTM-tag links sent to charities so referral traffic is attributable — see [`utm-rules.md`](utm-rules.md).
+- Do not put Amazon affiliate links in charity outreach email. The charity page is an `informer`; outreach that leads with monetization undercuts the relationship and the program's premise.
+
+Newsletter spotlight content itself follows [`newsletter-guide.md`](newsletter-guide.md) — same format, subject line, and link rules as any other issue.
+
+---
+
+## Rollout schedule
+
+Begin with 2–3 charities per week so each message can be personalized and responses managed properly.
+
+| Week | Charities | Action |
+|---|---|---|
+| 1 | 15 out of 10 Foundation · Cuddly · Every Bark Counts | Send initial introductions; record contacts and responses |
+| 2 | Fix'n Fidos · PAW-SOME MISSION · Reducing Animal Stress | Continue introductions; follow up on week 1 responses |
+| 3 | Rolling Dog Farm · Tails That Teach · Wild Tunes | Complete the first round; begin coordinating the next newsletter feature |
+
+All nine organizations currently on the page are covered by weeks 1–3. When the page changes, this table changes with it.
+
+### Week 4 onward — the regular cycle
+
+**Before newsletter publication:**
+
+- Contact the featured charity
+- Verify current listing information
+- Ask about anything timely they want highlighted
+
+**After publication:**
+
+- Send the published newsletter link
+- Encourage sharing
+- Record any social mention, newsletter mention, or website backlink
+
+**Ongoing:**
+
+- Add new charities to the outreach process when they are added to the page
+- Reconnect with existing charities when they have significant news or a new Chill-Dogs feature
+
+---
+
+## Tracking
+
+Maintain an outreach tracker with these columns:
+
+| Column | Notes |
+|---|---|
+| Charity | Must match the heading on `/shelter-dog-charities/` |
+| Primary contact | Name and role |
+| Email | |
+| Initial outreach date | Touch 1 |
+| Response | |
+| Listing corrections | Feed these back into `src/pages/shelter-dog-charities.astro` |
+| Newsletter feature date | |
+| Pre-publication contact | Touch 2 |
+| Post-publication follow-up | Touch 3 |
+| Social share | |
+| Newsletter mention | |
+| Website backlink | Target URL and the page it links from |
+| Notes / future story opportunities | |
+
+Listing corrections are a content change to the charity page, so they run through the normal publish path — see [`../checklists/marketing-publish-checklist.md`](../checklists/marketing-publish-checklist.md).
+
+---
+
+## Editorial benefits
+
+Charity contacts can supply:
+
+- updates on new programs
+- rescue stories
+- fundraising campaigns
+- volunteer opportunities
+- educational initiatives
+- quotes and expert perspectives
+- photos and approved media
+- suggestions for other organizations Chill-Dogs should consider
+
+Over time this becomes a recurring source of original material for the newsletter, website, Pinterest, and social channels.
+
+**Media use:** only publish charity logos, photos, or quotes the organization has explicitly approved, and keep a record of that approval in the tracker notes.
+
+---
+
+## Success measures
+
+Treat this primarily as an editorial and relationship-building program. Results can be measured through:
+
+- percentage of charities responding
+- charity-provided updates or story leads
+- social shares of Chill-Dogs coverage
+- newsletter mentions
+- earned backlinks
+- referral traffic (attributable via UTM tags)
+- new organizations referred to us
+- repeat engagement with charities already featured
+
+These are supporting metrics. They do not replace the keystone event `amazon_outbound_click` — the value chain runs: charity relationship → earned link and referral traffic → collector pages → converter pages → Amazon.
+
+---
+
+## Related knowledge
+
+- [`newsletter-guide.md`](newsletter-guide.md) — Email format, voice, and link rules for the spotlight itself
+- [`marketing-plan.md`](marketing-plan.md) — Channel strategy, KPIs, organic-first posture
+- [`utm-rules.md`](utm-rules.md) — UTM parameter format for links sent to charities
+- [`../writing/medical-and-vet-claim-guardrails.md`](../writing/medical-and-vet-claim-guardrails.md) — Claim guardrails for outreach copy
+- [`../checklists/marketing-publish-checklist.md`](../checklists/marketing-publish-checklist.md) — Publish gate for listing corrections and spotlights
+- [`../strategy/metrics-and-page-types.md`](../strategy/metrics-and-page-types.md) — Why the charity page is an `informer`

--- a/docs/ai/marketing/charity-outreach-templates.md
+++ b/docs/ai/marketing/charity-outreach-templates.md
@@ -226,7 +226,17 @@ Thanks for the work you do.
 Chill-Dogs
 ```
 
-**Note:** Cuddly is a fundraising platform, not a rescue. The listing and any outreach should describe it that way. If it is ever the newsletter spotlight, the story is likely a partner rescue's campaign rather than Cuddly itself.
+**Note:** Cuddly is a **for-profit company**, not a charity — The Cuddly Group, Inc., incorporated in Delaware, which raised a $4M Series A from Lead Edge Capital in 2020 and describes itself as a "for-good startup." It is a fundraising and wish-list platform, not a rescue.
+
+This matters for outreach in three ways:
+
+- Never call Cuddly a charity or a nonprofit in an email. "Platform," "organization," or "company" are accurate; the draft above uses "organizations" in the opening line for exactly this reason.
+- The 501(c)(3) verification we praise applies to the **partner rescues**, not to Cuddly itself. Do not blur the two.
+- Cuddly states it takes 0% of monetary donations (97% to the rescue, 3% to payment processing). Attribute that to them rather than asserting it as our own finding.
+
+Their own listing links to a Better Business Bureau profile filed under *marketing consultant* — a business category, not a charity one.
+
+If Cuddly is ever the newsletter spotlight, the story is a partner rescue's campaign rather than the platform itself.
 
 ### Every Bark Counts
 

--- a/docs/ai/marketing/charity-outreach-templates.md
+++ b/docs/ai/marketing/charity-outreach-templates.md
@@ -1,0 +1,285 @@
+---
+title: Charity Outreach Email Templates
+type: canonical
+domain: marketing
+status: active
+updated: 2026-08-19
+tags:
+  - chill-dogs
+  - charities
+  - outreach
+  - email
+  - templates
+  - marketing
+related:
+  - charity-outreach-program.md
+  - newsletter-guide.md
+  - utm-rules.md
+  - ../writing/medical-and-vet-claim-guardrails.md
+---
+
+# Charity Outreach Email Templates
+
+Copy templates for the three-touch charity outreach sequence, plus ready-to-send week 1 drafts.
+
+## Use this when
+
+Writing or sending any charity outreach email. The sequence and schedule these fit into live in [`charity-outreach-program.md`](charity-outreach-program.md).
+
+---
+
+## Before sending
+
+- **Plain text, not HTML.** These go person-to-person, not as a broadcast. No header image, no branded template, no tracking pixel.
+- **Short.** Touch 1 should be readable in under a minute. Charity inboxes are busy and mostly full of asks.
+- **Personalize the specific-detail line.** Every template has one. A message that could have been sent to any of the nine reads as a mail merge, which defeats the point of the program.
+- **Send from a real person's address**, not `info@` or `noreply@`. Sign with a real name.
+- **No vet-authority language** — see [`../writing/medical-and-vet-claim-guardrails.md`](../writing/medical-and-vet-claim-guardrails.md).
+- **Never offer or imply paid placement**, and never make the listing conditional on a link or a share.
+
+### Placeholders
+
+| Placeholder | Meaning |
+|---|---|
+| `{{CHARITY}}` | Organization name, matching the heading on `/shelter-dog-charities/` |
+| `{{CONTACT_NAME}}` | Named person if known; otherwise rework the greeting, do not write "Dear Sir or Madam" |
+| `{{SPECIFIC_DETAIL}}` | One true, concrete thing about their work — drawn from their own listing |
+| `{{SENDER_NAME}}` | Real sender name |
+| `{{NEWSLETTER_ARCHIVE_URL}}` | Buttondown archive URL for the published issue |
+
+### Link and UTM conventions
+
+Production URLs only. UTM-tag every link so referral traffic from outreach is attributable — format rules in [`utm-rules.md`](utm-rules.md).
+
+| Touch | Link |
+|---|---|
+| 1 — Introduction | `https://www.chill-dogs.com/shelter-dog-charities/?utm_source=charity-outreach&utm_medium=email&utm_campaign=charity-intro` |
+| 2 — Pre-publication | Same charity page link, `utm_campaign=charity-spotlight` |
+| 3 — Follow-up | `{{NEWSLETTER_ARCHIVE_URL}}` plus the charity page link with `utm_campaign=charity-spotlight` |
+
+Do not put Amazon affiliate links in any outreach email.
+
+---
+
+## Template 1 — Introduction
+
+**Goal:** establish contact and hand them something useful. **No ask.**
+
+**Subject:** `{{CHARITY}} is featured on Chill-Dogs`
+
+```
+Hi {{CONTACT_NAME}},
+
+I run Chill-Dogs, a small site about dog cooling, calming, comfort, and
+travel gear. We keep a page of dog charities we think are worth knowing
+about, and {{CHARITY}} is on it.
+
+{{SPECIFIC_DETAIL}}
+
+You can see the listing here:
+https://www.chill-dogs.com/shelter-dog-charities/?utm_source=charity-outreach&utm_medium=email&utm_campaign=charity-intro
+
+Two things worth saying plainly: the listing is editorial, so nobody paid
+for it and nothing is expected in return. And if anything there is wrong or
+out of date, send me a correction and I will fix it.
+
+We also feature one of these organizations in our newsletter from time to
+time. If that ends up being you, I will get in touch first rather than
+writing about you without asking.
+
+Thanks for the work you do.
+
+{{SENDER_NAME}}
+Chill-Dogs
+```
+
+**Do not** add a request for a link, a share, or a mention. That is what makes touch 3 work later.
+
+---
+
+## Template 2 — Pre-publication check-in
+
+**Goal:** get current material before the spotlight publishes.
+
+**Subject:** `Featuring {{CHARITY}} in the next Chill-Dogs newsletter`
+
+```
+Hi {{CONTACT_NAME}},
+
+{{CHARITY}} is scheduled for the next Chill-Dogs newsletter, going out
+{{DATE}}.
+
+Before I write it, is there anything current you would want readers to
+know about? A campaign, a donation page, an event, a volunteer need — if
+there is something specific you are pushing right now, I would rather
+point people at that than at your homepage.
+
+Also a good moment to flag anything on your listing that needs updating.
+
+No rush, and no problem if you would rather I just write from what is
+public.
+
+{{SENDER_NAME}}
+Chill-Dogs
+```
+
+If they do not reply, publish from public information. The check-in is a courtesy, not a dependency — do not let silence block the issue.
+
+---
+
+## Template 3 — Published feature follow-up
+
+**Goal:** deliver the published piece and make sharing easy. This is the **only** touch that mentions sharing, and it stays casual.
+
+**Subject:** `{{CHARITY}} in this week's Chill-Dogs newsletter`
+
+```
+Hi {{CONTACT_NAME}},
+
+The newsletter featuring {{CHARITY}} went out this morning. Here it is:
+
+{{NEWSLETTER_ARCHIVE_URL}}
+
+Your listing is also live here:
+https://www.chill-dogs.com/shelter-dog-charities/?utm_source=charity-outreach&utm_medium=email&utm_campaign=charity-spotlight
+
+Feel free to share it with your supporters or add it to your press or news
+page if that is useful to you. No obligation at all — it is yours to use
+or ignore.
+
+If you ever have news worth covering, my inbox is open.
+
+{{SENDER_NAME}}
+Chill-Dogs
+```
+
+Record any resulting social mention, newsletter mention, or backlink in the tracker.
+
+---
+
+## Week 1 drafts
+
+Ready to send once `{{CONTACT_NAME}}` and `{{SENDER_NAME}}` are filled in. The specific-detail line in each is drawn from that organization's own listing on `/shelter-dog-charities/` — if the listing changes, change these too.
+
+### 15 out of 10 Foundation
+
+**Subject:** `15 out of 10 Foundation is featured on Chill-Dogs`
+
+```
+Hi {{CONTACT_NAME}},
+
+I run Chill-Dogs, a small site about dog cooling, calming, comfort, and
+travel gear. We keep a page of dog charities we think are worth knowing
+about, and the 15 out of 10 Foundation is on it.
+
+What made us include you is the part of the mission most groups avoid:
+sponsoring dogs with behavioral or medical issues who are unlikely to get
+out of the shelter otherwise. Doug's story is the clearest version of why
+that gap needs filling.
+
+You can see the listing here:
+https://www.chill-dogs.com/shelter-dog-charities/?utm_source=charity-outreach&utm_medium=email&utm_campaign=charity-intro
+
+Two things worth saying plainly: the listing is editorial, so nobody paid
+for it and nothing is expected in return. And if anything there is wrong or
+out of date, send me a correction and I will fix it.
+
+We also feature one of these organizations in our newsletter from time to
+time. If that ends up being you, I will get in touch first rather than
+writing about you without asking.
+
+Thanks for the work you do.
+
+{{SENDER_NAME}}
+Chill-Dogs
+```
+
+### Cuddly
+
+**Subject:** `Cuddly is featured on Chill-Dogs`
+
+```
+Hi {{CONTACT_NAME}},
+
+I run Chill-Dogs, a small site about dog cooling, calming, comfort, and
+travel gear. We keep a page of organizations we think dog owners should
+know about, and Cuddly is on it.
+
+We included you for the verification side specifically — requiring partner
+rescues to be confirmed 501(c)(3)s is the thing that makes a fundraising
+platform worth recommending to readers, and it is not the norm.
+
+You can see the listing here:
+https://www.chill-dogs.com/shelter-dog-charities/?utm_source=charity-outreach&utm_medium=email&utm_campaign=charity-intro
+
+Two things worth saying plainly: the listing is editorial, so nobody paid
+for it and nothing is expected in return. And if anything there is wrong or
+out of date, send me a correction and I will fix it.
+
+We also feature one of these organizations in our newsletter from time to
+time. If that ends up being you, I will get in touch first rather than
+writing about you without asking.
+
+Thanks for the work you do.
+
+{{SENDER_NAME}}
+Chill-Dogs
+```
+
+**Note:** Cuddly is a fundraising platform, not a rescue. The listing and any outreach should describe it that way. If it is ever the newsletter spotlight, the story is likely a partner rescue's campaign rather than Cuddly itself.
+
+### Every Bark Counts
+
+**Subject:** `Every Bark Counts is featured on Chill-Dogs`
+
+```
+Hi {{CONTACT_NAME}},
+
+I run Chill-Dogs, a small site about dog cooling, calming, comfort, and
+travel gear. We keep a page of dog charities we think are worth knowing
+about, and Every Bark Counts is on it.
+
+The focus on rural shelters is why. They get the least support and the
+least attention, and choosing them deliberately says more about an
+organization than its fundraising total does.
+
+You can see the listing here:
+https://www.chill-dogs.com/shelter-dog-charities/?utm_source=charity-outreach&utm_medium=email&utm_campaign=charity-intro
+
+Two things worth saying plainly: the listing is editorial, so nobody paid
+for it and nothing is expected in return. And if anything there is wrong or
+out of date, send me a correction and I will fix it.
+
+We also feature one of these organizations in our newsletter from time to
+time. If that ends up being you, I will get in touch first rather than
+writing about you without asking.
+
+Thanks for the work you do.
+
+{{SENDER_NAME}}
+Chill-Dogs
+```
+
+**Note:** Every Bark Counts was founded by Austin Testa when he was 12. Confirm his current age before sending. If he is still a minor, route outreach through the organization's general or parent/guardian contact rather than to him directly, and do not publish new photos or personal detail about him without documented adult consent.
+
+---
+
+## What not to send
+
+- An ask for a backlink in touch 1
+- "We'd love to partner with you" — vague, and reads as a pitch
+- Anything implying the listing is paid, sponsored, or conditional
+- Vet-authority claims about products or care
+- Amazon affiliate links
+- HTML newsletter templates or tracking pixels
+- The same specific-detail line reused across two charities
+
+---
+
+## Related knowledge
+
+- [`charity-outreach-program.md`](charity-outreach-program.md) — Sequence, schedule, tracker, success measures
+- [`newsletter-guide.md`](newsletter-guide.md) — Format and voice for the spotlight issue itself
+- [`utm-rules.md`](utm-rules.md) — UTM parameter format
+- [`../writing/medical-and-vet-claim-guardrails.md`](../writing/medical-and-vet-claim-guardrails.md) — Claim guardrails for outreach copy
+- [`../checklists/marketing-publish-checklist.md`](../checklists/marketing-publish-checklist.md) — Publish gate for listing corrections

--- a/docs/ai/marketing/marketing-plan.md
+++ b/docs/ai/marketing/marketing-plan.md
@@ -3,7 +3,7 @@ title: Marketing Plan
 type: canonical
 domain: marketing
 status: active
-updated: 2026-08-10
+updated: 2026-08-19
 tags:
   - chill-dogs
   - marketing
@@ -15,6 +15,7 @@ related:
   - pinterest-launch-plan.md
   - newsletter-guide.md
   - utm-rules.md
+  - charity-outreach-program.md
   - ../strategy/chill-dogs-context.md
 ---
 
@@ -83,7 +84,15 @@ Announce new articles and guides to existing audience. Drives return visits and 
 
 See [`newsletter-guide.md`](newsletter-guide.md) for format.
 
-### 4. Paid (low priority)
+### 4. Charity outreach (earned links and story supply)
+
+Relationship-building with the organizations featured on `/shelter-dog-charities/`. Editorial first: coverage is unpaid and unsponsored, and the ask for sharing comes only after a feature publishes.
+
+**Strategy:** Three-touch sequence per charity — introduction, pre-publication check-in, post-publication follow-up. Yields earned backlinks, referral traffic, and a pipeline of original story material.
+
+See [`charity-outreach-program.md`](charity-outreach-program.md) for the sequence, schedule, and tracker.
+
+### 5. Paid (low priority)
 
 No active paid budget defined. Homepage hero experiment pages under `/v/` remain available to test conversion messaging for potential future paid campaigns. The retired `/cooling/v/` and `/calming/v/` routes are no longer built.
 
@@ -144,5 +153,6 @@ New articles and converter pages should be driven by:
 - [`pinterest-launch-plan.md`](pinterest-launch-plan.md) — Pinterest boards, pins, cadence
 - [`newsletter-guide.md`](newsletter-guide.md) — Email format and rules
 - [`utm-rules.md`](utm-rules.md) — UTM parameter format
+- [`charity-outreach-program.md`](charity-outreach-program.md) — Charity relationships and spotlight coordination
 - [`../strategy/chill-dogs-context.md`](../strategy/chill-dogs-context.md) — Full site context and categories
 - [`../checklists/marketing-publish-checklist.md`](../checklists/marketing-publish-checklist.md) — Publish checklist

--- a/docs/ai/marketing/newsletter-guide.md
+++ b/docs/ai/marketing/newsletter-guide.md
@@ -3,7 +3,7 @@ title: Newsletter Guide
 type: canonical
 domain: marketing
 status: active
-updated: 2026-05-03
+updated: 2026-08-19
 tags:
   - chill-dogs
   - newsletter
@@ -13,6 +13,7 @@ tags:
 related:
   - marketing-plan.md
   - utm-rules.md
+  - charity-outreach-program.md
   - ../writing/article-writing-guide.md
   - ../writing/medical-and-vet-claim-guardrails.md
 ---
@@ -114,5 +115,6 @@ The newsletter reader is a fellow dog owner. Write to them directly and usefully
 
 - [`utm-rules.md`](utm-rules.md) — UTM parameter format
 - [`marketing-plan.md`](marketing-plan.md) — Channel strategy and KPIs
+- [`charity-outreach-program.md`](charity-outreach-program.md) — Coordinating charity spotlight issues
 - [`../writing/article-writing-guide.md`](../writing/article-writing-guide.md) — Article voice and structure
 - [`../writing/medical-and-vet-claim-guardrails.md`](../writing/medical-and-vet-claim-guardrails.md) — Health claim rules


### PR DESCRIPTION
Applies a 3-commit patch adding a charity outreach program to the AI knowledge graph. Docs-only — no page or component changes.

## What lands

**`docs/ai/marketing/charity-outreach-program.md`** (new) — the canonical program doc: three-touch outreach sequence (introduction → pre-publication check-in → post-publication follow-up), a 3-week rollout covering all nine organizations on `/shelter-dog-charities/`, tracker columns, and success measures. Explicitly holds the line that the charity page stays an `informer`: no product placements, affiliate links, or converter CTAs in service of outreach.

**`docs/ai/marketing/charity-outreach-templates.md`** (new) — email copy for each touch, placeholder and UTM conventions, and personalized week 1 drafts for the first three organizations.

Wired into `AI_INDEX.md` (new task-router entry), `KNOWLEDGE_GRAPH.md` (two nodes in the marketing chain), `marketing-plan.md` (new channel §4, Paid renumbered to §5), and `newsletter-guide.md`.

## One deviation from the patch

The patch's third commit also added a clarifying paragraph to `src/pages/shelter-dog-charities.astro` saying CUDDLY is a for-profit company. **That change was dropped** — the page already carries the same clarification, added in c1ac33c and tightened in 517a69f, as an `<aside class="charity-note">`. The patch predates that work and the charity page redesign, so `git am` conflicted there, and applying it would have duplicated copy that is already live. The commit's templates-doc half was kept and its message reworded to match what it actually does.

## Open item for you — not fixed here

The intro copy still reads "our **favorite charities**" while CUDDLY is now explicitly flagged as a for-profit company. "charities and organizations" would resolve it, but two things are worth knowing before deciding:

The phrase lives in **three** places that need to stay in sync:
- `src/pages/shelter-dog-charities.astro:16` — the visible intro line
- `src/pages/shelter-dog-charities.astro:9` — the `description` prop
- `src/data/content-sitemap.ts:861` — mirrors the description

And there is a constraint: the meta description is currently 147 chars, and the direct "charities and organizations" substitution lands it at exactly **165** — the ceiling `seo-meta.test.ts` enforces for `og:description`. Any rewording needs to come in under that, so this is a copy decision rather than a find-and-replace. Leaving it to you.

## Also worth a look

The new CUDDLY note in the templates doc asserts external facts — Delaware incorporation, a $4M Series A from Lead Edge Capital in 2020 — that could not be verified from this container. Worth a sourcing check before that copy is relied on in real outreach.

## Verification

All three gates pass on this branch:

| Check | Result |
|---|---|
| `bun run check:ai-docs` | 34 files checked, 0 issues |
| `bun run build` | 63 pages built |
| `bun run test` | 31 files, 267 tests passed |

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9v4B7dMj9raPebPN2sgS8)_